### PR TITLE
Dependency group ID typo and warehouse path parsing issue

### DIFF
--- a/dazzleduck-sql-flight/pom.xml
+++ b/dazzleduck-sql-flight/pom.xml
@@ -23,7 +23,7 @@
             <version>0.0.3</version>
         </dependency>
         <dependency>
-            <groupId>io.dazzlerduck.sql</groupId>
+            <groupId>io.dazzleduck.sql</groupId> <!-- ✅ fixed -->
             <artifactId>dazzleduck-sql-http</artifactId>
             <version>0.0.3</version>
             <scope>test</scope>

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/auth2/AuthUtils.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/auth2/AuthUtils.java
@@ -2,6 +2,7 @@ package io.dazzleduck.sql.flight.server.auth2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigObject;
 import io.dazzleduck.sql.common.auth.Validator;
 import org.apache.arrow.flight.*;

--- a/dazzleduck-sql-flight/src/test/java/io/dazzleduck/sql/flight/server/AuthUtilsLoginTest.java
+++ b/dazzleduck-sql-flight/src/test/java/io/dazzleduck/sql/flight/server/AuthUtilsLoginTest.java
@@ -9,7 +9,6 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
@@ -29,10 +28,12 @@ public class AuthUtilsLoginTest {
     @BeforeAll
     public static void setup() throws Exception {
         warehousePath = Files.createTempDirectory("duckdb_warehouse_" + AuthUtilsLoginTest.class.getSimpleName()).toString();
+        // Fix path escaping for Windows
+        String escapedWarehousePath = warehousePath.replace("\\", "\\\\");
         // Start the HTTP login service
         Main.main(new String[]{
-                "--conf", "port=" + HTTP_PORT,
-                "--conf", "warehousePath=" + warehousePath
+                "--conf", "port: " + HTTP_PORT,
+                "--conf", "warehousePath: \"" + escapedWarehousePath + "\""
         });
 
         setUpFlightServerAndClient();

--- a/dazzleduck-sql-flight/src/test/java/io/dazzleduck/sql/flight/server/AuthUtilsLoginTest.java
+++ b/dazzleduck-sql-flight/src/test/java/io/dazzleduck/sql/flight/server/AuthUtilsLoginTest.java
@@ -47,7 +47,6 @@ public class AuthUtilsLoginTest {
     }
 
     @Test
-    @Disabled
     public void testLoginWithHttp() {
         var result = sqlClient.execute("select 1");
         assertNotNull(result);


### PR DESCRIPTION
This PR fixes issue #11 
<img width="1920" height="1080" alt="Screenshot 2025-07-21 134314" src="https://github.com/user-attachments/assets/18e4f5f3-ec27-469b-8049-3dc4612de700" />

🔧 What was the issue?
There was a typo in the Maven dependency: io.dazzlerduck.sql instead of io.dazzleduck.sql.

The warehousePath on Windows caused a ConfigException due to unescaped backslashes in the path string, which is invalid in HOCON format.

✅ Fixes made:
Corrected the groupId in the test dependency.

Escaped the backslashes in the dynamically generated warehousePath to comply with HOCON parsing.