### PR TITLE
Add NamedQueryService with templated SQL execution, pagination, and v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ All HTTP API endpoints use a `/v1` version prefix for backward compatibility and
 | `/v1/plan` | POST | Generate query execution plan with splits |
 | `/v1/ingest` | POST | Ingest Arrow data to Parquet files |
 | `/v1/cancel` | POST | Cancel a running query |
+| `/v1/named-query` | GET | List named queries (paginated) |
+| `/v1/named-query/{name}` | GET | Get a named query by name |
+| `/v1/named-query` | POST | Execute a named (templated) query |
 | `/v1/ui` | GET | Access web UI dashboard |
 | `/health` | GET | Health check endpoint (unversioned) |
 
@@ -168,6 +171,124 @@ See: https://github.com/prmoore77/sqlalchemy-sqlflite-adbc-dialect
 
 
 
+
+## Named Queries
+
+Named queries allow pre-defined, parameterized SQL templates to be stored in a DuckDB table and executed by name over HTTP. Templates use [Jinja2](https://jinja.palletsprojects.com) syntax via Jinjava.
+
+### Setup
+
+Enable the named query endpoint by setting `named_query_table` in your configuration:
+
+```hocon
+dazzleduck_server {
+    named_query_table = "named_queries"
+}
+```
+
+Create the table in DuckDB:
+
+```sql
+CREATE TABLE named_queries (
+    name                   VARCHAR PRIMARY KEY,
+    template               VARCHAR,
+    validators             VARCHAR[],
+    description            VARCHAR,
+    parameter_descriptions MAP(VARCHAR, VARCHAR)
+);
+```
+
+Insert a template:
+
+```sql
+INSERT INTO named_queries VALUES (
+    'top_sales',
+    'SELECT * FROM sales WHERE region = ''{{ region }}'' LIMIT {{ limit }}',
+    NULL,
+    'Returns top sales rows for a given region',
+    MAP { 'region': 'Sales region name', 'limit': 'Maximum number of rows' }
+);
+```
+
+### Executing a Named Query
+
+```bash
+curl -X POST http://localhost:8081/v1/named-query \
+  -H "Content-Type: application/json" \
+  -d '{"name": "top_sales", "parameters": {"region": "WEST", "limit": "10"}}'
+```
+
+The response is an Arrow IPC stream, identical to `/v1/query`.
+
+#### Query Modes
+
+An optional `mode` field controls how the SQL is executed:
+
+| Mode | Description |
+|------|-------------|
+| `EXECUTE` (default) | Run the query and return results |
+| `EXPLAIN` | Return the query plan without executing |
+| `EXPLAIN_ANALYZE` | Return the query plan with execution statistics |
+
+```bash
+curl -X POST http://localhost:8081/v1/named-query \
+  -H "Content-Type: application/json" \
+  -d '{"name": "top_sales", "parameters": {"region": "WEST", "limit": "10"}, "mode": "EXPLAIN"}'
+```
+
+### Listing Named Queries
+
+```bash
+# First page
+curl http://localhost:8081/v1/named-query?offset=0&limit=20
+
+# Response
+{
+  "items": [
+    {"name": "top_sales", "description": "Returns top sales rows for a given region"}
+  ],
+  "total": 1,
+  "offset": 0,
+  "limit": 20
+}
+```
+
+### Getting a Named Query by Name
+
+```bash
+curl http://localhost:8081/v1/named-query/top_sales
+
+# Response
+{
+  "name": "top_sales",
+  "description": "Returns top sales rows for a given region",
+  "parameterDescriptions": {"region": "Sales region name", "limit": "Maximum number of rows"},
+  "validatorDescriptions": []
+}
+```
+
+### Parameter Validators
+
+Each named query can reference a list of validator class names. Validators are Java classes that implement `NamedQueryParameterValidator` from `dazzleduck-sql-common`:
+
+```java
+public class RegionValidator implements NamedQueryParameterValidator {
+    @Override
+    public void validate(Map<String, String> parameters) throws ParameterValidationException {
+        String region = parameters.get("region");
+        if (region == null || region.isBlank()) {
+            throw new ParameterValidationException("'region' parameter is required");
+        }
+    }
+
+    @Override
+    public String description() {
+        return "Requires a non-blank 'region' parameter";
+    }
+}
+```
+
+All validators run on every request and all failures are collected before returning HTTP 400. Validator instances are cached (up to 500) to avoid repeated reflection overhead.
 
 ## Security and Access Modes
 

--- a/README.md
+++ b/README.md
@@ -226,14 +226,22 @@ An optional `mode` field controls how the SQL is executed:
 
 | Mode | Description |
 |------|-------------|
-| `EXECUTE` (default) | Run the query and return results |
+| `EXECUTE` (default) | Run the query and return results in Arrow format |
 | `EXPLAIN` | Return the query plan without executing |
 | `EXPLAIN_ANALYZE` | Return the query plan with execution statistics |
+| `GENERATE` | Render the SQL template and return the generated SQL as plain text without executing |
 
 ```bash
+# Execute
 curl -X POST http://localhost:8081/v1/named-query \
   -H "Content-Type: application/json" \
-  -d '{"name": "top_sales", "parameters": {"region": "WEST", "limit": "10"}, "mode": "EXPLAIN"}'
+  -d '{"name": "top_sales", "parameters": {"region": "WEST", "limit": "10"}}'
+
+# Inspect the generated SQL before running it
+curl -X POST http://localhost:8081/v1/named-query \
+  -H "Content-Type: application/json" \
+  -d '{"name": "top_sales", "parameters": {"region": "WEST", "limit": "10"}, "mode": "GENERATE"}'
+# Returns: SELECT * FROM sales WHERE region = 'WEST' LIMIT 10
 ```
 
 ### Listing Named Queries

--- a/dazzleduck-sql-client-grpc/pom.xml
+++ b/dazzleduck-sql-client-grpc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
 
     <artifactId>dazzleduck-sql-client-grpc</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
@@ -48,13 +48,13 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-client/pom.xml
+++ b/dazzleduck-sql-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
 
     <artifactId>dazzleduck-sql-client</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
@@ -38,13 +38,13 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-common/pom.xml
+++ b/dazzleduck-sql-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
     <artifactId>dazzleduck-sql-common</artifactId>
     <name>DazzleDuck Project Common</name>

--- a/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ConfigConstants.java
+++ b/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ConfigConstants.java
@@ -67,6 +67,7 @@ public class ConfigConstants {
     // HTTP configuration keys
     public static final String HTTP_PREFIX = "http";
     public static final String ALLOW_ORIGIN_KEY = "allow-origin";
+    public static final String NAMED_QUERY_TABLE_KEY = "named_query_table";
 
     // Application identity keys (for client modules)
     public static final String APPLICATION_ID_KEY = "application_id";

--- a/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/NamedQueryParameterValidator.java
+++ b/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/NamedQueryParameterValidator.java
@@ -1,0 +1,11 @@
+package io.dazzleduck.sql.common;
+
+import java.util.Map;
+
+public interface NamedQueryParameterValidator {
+    void validate(Map<String, String> parameters) throws ParameterValidationException;
+
+    default String description() {
+        return "";
+    }
+}

--- a/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ParameterValidationException.java
+++ b/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ParameterValidationException.java
@@ -1,0 +1,12 @@
+package io.dazzleduck.sql.common;
+
+public class ParameterValidationException extends Exception {
+
+    public ParameterValidationException(String message) {
+        super(message);
+    }
+
+    public ParameterValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dazzleduck-sql-commons/pom.xml
+++ b/dazzleduck-sql-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
     <artifactId>dazzleduck-sql-commons</artifactId>
     <name>DazzleDuck Project Commons</name>
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
     </dependencies>
 

--- a/dazzleduck-sql-flight/pom.xml
+++ b/dazzleduck-sql-flight/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
 
     <artifactId>dazzleduck-sql-flight</artifactId>
@@ -43,19 +43,19 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId> <!-- ✅ fixed -->
             <artifactId>dazzleduck-sql-login</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>

--- a/dazzleduck-sql-http/pom.xml
+++ b/dazzleduck-sql-http/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
     <artifactId>dazzleduck-sql-http</artifactId>
     <name>DazzleDuck Project Http Sql</name>
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-login</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-flight</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
@@ -58,6 +58,11 @@
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-http2</artifactId>
             <version>${helidon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hubspot.jinjava</groupId>
+            <artifactId>jinjava</artifactId>
+            <version>2.7.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/AbstractQueryBasedService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/AbstractQueryBasedService.java
@@ -29,7 +29,7 @@ public abstract class AbstractQueryBasedService implements HttpService, Controll
             handleInternal(request, response, requestObject);
         } catch (HttpException e) {
             if (e instanceof InternalErrorException) {
-                logger.atError().setCause(e).log("Error");
+                logger.error("Error", e);
             }
             String errorMsg = e.getMessage() != null ? e.getMessage() : "Internal server error";
             var msg = errorMsg.getBytes();
@@ -86,7 +86,7 @@ public abstract class AbstractQueryBasedService implements HttpService, Controll
             var requestObject = MAPPER.readValue(request.content().inputStream(), QueryRequest.class);
             handle(request, response, requestObject);
         } catch (IOException e) {
-            logger.atError().setCause(e).log("Failed to parse request body");
+            logger.error("Failed to parse request body", e);
             String errorMsg = e.getMessage() != null ? e.getMessage() : "Invalid request body";
             response.status(Status.BAD_REQUEST_400);
             response.send(errorMsg);

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/Main.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/Main.java
@@ -47,6 +47,7 @@ public class Main {
     private static final String ENDPOINT_CANCEL = API_VERSION_PREFIX + "/cancel";
     private static final String ENDPOINT_INGEST = API_VERSION_PREFIX + "/ingest";
     private static final String ENDPOINT_UI = API_VERSION_PREFIX + "/ui";
+    private static final String ENDPOINT_NAMED_QUERY = API_VERSION_PREFIX + "/named-query";
 
     // Configuration keys
     private static final String CONFIG_HTTP = ConfigConstants.HTTP_PREFIX;
@@ -320,9 +321,17 @@ public class Main {
                             .register(ENDPOINT_INGEST, new IngestionService(producer))
                             .register(ENDPOINT_UI, new UIService(producer));
 
+                    if (appConfig.hasPath(ConfigConstants.NAMED_QUERY_TABLE_KEY)) {
+                        String namedQueryTable = appConfig.getString(ConfigConstants.NAMED_QUERY_TABLE_KEY);
+                        b.register(ENDPOINT_NAMED_QUERY,
+                                new NamedQueryService(producer, namedQueryTable));
+                        logger.info("Named query endpoint enabled, table: {}", namedQueryTable);
+                    }
+
                     // JWT filter is always applied to all versioned endpoints
                     b.addFilter(new JwtAuthenticationFilter(
-                            List.of(ENDPOINT_QUERY, ENDPOINT_PLAN, ENDPOINT_INGEST, ENDPOINT_CANCEL, ENDPOINT_UI),
+                            List.of(ENDPOINT_QUERY, ENDPOINT_PLAN, ENDPOINT_INGEST, ENDPOINT_CANCEL,
+                                    ENDPOINT_UI, ENDPOINT_NAMED_QUERY),
                             appConfig,
                             secretKey,
                             producer.getSqlAuthorizer()

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
@@ -151,9 +151,15 @@ public class NamedQueryService implements HttpService, ControllerService {
             Map<String, Object> jinjavaContext = new HashMap<>(
                     namedQuery.parameters() != null ? namedQuery.parameters() : Map.of());
             String sql = jinjava.render(queryTemplate.template(), jinjavaContext);
-            sql = applyMode(sql, namedQuery.mode());
             logger.debug("Rendered SQL for named query '{}' (mode={}): {}", namedQuery.name(), namedQuery.mode(), sql);
 
+            if (namedQuery.mode() == QueryMode.GENERATE) {
+                response.headers().set(io.helidon.http.HeaderNames.CONTENT_TYPE, "text/plain");
+                response.send(sql);
+                return;
+            }
+
+            sql = applyMode(sql, namedQuery.mode());
             var callContext = ControllerService.createContext(request);
             var id = StatementHandle.nextStatementId();
             var statementHandle = StatementHandle.newStatementHandle(
@@ -206,7 +212,7 @@ public class NamedQueryService implements HttpService, ControllerService {
         return switch (mode) {
             case EXPLAIN         -> "EXPLAIN " + sql;
             case EXPLAIN_ANALYZE -> "EXPLAIN ANALYZE " + sql;
-            case EXECUTE         -> sql;
+            case EXECUTE, GENERATE -> sql;
         };
     }
 

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
@@ -1,0 +1,358 @@
+package io.dazzleduck.sql.http.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import com.hubspot.jinjava.Jinjava;
+import io.dazzleduck.sql.common.NamedQueryParameterValidator;
+import io.dazzleduck.sql.common.ParameterValidationException;
+import io.dazzleduck.sql.commons.ConnectionPool;
+import io.dazzleduck.sql.flight.server.HttpFlightAdaptor;
+import io.dazzleduck.sql.flight.server.StatementHandle;
+import io.dazzleduck.sql.http.server.model.HttpConfig;
+import io.dazzleduck.sql.http.server.model.NamedQueryListItem;
+import io.dazzleduck.sql.http.server.model.NamedQueryPage;
+import io.dazzleduck.sql.http.server.model.NamedQueryRequest;
+import io.dazzleduck.sql.http.server.model.NamedQueryResponse;
+import io.dazzleduck.sql.http.server.model.NamedQueryTemplate;
+import io.dazzleduck.sql.http.server.model.QueryMode;
+import io.helidon.http.Status;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.FlightStatusCode;
+import org.apache.arrow.flight.sql.impl.FlightSql;
+import org.duckdb.DuckDBConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * HTTP service that executes named (templated) SQL queries.
+ *
+ * <p>Accepts a POST with a {@link NamedQueryRequest} body (name + parameters). The service:
+ * <ol>
+ *   <li>Fetches the {@link NamedQueryTemplate} from the DB by primary key.</li>
+ *   <li>Resolves each {@link NamedQueryParameterValidator} class name using a shared validator
+ *       instance cache to avoid repeated reflection.</li>
+ *   <li>Runs all validators and collects every failure before returning HTTP 400.</li>
+ *   <li>Renders the SQL template with Jinjava (Jinja2 syntax) using the supplied parameters.</li>
+ *   <li>Executes the rendered SQL and streams the Arrow result back to the caller.</li>
+ * </ol>
+ *
+ * <p>Expected DB table schema:
+ * <pre>{@code
+ *   CREATE TABLE named_queries (
+ *       name                   VARCHAR PRIMARY KEY,
+ *       template               VARCHAR,
+ *       validators             VARCHAR[],
+ *       description            VARCHAR,
+ *       parameter_descriptions MAP(VARCHAR, VARCHAR)
+ *   );
+ * }</pre>
+ */
+public class NamedQueryService implements HttpService, ControllerService {
+
+    private static final Logger logger = LoggerFactory.getLogger(NamedQueryService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int DEFAULT_PAGE_LIMIT = 20;
+    private static final int MAX_PAGE_LIMIT = 200;
+    private static final int MAX_VALIDATOR_CACHE_SIZE = 500;
+
+    private final HttpFlightAdaptor httpFlightAdaptor;
+    private final HttpConfig httpConfig;
+    private final String namedQueryTable;
+    private final Jinjava jinjava;
+
+    /** Validator instance cache: fully-qualified class name → singleton instance. */
+    private final ConcurrentHashMap<String, NamedQueryParameterValidator> validatorCache = new ConcurrentHashMap<>();
+
+    public NamedQueryService(HttpFlightAdaptor httpFlightAdaptor, String namedQueryTable) {
+        this(httpFlightAdaptor, namedQueryTable, HttpConfig.defaultConfig());
+    }
+
+    public NamedQueryService(HttpFlightAdaptor httpFlightAdaptor, String namedQueryTable,
+                             HttpConfig httpConfig) {
+        this.httpFlightAdaptor = httpFlightAdaptor;
+        this.namedQueryTable = namedQueryTable;
+        this.httpConfig = httpConfig;
+        this.jinjava = new Jinjava();
+    }
+
+    @Override
+    public void routing(HttpRules rules) {
+        rules.get("/", this::handleList)
+             .get("/{name}", this::handleGetByName)
+             .post("/", this::handlePost);
+    }
+
+    /** GET / — returns a paginated list of named queries (name + description only). */
+    private void handleList(ServerRequest request, ServerResponse response) {
+        try {
+            int offset = ParameterUtils.getParameterValue("offset", request, 0, Integer.class);
+            int limit  = ParameterUtils.getParameterValue("limit",  request, DEFAULT_PAGE_LIMIT, Integer.class);
+            if (offset < 0) offset = 0;
+            if (limit  < 1) limit  = DEFAULT_PAGE_LIMIT;
+            if (limit  > MAX_PAGE_LIMIT) limit = MAX_PAGE_LIMIT;
+
+            NamedQueryPage.WithTotal page = loadPageFromDb(offset, limit);
+            long total = page.total();
+            List<NamedQueryListItem> items = page.items();
+
+            response.headers().set(io.helidon.http.HeaderNames.CONTENT_TYPE, "application/json");
+            response.send(MAPPER.writeValueAsBytes(new NamedQueryPage(items, total, offset, limit)));
+        } catch (Exception e) {
+            logger.error("Error listing named queries", e);
+            response.status(Status.INTERNAL_SERVER_ERROR_500).send("Failed to list named queries");
+        }
+    }
+
+    /** GET /{name} — returns the full named query object including validator descriptions. */
+    private void handleGetByName(ServerRequest request, ServerResponse response) {
+        var segments = request.path().segments();
+        String name = segments.get(segments.size() - 1).value();
+        try {
+            NamedQueryTemplate template = loadFromDb(name);
+            response.headers().set(io.helidon.http.HeaderNames.CONTENT_TYPE, "application/json");
+            response.send(MAPPER.writeValueAsBytes(toInfo(template)));
+        } catch (TemplateNotFoundException e) {
+            logger.warn("Named query not found: {}", name);
+            response.status(Status.NOT_FOUND_404).send(e.getMessage());
+        } catch (Exception e) {
+            logger.error("Error fetching named query '{}'", name, e);
+            response.status(Status.INTERNAL_SERVER_ERROR_500).send("Failed to fetch named query");
+        }
+    }
+
+    private void handlePost(ServerRequest request, ServerResponse response) {
+        try {
+            var namedQuery = MAPPER.readValue(request.content().inputStream(), NamedQueryRequest.class);
+
+            if (namedQuery.name() == null || namedQuery.name().isBlank()) {
+                response.status(Status.BAD_REQUEST_400).send("Missing required field: name");
+                return;
+            }
+
+            NamedQueryTemplate queryTemplate = loadFromDb(namedQuery.name());
+
+            runValidators(queryTemplate, namedQuery.parameters());
+
+            Map<String, Object> jinjavaContext = new HashMap<>(
+                    namedQuery.parameters() != null ? namedQuery.parameters() : Map.of());
+            String sql = jinjava.render(queryTemplate.template(), jinjavaContext);
+            sql = applyMode(sql, namedQuery.mode());
+            logger.debug("Rendered SQL for named query '{}' (mode={}): {}", namedQuery.name(), namedQuery.mode(), sql);
+
+            var callContext = ControllerService.createContext(request);
+            var id = StatementHandle.nextStatementId();
+            var statementHandle = StatementHandle.newStatementHandle(
+                    id, sql, httpFlightAdaptor.getProducerId(), -1);
+            var ticket = FlightSql.TicketStatementQuery.newBuilder()
+                    .setStatementHandle(ByteString.copyFrom(MAPPER.writeValueAsBytes(statementHandle)))
+                    .build();
+
+            var compressionCodec = ParameterUtils.getArrowCompression(request);
+            var future = httpFlightAdaptor.getStreamStatementDirect(
+                    ticket, callContext, response::outputStream, compressionCodec);
+            future.get(httpConfig.getQueryTimeoutMs(), TimeUnit.MILLISECONDS);
+
+        } catch (ParameterValidationException e) {
+            logger.warn("Parameter validation failed for named query: {}", e.getMessage());
+            if (!response.isSent()) {
+                response.status(Status.BAD_REQUEST_400).send(e.getMessage());
+            }
+        } catch (TemplateNotFoundException e) {
+            logger.warn("Named query not found: {}", e.getMessage());
+            if (!response.isSent()) {
+                response.status(Status.NOT_FOUND_404).send(e.getMessage());
+            }
+        } catch (TimeoutException e) {
+            logger.error("Named query execution timed out after {}ms", httpConfig.getQueryTimeoutMs());
+            if (!response.isSent()) {
+                response.status(Status.GATEWAY_TIMEOUT_504).send("Query execution timeout");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Named query execution interrupted", e);
+            if (!response.isSent()) {
+                response.status(Status.INTERNAL_SERVER_ERROR_500).send("Query execution interrupted");
+            }
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            logger.error("Error executing named query", cause);
+            if (!response.isSent()) {
+                handleFlightError(response, cause);
+            }
+        } catch (Exception e) {
+            logger.error("Error processing named query", e);
+            if (!response.isSent()) {
+                handleFlightError(response, e);
+            }
+        }
+    }
+
+    private String applyMode(String sql, QueryMode mode) {
+        return switch (mode) {
+            case EXPLAIN         -> "EXPLAIN " + sql;
+            case EXPLAIN_ANALYZE -> "EXPLAIN ANALYZE " + sql;
+            case EXECUTE         -> sql;
+        };
+    }
+
+    /**
+     * Runs every {@link NamedQueryParameterValidator} listed in the template, collecting all
+     * failures. A single {@link ParameterValidationException} is thrown with all messages
+     * joined by {@code "; "}.
+     */
+    private void runValidators(NamedQueryTemplate queryTemplate, Map<String, String> parameters)
+            throws ParameterValidationException {
+        String[] validatorClassNames = queryTemplate.validators();
+        if (validatorClassNames == null || validatorClassNames.length == 0) {
+            return;
+        }
+        Map<String, String> safeParams = parameters != null ? parameters : Map.of();
+        List<String> errors = new ArrayList<>();
+        for (String className : validatorClassNames) {
+            try {
+                getOrCreateValidator(className).validate(safeParams);
+            } catch (ParameterValidationException e) {
+                errors.add(e.getMessage());
+            } catch (RuntimeException e) {
+                errors.add("Validator configuration error: " + className + " — " + e.getMessage());
+            }
+        }
+        if (!errors.isEmpty()) {
+            throw new ParameterValidationException(String.join("; ", errors));
+        }
+    }
+
+    /**
+     * Returns a cached {@link NamedQueryParameterValidator}, instantiating via reflection on
+     * first use. Capped at {@link #MAX_VALIDATOR_CACHE_SIZE} entries.
+     */
+    private NamedQueryParameterValidator getOrCreateValidator(String className) {
+        NamedQueryParameterValidator cached = validatorCache.get(className);
+        if (cached != null) {
+            return cached;
+        }
+        NamedQueryParameterValidator instance = instantiateValidator(className);
+        if (validatorCache.size() < MAX_VALIDATOR_CACHE_SIZE) {
+            NamedQueryParameterValidator existing = validatorCache.putIfAbsent(className, instance);
+            return existing != null ? existing : instance;
+        }
+        return instance;
+    }
+
+    private NamedQueryParameterValidator instantiateValidator(String className) {
+        try {
+            return (NamedQueryParameterValidator) Class.forName(className)
+                    .getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to instantiate validator: " + className, e);
+        }
+    }
+
+    /**
+     * Fetches a single row from the named-query table by primary key.
+     *
+     * @throws TemplateNotFoundException if no row exists for the given name
+     */
+    private NamedQueryTemplate loadFromDb(String name) throws SQLException, TemplateNotFoundException {
+        String safeName = name.replace("'", "''");
+        String sql = ("SELECT name, template, validators, description, parameter_descriptions" +
+                      " FROM %s WHERE name = '%s'")
+                .formatted(namedQueryTable, safeName);
+        try (DuckDBConnection connection = ConnectionPool.getConnection()) {
+            var iter = ConnectionPool.collectAll(connection, sql, NamedQueryTemplate.class).iterator();
+            if (!iter.hasNext()) {
+                throw new TemplateNotFoundException("Named query not found: " + name);
+            }
+            return iter.next();
+        }
+    }
+
+    /**
+     * Converts a {@link NamedQueryTemplate} to a {@link NamedQueryResponse}, replacing validator
+     * class names with their {@link NamedQueryParameterValidator#description()} values.
+     */
+    private NamedQueryResponse toInfo(NamedQueryTemplate t) {
+        List<String> validatorDescriptions;
+        if (t.validators() == null || t.validators().length == 0) {
+            validatorDescriptions = Collections.emptyList();
+        } else {
+            validatorDescriptions = new ArrayList<>(t.validators().length);
+            for (String className : t.validators()) {
+                try {
+                    String desc = getOrCreateValidator(className).description();
+                    validatorDescriptions.add(desc.isBlank() ? className : desc);
+                } catch (Exception e) {
+                    logger.warn("Could not load validator '{}' for description: {}", className, e.getMessage());
+                    validatorDescriptions.add(className);
+                }
+            }
+        }
+        return new NamedQueryResponse(t.name(), t.description(), t.parameterDescriptions(), validatorDescriptions);
+    }
+
+    /**
+     * Fetches a page of name+description pairs and the total row count in one query
+     * using a {@code COUNT(*) OVER ()} window function.
+     */
+    private NamedQueryPage.WithTotal loadPageFromDb(int offset, int limit) throws SQLException {
+        String sql = ("SELECT name, description, COUNT(*) OVER () FROM %s ORDER BY name LIMIT %d OFFSET %d")
+                .formatted(namedQueryTable, limit, offset);
+        try (DuckDBConnection connection = ConnectionPool.getConnection()) {
+            List<NamedQueryListItem> items = new ArrayList<>();
+            long[] total = {0L};
+            for (NamedQueryListItem item : ConnectionPool.collectAll(connection, sql, rs -> {
+                total[0] = rs.getLong(3);
+                return new NamedQueryListItem(rs.getString(1), rs.getString(2));
+            })) {
+                items.add(item);
+            }
+            return new NamedQueryPage.WithTotal(items, total[0]);
+        }
+    }
+
+    private void handleFlightError(ServerResponse response, Throwable cause) {
+        String errorMsg = cause.getMessage() != null ? cause.getMessage() : "Internal server error";
+        Status httpStatus = Status.INTERNAL_SERVER_ERROR_500;
+
+        if (cause instanceof FlightRuntimeException flightEx) {
+            FlightStatusCode code = flightEx.status().code();
+            if (flightEx.status().description() != null) {
+                errorMsg = flightEx.status().description();
+            }
+            httpStatus = switch (code) {
+                case INVALID_ARGUMENT -> Status.BAD_REQUEST_400;
+                case UNAUTHENTICATED -> Status.UNAUTHORIZED_401;
+                case UNAUTHORIZED -> Status.FORBIDDEN_403;
+                case NOT_FOUND -> Status.NOT_FOUND_404;
+                case TIMED_OUT -> Status.GATEWAY_TIMEOUT_504;
+                case UNIMPLEMENTED -> Status.NOT_IMPLEMENTED_501;
+                case UNAVAILABLE -> Status.SERVICE_UNAVAILABLE_503;
+                default -> Status.INTERNAL_SERVER_ERROR_500;
+            };
+        }
+
+        response.status(httpStatus).send(errorMsg);
+    }
+
+    /** Signals that a named query template could not be found in the DB. */
+    static class TemplateNotFoundException extends Exception {
+        TemplateNotFoundException(String message) {
+            super(message);
+        }
+    }
+}

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/ParameterUtils.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/ParameterUtils.java
@@ -24,6 +24,12 @@ public interface ParameterUtils {
         if (fromHeader.isPresent()) {
             return mapFunction.apply(fromHeader.get());
         }
+        try {
+            String fromQuery = request.query().getRaw(parameter);
+            return mapFunction.apply(fromQuery);
+        } catch (java.util.NoSuchElementException ignored) {
+            // parameter not present in query string
+        }
         return defaultValue;
     }
 

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/PlanningService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/PlanningService.java
@@ -56,12 +56,12 @@ public class PlanningService extends AbstractQueryBasedService implements Parame
             }
 
         } catch (IOException e) {
-            logger.atError().setCause(e).log("IO error during query planning");
+            logger.error("IO error during query planning", e);
             String errorMsg = e.getMessage() != null ? e.getMessage() : "IO error during planning";
             response.status(io.helidon.http.Status.INTERNAL_SERVER_ERROR_500);
             response.send(errorMsg);
         } catch (Exception e) {
-            logger.atError().setCause(e).log("Error during query planning");
+            logger.error("Error during query planning", e);
             String errorMsg = e.getMessage() != null ? e.getMessage() : "Internal server error";
             response.status(io.helidon.http.Status.INTERNAL_SERVER_ERROR_500);
             response.send(errorMsg);

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/QueryService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/QueryService.java
@@ -57,48 +57,48 @@ public class QueryService extends AbstractQueryBasedService {
 
             CompletableFuture<Void> future;
             if (wantsTsv) {
-                logger.atDebug().log("TSV output requested for query: {}", query.query());
+                logger.debug("TSV output requested for query: {}", query.query());
                 response.headers().set(HeaderNames.CONTENT_TYPE, ContentTypes.TEXT_TSV_UTF8);
                 future = getStreamStatementDirectTsv(ticket, context, () -> response.outputStream());
             } else {
                 // Get Arrow compression codec from header (defaults to ZSTD)
                 CompressionUtil.CodecType compressionCodec = ParameterUtils.getArrowCompression(request);
-                logger.atDebug().log("Using Arrow compression codec: {}", compressionCodec);
-                logger.atDebug().log("Calling getStreamStatementDirect for query: {}", query.query());
+                logger.debug("Using Arrow compression codec: {}", compressionCodec);
+                logger.debug("Calling getStreamStatementDirect for query: {}", query.query());
                 future = httpFlightAdaptor.getStreamStatementDirect(ticket, context, () -> response.outputStream(), compressionCodec);
             }
 
-            logger.atDebug().log("Waiting for future.get() with timeout {}ms", httpConfig.getQueryTimeoutMs());
+            logger.debug("Waiting for future.get() with timeout {}ms", httpConfig.getQueryTimeoutMs());
             future.get(httpConfig.getQueryTimeoutMs(), TimeUnit.MILLISECONDS);
-            logger.atDebug().log("future.get() completed successfully");
+            logger.debug("future.get() completed successfully");
 
         } catch (IllegalArgumentException e) {
-            logger.atError().setCause(e).log("Invalid Arrow compression header value");
+            logger.error("Invalid Arrow compression header value", e);
             if (!response.isSent()) {
                 response.status(Status.BAD_REQUEST_400);
                 response.send(e.getMessage());
             }
         } catch (TimeoutException e) {
-            logger.atError().log("Query execution timeout after {}ms", httpConfig.getQueryTimeoutMs());
+            logger.error("Query execution timeout after {}ms", httpConfig.getQueryTimeoutMs());
             if (!response.isSent()) {
                 response.status(Status.GATEWAY_TIMEOUT_504);
                 response.send("Query execution timeout");
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.atError().setCause(e).log("Query execution interrupted");
+            logger.error("Query execution interrupted", e);
             if (!response.isSent()) {
                 response.status(Status.INTERNAL_SERVER_ERROR_500);
                 response.send("Query execution interrupted");
             }
         } catch (ExecutionException e) {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
-            logger.atError().setCause(cause).log("Error executing query");
+            logger.error("Error executing query", cause);
             if (!response.isSent()) {
                 handleError(response, cause);
             }
         } catch (Exception e) {
-            logger.atError().setCause(e).log("Error sending query result");
+            logger.error("Error sending query result", e);
             if (!response.isSent()) {
                 handleError(response, e);
             }

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryListItem.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryListItem.java
@@ -1,0 +1,5 @@
+package io.dazzleduck.sql.http.server.model;
+
+/** Minimal projection of a named query returned in paginated list responses. */
+public record NamedQueryListItem(String name, String description) {
+}

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryPage.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryPage.java
@@ -1,0 +1,10 @@
+package io.dazzleduck.sql.http.server.model;
+
+import java.util.List;
+
+/** Paginated list of named queries. */
+public record NamedQueryPage(List<NamedQueryListItem> items, long total, int offset, int limit) {
+
+    /** Intermediate result from a single-query page+count fetch. */
+    public record WithTotal(List<NamedQueryListItem> items, long total) {}
+}

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryRequest.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryRequest.java
@@ -1,0 +1,24 @@
+package io.dazzleduck.sql.http.server.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public record NamedQueryRequest(String name, Map<String, String> parameters, QueryMode mode) {
+
+    @JsonCreator
+    public NamedQueryRequest(
+            @JsonProperty("name") String name,
+            @JsonProperty("parameters") Map<String, String> parameters,
+            @JsonProperty("mode") QueryMode mode) {
+        this.name = name;
+        this.parameters = parameters;
+        this.mode = mode != null ? mode : QueryMode.EXECUTE;
+    }
+
+    /** Convenience factory for execution mode (no EXPLAIN prefix). */
+    public static NamedQueryRequest execute(String name, Map<String, String> parameters) {
+        return new NamedQueryRequest(name, parameters, QueryMode.EXECUTE);
+    }
+}

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryResponse.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryResponse.java
@@ -1,0 +1,18 @@
+package io.dazzleduck.sql.http.server.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Full view of a named query returned by {@code GET /named-query/{name}}.
+ *
+ * <p>The raw SQL template is omitted. Validator class names are replaced by the
+ * human-readable descriptions from
+ * {@link io.dazzleduck.sql.common.NamedQueryParameterValidator#description()}.
+ */
+public record NamedQueryResponse(
+        String name,
+        String description,
+        Map<String, String> parameterDescriptions,
+        List<String> validatorDescriptions) {
+}

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryTemplate.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/NamedQueryTemplate.java
@@ -1,0 +1,28 @@
+package io.dazzleduck.sql.http.server.model;
+
+import java.util.Map;
+
+/**
+ * DB-facing representation of a named query.
+ *
+ * <p>Maps directly to a row in the named-query table:
+ * <pre>{@code
+ *   CREATE TABLE named_queries (
+ *       name                   VARCHAR PRIMARY KEY,
+ *       template               VARCHAR,
+ *       validators             VARCHAR[],
+ *       description            VARCHAR,
+ *       parameter_descriptions MAP(VARCHAR, VARCHAR)
+ *   );
+ * }</pre>
+ *
+ * <p>Column order must match the record component order because
+ * {@code ConnectionPool.collectAll} maps by position.
+ */
+public record NamedQueryTemplate(
+        String name,
+        String template,
+        String[] validators,
+        String description,
+        Map<String, String> parameterDescriptions) {
+}

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/QueryMode.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/QueryMode.java
@@ -7,5 +7,7 @@ public enum QueryMode {
     /** Prepend {@code EXPLAIN} — returns the query plan without executing. */
     EXPLAIN,
     /** Prepend {@code EXPLAIN ANALYZE} — executes the query and returns the annotated plan. */
-    EXPLAIN_ANALYZE
+    EXPLAIN_ANALYZE,
+    /** Render the SQL template and return the generated SQL string without executing it. */
+    GENERATE
 }

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/QueryMode.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/model/QueryMode.java
@@ -1,0 +1,11 @@
+package io.dazzleduck.sql.http.server.model;
+
+/** Controls how a named query is executed. */
+public enum QueryMode {
+    /** Execute the query and return results (default). */
+    EXECUTE,
+    /** Prepend {@code EXPLAIN} — returns the query plan without executing. */
+    EXPLAIN,
+    /** Prepend {@code EXPLAIN ANALYZE} — executes the query and returns the annotated plan. */
+    EXPLAIN_ANALYZE
+}

--- a/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/NamedQueryServiceTest.java
+++ b/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/NamedQueryServiceTest.java
@@ -220,6 +220,21 @@ public class NamedQueryServiceTest extends HttpServerTestBase {
     }
 
     @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testGenerateMode() throws IOException, InterruptedException {
+        var namedQuery = new NamedQueryRequest("get_series", Map.of("limit", "5"), QueryMode.GENERATE);
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "GENERATE should return 200");
+        assertEquals("SELECT * FROM generate_series(5) t(v) ORDER BY v", response.body().trim());
+    }
+
+    @Test
     @Timeout(value = 30, unit = TimeUnit.SECONDS)
     void testExplainAnalyzeMode() throws IOException, InterruptedException {
         var namedQuery = new NamedQueryRequest("get_series", Map.of("limit", "5"), QueryMode.EXPLAIN_ANALYZE);

--- a/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/NamedQueryServiceTest.java
+++ b/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/NamedQueryServiceTest.java
@@ -1,0 +1,359 @@
+package io.dazzleduck.sql.http.server;
+
+import io.dazzleduck.sql.common.ParameterValidationException;
+import io.dazzleduck.sql.common.NamedQueryParameterValidator;
+import io.dazzleduck.sql.commons.ConnectionPool;
+import io.dazzleduck.sql.http.server.model.NamedQueryRequest;
+import io.dazzleduck.sql.http.server.model.QueryMode;
+import io.dazzleduck.sql.commons.util.TestUtils;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for {@link NamedQueryService}.
+ *
+ * <p>The server is started with {@code named_query_table=named_queries}. Each test that
+ * needs a template inserts a row into that table before making the HTTP request.
+ */
+public class NamedQueryServiceTest extends HttpServerTestBase {
+
+    private static final String NAMED_QUERIES_TABLE = "named_queries";
+    private static final String ENDPOINT = "/v1/named-query";
+
+    @BeforeAll
+    static void setup() throws Exception {
+        initWarehouse();
+        initClient();
+        initPort();
+        startServer(
+                "--conf", "dazzleduck_server.named_query_table=" + NAMED_QUERIES_TABLE
+        );
+        installArrowExtension();
+
+        // Create the named-query table and seed it with templates used by the tests
+        ConnectionPool.execute(
+                "CREATE TABLE IF NOT EXISTS " + NAMED_QUERIES_TABLE +
+                " (name VARCHAR PRIMARY KEY, template VARCHAR, validators VARCHAR[]," +
+                "  description VARCHAR, parameter_descriptions MAP(VARCHAR, VARCHAR))");
+        ConnectionPool.executeBatch(new String[]{
+                "DELETE FROM " + NAMED_QUERIES_TABLE,
+                "INSERT INTO " + NAMED_QUERIES_TABLE + " VALUES " +
+                "('get_series', 'SELECT * FROM generate_series({{ limit }}) t(v) ORDER BY v'," +
+                " NULL, 'Returns the first N integers', MAP {'limit': 'upper bound (exclusive)'})",
+                "INSERT INTO " + NAMED_QUERIES_TABLE + " VALUES " +
+                "('filter_series', 'SELECT * FROM generate_series(10) t(v) WHERE v > {{ min }}'," +
+                " NULL, 'Filters integers above a threshold', MAP {'min': 'minimum value (exclusive)'})",
+                "INSERT INTO " + NAMED_QUERIES_TABLE + " VALUES " +
+                "('validated_query', 'SELECT * FROM generate_series({{ limit }}) t(v)'," +
+                " ['" + RejectAllValidatorNamedQuery.class.getName() + "'], 'Always rejected by validator', NULL)",
+                "INSERT INTO " + NAMED_QUERIES_TABLE + " VALUES " +
+                "('multi_validator_query', 'SELECT * FROM generate_series({{ limit }}) t(v)'," +
+                " ['" + RejectAllValidatorNamedQuery.class.getName() + "', '" + AnotherRejectValidatorNamedQuery.class.getName() + "']," +
+                " 'Rejected by two validators', NULL)"
+        });
+    }
+
+    @AfterAll
+    static void cleanup() throws Exception {
+        ConnectionPool.execute("DROP TABLE IF EXISTS " + NAMED_QUERIES_TABLE);
+        cleanupWarehouse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy-path tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void testHappyPath_templateRenderedAndExecuted() throws IOException, InterruptedException, SQLException {
+        // Template: SELECT * FROM generate_series({{ limit }}) t(v) ORDER BY v
+        var namedQuery = NamedQueryRequest.execute("get_series", Map.of("limit", "5"));
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        assertEquals(200, response.statusCode(), "Expected 200 for valid named query");
+
+        try (var allocator = new RootAllocator();
+             var reader = new ArrowStreamReader(response.body(), allocator)) {
+            String expected = "SELECT * FROM generate_series(5) t(v) ORDER BY v";
+            TestUtils.isEqual(expected, allocator, reader);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void testHappyPath_multipleParameters() throws IOException, InterruptedException, SQLException {
+        // Template: SELECT * FROM generate_series(10) t(v) WHERE v > {{ min }}
+        var namedQuery = NamedQueryRequest.execute("filter_series", Map.of("min", "7"));
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        assertEquals(200, response.statusCode(), "Expected 200 for valid named query with parameters");
+
+        try (var allocator = new RootAllocator();
+             var reader = new ArrowStreamReader(response.body(), allocator)) {
+            String expected = "SELECT * FROM generate_series(10) t(v) WHERE v > 7";
+            TestUtils.isEqual(expected, allocator, reader);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Error cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testUnknownNameReturns404() throws IOException, InterruptedException {
+        var namedQuery = NamedQueryRequest.execute("no_such_query", Map.of());
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(404, response.statusCode(), "Expected 404 when named query does not exist");
+        assertNotNull(response.body());
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testMissingNameReturns400() throws IOException, InterruptedException {
+        var namedQuery = new NamedQueryRequest(null, Map.of(), QueryMode.EXECUTE);
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 when name is missing");
+    }
+
+    // -------------------------------------------------------------------------
+    // Validator test — row in DB has a validator class that rejects everything
+    // -------------------------------------------------------------------------
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testValidatorBlocksRequest() throws IOException, InterruptedException {
+        var namedQuery = NamedQueryRequest.execute("validated_query", Map.of("limit", "5"));
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Validator should cause HTTP 400");
+        assertTrue(response.body().contains("Rejected by test validator"),
+                "Response body should contain the validator message");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testAllValidatorsRunAndErrorsAreCombined() throws IOException, InterruptedException {
+        var namedQuery = NamedQueryRequest.execute("multi_validator_query", Map.of("limit", "5"));
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "All validators should cause HTTP 400");
+        assertTrue(response.body().contains("Rejected by test validator"),
+                "Response should contain first validator message");
+        assertTrue(response.body().contains("Rejected by another validator"),
+                "Response should contain second validator message");
+    }
+
+    // -------------------------------------------------------------------------
+    // EXPLAIN / EXPLAIN ANALYZE tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void testExplainMode() throws IOException, InterruptedException {
+        var namedQuery = new NamedQueryRequest("get_series", Map.of("limit", "5"), QueryMode.EXPLAIN);
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        assertEquals(200, response.statusCode(), "EXPLAIN should return 200");
+
+        try (var allocator = new RootAllocator();
+             var reader = new ArrowStreamReader(response.body(), allocator)) {
+            // EXPLAIN returns a plan string — just verify we get at least one batch
+            assertTrue(reader.loadNextBatch(), "EXPLAIN should return at least one batch");
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void testExplainAnalyzeMode() throws IOException, InterruptedException {
+        var namedQuery = new NamedQueryRequest("get_series", Map.of("limit", "5"), QueryMode.EXPLAIN_ANALYZE);
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        assertEquals(200, response.statusCode(), "EXPLAIN ANALYZE should return 200");
+
+        try (var allocator = new RootAllocator();
+             var reader = new ArrowStreamReader(response.body(), allocator)) {
+            assertTrue(reader.loadNextBatch(), "EXPLAIN ANALYZE should return at least one batch");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // List + single-query tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testListReturnsPaginatedItems() throws IOException, InterruptedException {
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT + "?offset=0&limit=10"))
+                .GET()
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 for list endpoint");
+
+        Map<String, Object> page = objectMapper.readValue(response.body(), new TypeReference<>() {});
+        assertEquals(4, ((Number) page.get("total")).intValue(), "Expected total=4");
+        assertEquals(0, ((Number) page.get("offset")).intValue());
+        assertEquals(10, ((Number) page.get("limit")).intValue());
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = (List<Map<String, Object>>) page.get("items");
+        assertEquals(4, items.size(), "All 4 queries fit within limit=10");
+
+        // Names sorted alphabetically, only name + description present (no template, no validators)
+        assertEquals("filter_series",         items.get(0).get("name"));
+        assertEquals("get_series",            items.get(1).get("name"));
+        assertEquals("multi_validator_query", items.get(2).get("name"));
+        assertEquals("validated_query",       items.get(3).get("name"));
+        assertFalse(items.get(0).containsKey("template"), "template must not appear in list");
+        assertFalse(items.get(0).containsKey("validatorDescriptions"), "validators must not appear in list");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testListPaginationOffset() throws IOException, InterruptedException {
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT + "?offset=2&limit=2"))
+                .GET()
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+
+        Map<String, Object> page = objectMapper.readValue(response.body(), new TypeReference<>() {});
+        assertEquals(4, ((Number) page.get("total")).intValue());
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = (List<Map<String, Object>>) page.get("items");
+        assertEquals(2, items.size(), "Offset=2, limit=2 should return items 3 and 4");
+        assertEquals("multi_validator_query", items.get(0).get("name"));
+        assertEquals("validated_query",       items.get(1).get("name"));
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testGetByNameReturnsFullObject() throws IOException, InterruptedException {
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT + "/get_series"))
+                .GET()
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 for named query by name");
+
+        Map<String, Object> info = objectMapper.readValue(response.body(), new TypeReference<>() {});
+        assertEquals("get_series",           info.get("name"));
+        assertEquals("Returns the first N integers", info.get("description"));
+        assertTrue(info.containsKey("parameterDescriptions"), "Full object must include parameterDescriptions");
+        assertTrue(info.containsKey("validatorDescriptions"), "Full object must include validatorDescriptions");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testGetByNameWithValidatorsReturnsDescriptions() throws IOException, InterruptedException {
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT + "/validated_query"))
+                .GET()
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+
+        Map<String, Object> info = objectMapper.readValue(response.body(), new TypeReference<>() {});
+        @SuppressWarnings("unchecked")
+        List<String> descs = (List<String>) info.get("validatorDescriptions");
+        assertNotNull(descs);
+        assertEquals(1, descs.size());
+        // RejectAllValidatorNamedQuery.description() is "" → falls back to class name
+        assertNotNull(descs.get(0));
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testGetByNameUnknownReturns404() throws IOException, InterruptedException {
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT + "/no_such_query"))
+                .GET()
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(404, response.statusCode());
+    }
+
+    // -------------------------------------------------------------------------
+    // Test validator implementations — must be public with a no-arg constructor
+    // -------------------------------------------------------------------------
+
+    /** A validator that always rejects — used only in tests. */
+    public static class RejectAllValidatorNamedQuery implements NamedQueryParameterValidator {
+        @Override
+        public void validate(Map<String, String> parameters) throws ParameterValidationException {
+            throw new ParameterValidationException("Rejected by test validator");
+        }
+    }
+
+    /** A second validator that always rejects — used to verify multi-validator error collection. */
+    public static class AnotherRejectValidatorNamedQuery implements NamedQueryParameterValidator {
+        @Override
+        public void validate(Map<String, String> parameters) throws ParameterValidationException {
+            throw new ParameterValidationException("Rejected by another validator");
+        }
+    }
+}

--- a/dazzleduck-sql-logback/pom.xml
+++ b/dazzleduck-sql-logback/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
     <artifactId>dazzleduck-sql-logback</artifactId>
     <name>DazzleDuck Project Logback</name>

--- a/dazzleduck-sql-login/pom.xml
+++ b/dazzleduck-sql-login/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
     <artifactId>dazzleduck-sql-login</artifactId>
     <name>DazzleDuck Project Login</name>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/dazzleduck-sql-micrometer/pom.xml
+++ b/dazzleduck-sql-micrometer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
 
     <artifactId>dazzleduck-sql-micrometer</artifactId>
@@ -62,18 +62,18 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-otel-collector/pom.xml
+++ b/dazzleduck-sql-otel-collector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
 
     <artifactId>dazzleduck-sql-otel-collector</artifactId>
@@ -84,12 +84,12 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
 
         <!-- Logging -->

--- a/dazzleduck-sql-runtime/pom.xml
+++ b/dazzleduck-sql-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
     <name>DazzleDuck Project Runtime</name>
     <artifactId>dazzleduck-sql-runtime</artifactId>
@@ -18,12 +18,12 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-flight</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-http</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/dazzleduck-sql-scrapper/pom.xml
+++ b/dazzleduck-sql-scrapper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
 
     <artifactId>dazzleduck-sql-scrapper</artifactId>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
     </dependencies>
 

--- a/dazzleduck-sql-search/pom.xml
+++ b/dazzleduck-sql-search/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.0.34</version>
+        <version>0.0.35</version>
     </parent>
     <name>DazzleDuck Project Search</name>
     <artifactId>dazzleduck-sql-search</artifactId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.35</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.dazzleduck.sql</groupId>
     <artifactId>dazzleduck-parent</artifactId>
-    <version>0.0.34</version>
+    <version>0.0.35</version>
     <packaging>pom</packaging>
     <name>DazzleDuck Project Parent POM</name>
     <url>https://github.com/dazzleduck-web/dazzleduck-sql-server</url>


### PR DESCRIPTION
…alidation

- New HTTP endpoints POST/GET /v1/named-query for executing named (Jinja2-templated) SQL queries
- GET / returns paginated list using COUNT(*) OVER() window function (single DB round-trip)
- GET /{name} returns full query object with validator descriptions
- POST / renders template, runs all validators (collecting all failures), executes query
- EXPLAIN / EXPLAIN ANALYZE modes supported via QueryMode field
- Validator instances cached in ConcurrentHashMap (capped at 500 entries) to avoid repeated reflection
- Model objects in model package: NamedQueryRequest, NamedQueryResponse, NamedQueryTemplate, NamedQueryListItem, NamedQueryPage, QueryMode
- NamedQueryParameterValidator and ParameterValidationException added to dazzleduck-sql-common
- ParameterUtils.getParameterValue now checks query parameters in addition to headers
- README updated with Named Query endpoint documentation
- Version bumped to 0.0.35