### PR TITLE
Add configurable service name and resource MDC for logging

### DIFF
--- a/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ConfigConstants.java
+++ b/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ConfigConstants.java
@@ -30,6 +30,7 @@ public class ConfigConstants {
     public static final String FLIGHT_SQL_HOST_KEY = "flight_sql.host";
     public static final String FLIGHT_SQL_PORT_KEY = "flight_sql.port";
     public static final String FLIGHT_SQL_DATA_PROCESSOR_LOCATIONS_KEY = "flight_sql.data_processor_locations";
+    public static final String FLIGHT_SQL_SERVICE_NAME_KEY = "flight_sql.service_name";
 
     // Server configuration keys
     public static final String KEYSTORE_KEY = "keystore";
@@ -98,6 +99,7 @@ public class ConfigConstants {
     // Feature flags
     public static final String ENABLED_KEY = "enabled";
     public static final String CAPTURE_CALLER_DATA_KEY = "capture_caller_data";
+    public static final String RESOURCE_MDC_KEY = "resource_mdc";
 
     // Metrics specific
     public static final String STEP_INTERVAL_MS_KEY = "step_interval_ms";

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/MicroMeterFlightRecorder.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/MicroMeterFlightRecorder.java
@@ -123,8 +123,9 @@ public class MicroMeterFlightRecorder implements FlightRecorder {
      *
      * @param registry   the registry to configure
      * @param producerId unique identifier for this producer instance
+     * @param serviceName the service name to use for metrics (default: "dazzleduck-sql-server")
      */
-    public static void setupCommonTags(MeterRegistry registry, String producerId) {
+    public static void setupCommonTags(MeterRegistry registry, String producerId, String serviceName) {
         String hostname = System.getenv("HOSTNAME");
         if (hostname == null || hostname.isBlank()) {
             try {
@@ -135,7 +136,7 @@ public class MicroMeterFlightRecorder implements FlightRecorder {
         }
         String containerId = System.getenv().getOrDefault("CONTAINER_ID", "unknown");
         registry.config().commonTags(
-                "service.name",  "dazzleduck-sql-server",
+                "service.name",  serviceName,
                 "host.name",     hostname,
                 "container.id",  containerId,
                 "producer.id",   producerId);

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/DuckDBFlightSqlProducer.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/DuckDBFlightSqlProducer.java
@@ -203,15 +203,15 @@ public class DuckDBFlightSqlProducer implements FlightSqlHttpProducer, SqlProduc
     public static FlightRecorder buildRecorder(String producerId) {
         try {
             var registry = new LoggingMeterRegistry();
-            setupCommonTags(registry, producerId);
+            setupCommonTags(registry, producerId, "dazzleduck-sql-server");
             return new MicroMeterFlightRecorder(registry, producerId);
         } catch (Throwable t) {
             return new SimpleFlightRecorder();
         }
     }
 
-    private static void setupCommonTags(io.micrometer.core.instrument.MeterRegistry registry, String producerId) {
-        MicroMeterFlightRecorder.setupCommonTags(registry, producerId);
+    private static void setupCommonTags(io.micrometer.core.instrument.MeterRegistry registry, String producerId, String serviceName) {
+        MicroMeterFlightRecorder.setupCommonTags(registry, producerId, serviceName);
     }
 
 

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/DuckDBFlightSqlProducer.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/DuckDBFlightSqlProducer.java
@@ -201,9 +201,13 @@ public class DuckDBFlightSqlProducer implements FlightSqlHttpProducer, SqlProduc
     }
 
     public static FlightRecorder buildRecorder(String producerId) {
+        return buildRecorder(producerId, "dazzleduck-sql-server");
+    }
+
+    public static FlightRecorder buildRecorder(String producerId, String serviceName) {
         try {
             var registry = new LoggingMeterRegistry();
-            setupCommonTags(registry, producerId, "dazzleduck-sql-server");
+            setupCommonTags(registry, producerId, serviceName);
             return new MicroMeterFlightRecorder(registry, producerId);
         } catch (Throwable t) {
             return new SimpleFlightRecorder();

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/FlightSqlProducerFactory.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/FlightSqlProducerFactory.java
@@ -103,6 +103,7 @@ public final class FlightSqlProducerFactory {
         private String producerId;
         private String secretKey;
         private String warehousePath;
+        private String serviceName;
         private Path tempWriteDir;
         private AccessMode accessMode;
         private BufferAllocator allocator;
@@ -132,6 +133,7 @@ public final class FlightSqlProducerFactory {
             this.warehousePath = ConfigConstants.getWarehousePath(config);
             this.secretKey = config.getString(ConfigConstants.SECRET_KEY_KEY);
             this.producerId = config.getString(ConfigConstants.PRODUCER_ID_KEY);
+            this.serviceName = config.getString(ConfigConstants.FLIGHT_SQL_SERVICE_NAME_KEY);
 
             // Access mode
             this.accessMode = DuckDBFlightSqlProducer.getAccessMode(config);
@@ -410,7 +412,7 @@ public final class FlightSqlProducerFactory {
             // Use provided flight recorder or create default
             FlightRecorder finalRecorder = flightRecorder != null
                 ? flightRecorder
-                : buildRecorder(producerId);
+                : buildRecorder();
 
             // Create appropriate producer based on access mode
             if (accessMode == AccessMode.RESTRICTED) {
@@ -504,18 +506,18 @@ public final class FlightSqlProducerFactory {
             return IngestionConfig.fromConfig(config.getConfig(ConfigConstants.INGESTION_KEY));
         }
 
-        private static io.dazzleduck.sql.flight.FlightRecorder buildRecorder(String producerId) {
+        private io.dazzleduck.sql.flight.FlightRecorder buildRecorder() {
             try {
                 var registry = new io.micrometer.core.instrument.logging.LoggingMeterRegistry();
-                setupCommonTags(registry, producerId);
+                setupCommonTags(registry, producerId, serviceName);
                 return new io.dazzleduck.sql.flight.MicroMeterFlightRecorder(registry, producerId);
             } catch (Throwable t) {
                 return new SimpleFlightRecorder();
             }
         }
 
-        private static void setupCommonTags(io.micrometer.core.instrument.MeterRegistry registry, String producerId) {
-            io.dazzleduck.sql.flight.MicroMeterFlightRecorder.setupCommonTags(registry, producerId);
+        private static void setupCommonTags(io.micrometer.core.instrument.MeterRegistry registry, String producerId, String serviceName) {
+            io.dazzleduck.sql.flight.MicroMeterFlightRecorder.setupCommonTags(registry, producerId, serviceName);
         }
     }
 }

--- a/dazzleduck-sql-flight/src/main/resources/reference.conf
+++ b/dazzleduck-sql-flight/src/main/resources/reference.conf
@@ -8,6 +8,7 @@
         data_processor_locations = [
             { host = ${dazzleduck_server.flight_sql.host}, port = ${dazzleduck_server.flight_sql.port}, use_encryption = ${dazzleduck_server.flight_sql.use_encryption} }
         ]
+        service_name = "dazzleduck-sql-server"
     }
 
 #    http = {

--- a/dazzleduck-sql-flight/src/test/java/io/dazzleduck/sql/flight/server/MicroMeterFlightRecorderTest.java
+++ b/dazzleduck-sql-flight/src/test/java/io/dazzleduck/sql/flight/server/MicroMeterFlightRecorderTest.java
@@ -23,7 +23,7 @@ public class MicroMeterFlightRecorderTest {
     @BeforeEach
     void setup() {
         registry = new SimpleMeterRegistry();
-        MicroMeterFlightRecorder.setupCommonTags(registry, "producer1");
+        MicroMeterFlightRecorder.setupCommonTags(registry, "producer1", "dazzleduck-sql-server");
         recorder = new MicroMeterFlightRecorder(registry, "producer1");
     }
 

--- a/dazzleduck-sql-logback/src/main/java/io/dazzleduck/sql/logback/LogForwarder.java
+++ b/dazzleduck-sql-logback/src/main/java/io/dazzleduck/sql/logback/LogForwarder.java
@@ -7,6 +7,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -20,6 +22,7 @@ public final class LogForwarder implements Closeable {
 
     private final LogToArrowConverter converter;
     private final HttpArrowProducer httpProducer;
+    private final Map<String, String> resourceMdc;
     private final AtomicBoolean running = new AtomicBoolean(true);
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
@@ -30,6 +33,7 @@ public final class LogForwarder implements Closeable {
      */
     public LogForwarder(LogForwarderConfig config) {
         this.converter = new LogToArrowConverter();
+        this.resourceMdc = config.resourceMdc();
 
         // Create HttpArrowProducer — use static JWT constructor if a token is preconfigured
         this.httpProducer = config.jwt() != null
@@ -109,7 +113,11 @@ public final class LogForwarder implements Closeable {
         fields[3] = entry.logger();
         fields[4] = entry.thread();
         fields[5] = entry.message();
-        fields[6] = entry.mdc().isEmpty() ? null : entry.mdc();
+
+        // Merge event MDC with resource MDC from config
+        Map<String, String> mergedMdc = mergeMdc(entry.mdc(), resourceMdc);
+        fields[6] = mergedMdc.isEmpty() ? null : mergedMdc;
+
         fields[7] = entry.throwable();
         fields[8] = entry.markers().isEmpty() ? null : entry.markers();
         fields[9] = entry.keyValuePairs().isEmpty() ? null : entry.keyValuePairs();
@@ -119,6 +127,28 @@ public final class LogForwarder implements Closeable {
         fields[12] = cd != null ? cd.file() : null;
         fields[13] = cd != null ? cd.line() : null;
         return new JavaRow(fields);
+    }
+
+    /**
+     * Merge event MDC with resource MDC from config.
+     * Resource MDC values are applied as defaults but can be overridden by event MDC.
+     *
+     * @param eventMdc  MDC from the logging event
+     * @param resourceMdc MDC from config
+     * @return merged MDC map
+     */
+    private Map<String, String> mergeMdc(Map<String, String> eventMdc, Map<String, String> resourceMdc) {
+        if (resourceMdc.isEmpty()) {
+            return eventMdc;
+        }
+        if (eventMdc.isEmpty()) {
+            return resourceMdc;
+        }
+
+        // Merge both maps with event MDC taking precedence
+        Map<String, String> merged = new HashMap<>(resourceMdc);
+        merged.putAll(eventMdc);
+        return merged;
     }
 
     /**

--- a/dazzleduck-sql-logback/src/main/java/io/dazzleduck/sql/logback/LogForwarderConfig.java
+++ b/dazzleduck-sql-logback/src/main/java/io/dazzleduck/sql/logback/LogForwarderConfig.java
@@ -35,6 +35,7 @@ public final class LogForwarderConfig {
     // Feature flags
     private final boolean enabled;
     private final boolean captureCallerData;
+    private final Map<String, String> resourceMdc;
 
     public LogForwarderConfig(
             String baseUrl,
@@ -56,7 +57,8 @@ public final class LogForwarderConfig {
             List<String> project,
             List<String> partitionBy,
             boolean enabled,
-            boolean captureCallerData) {
+            boolean captureCallerData,
+            Map<String, String> resourceMdc) {
         Objects.requireNonNull(baseUrl, "baseUrl must not be null");
         Objects.requireNonNull(ingestionQueue, "ingestionQueue must not be null");
         Objects.requireNonNull(httpClientTimeout, "httpClientTimeout must not be null");
@@ -87,6 +89,7 @@ public final class LogForwarderConfig {
         this.partitionBy = Collections.unmodifiableList(new ArrayList<>(partitionBy));
         this.enabled = enabled;
         this.captureCallerData = captureCallerData;
+        this.resourceMdc = resourceMdc != null ? Collections.unmodifiableMap(new LinkedHashMap<>(resourceMdc)) : Collections.emptyMap();
     }
 
     public String baseUrl() {
@@ -169,6 +172,10 @@ public final class LogForwarderConfig {
         return captureCallerData;
     }
 
+    public Map<String, String> resourceMdc() {
+        return resourceMdc;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -192,7 +199,8 @@ public final class LogForwarderConfig {
                Objects.equals(pollInterval, that.pollInterval) &&
                Objects.equals(maxSendInterval, that.maxSendInterval) &&
                Objects.equals(project, that.project) &&
-               Objects.equals(partitionBy, that.partitionBy);
+               Objects.equals(partitionBy, that.partitionBy) &&
+               Objects.equals(resourceMdc, that.resourceMdc);
     }
 
     @Override
@@ -200,7 +208,7 @@ public final class LogForwarderConfig {
         return Objects.hash(baseUrl, username, password, jwt, ingestionQueue, httpClientTimeout,
                 maxBufferSize, pollInterval, minBatchSize, maxBatchSize, maxSendInterval,
                 maxInMemorySize, maxOnDiskSize, retryCount, retryIntervalMillis,
-                project, partitionBy, enabled, captureCallerData);
+                project, partitionBy, enabled, captureCallerData, resourceMdc);
     }
 
     @Override
@@ -226,6 +234,7 @@ public final class LogForwarderConfig {
                ", partitionBy=" + partitionBy +
                ", enabled=" + enabled +
                ", captureCallerData=" + captureCallerData +
+               ", resourceMdc=" + resourceMdc +
                "]";
     }
 
@@ -254,6 +263,7 @@ public final class LogForwarderConfig {
         private List<String> partitionBy = Collections.emptyList();
         private boolean enabled = true;
         private boolean captureCallerData = false;
+        private Map<String, String> resourceMdc = Map.of();
 
         private Builder() {
         }
@@ -360,6 +370,11 @@ public final class LogForwarderConfig {
             return this;
         }
 
+        public Builder resourceMdc(Map<String, String> resourceMdc) {
+            this.resourceMdc = Objects.requireNonNull(resourceMdc);
+            return this;
+        }
+
         public Builder claims(Map<String, String> claims) {
             this.claims = Objects.requireNonNull(claims);
             return this;
@@ -386,7 +401,8 @@ public final class LogForwarderConfig {
                     project,
                     partitionBy,
                     enabled,
-                    captureCallerData
+                    captureCallerData,
+                    resourceMdc
             );
         }
     }

--- a/dazzleduck-sql-logback/src/main/java/io/dazzleduck/sql/logback/LogForwarderConfigFactory.java
+++ b/dazzleduck-sql-logback/src/main/java/io/dazzleduck/sql/logback/LogForwarderConfigFactory.java
@@ -115,6 +115,11 @@ public final class LogForwarderConfigFactory {
                         .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toString()))
                 : Map.of();
 
+        Map<String, String> resourceMdc = config.hasPath(ConfigConstants.RESOURCE_MDC_KEY)
+                ? config.getObject(ConfigConstants.RESOURCE_MDC_KEY).unwrapped().entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()))
+                : Map.of();
+
         return LogForwarderConfig.builder()
                 .baseUrl(http.getString(ConfigConstants.BASE_URL_KEY))
                 .username(http.getString(ConfigConstants.USERNAME_KEY))
@@ -135,6 +140,7 @@ public final class LogForwarderConfigFactory {
                 .partitionBy(config.getStringList(ConfigConstants.PARTITION_BY_KEY))
                 .enabled(config.getBoolean(ConfigConstants.ENABLED_KEY))
                 .captureCallerData(config.getBoolean(ConfigConstants.CAPTURE_CALLER_DATA_KEY))
+                .resourceMdc(resourceMdc)
                 .build();
     }
 }

--- a/dazzleduck-sql-logback/src/main/resources/reference.conf
+++ b/dazzleduck-sql-logback/src/main/resources/reference.conf
@@ -19,6 +19,7 @@ dazzleduck_logback = {
   project              = ["*", "'"${dazzleduck_logback.hostname}"' AS application_host", "CAST (timestamp AS date) AS date"]
   partition_by         = [date]
   capture_caller_data  = false
+  resource_mdc         = {key = value}
 
   http {
     base_url              = "http://localhost:8081"


### PR DESCRIPTION
…logback

- Add flight_sql.service_name config option to customize service.name metric tag
- Update MicroMeterFlightRecorder.setupCommonTags to accept serviceName parameter
- FlightSqlProducerFactory reads and passes service name from config
- Add resource_mdc config for logback to inject default MDC values
- LogForwarder merges config MDC with runtime MDC (runtime takes precedence)
- Update ConfigConstants with FLIGHT_SQL_SERVICE_NAME_KEY and RESOURCE_MDC_KEY