### PR TITLE
fix: run startup script in Main before toProperties() to fix DuckLake…

### DIFF
--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/Main.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/Main.java
@@ -2,6 +2,7 @@ package io.dazzleduck.sql.otel.collector;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import io.dazzleduck.sql.commons.ConnectionPool;
 import io.dazzleduck.sql.otel.collector.config.CollectorConfig;
 import io.dazzleduck.sql.otel.collector.config.CollectorProperties;
 import org.slf4j.Logger;
@@ -36,7 +37,16 @@ public class Main {
             return;
         }
 
-        CollectorProperties props = new CollectorConfig(args.configFile).toProperties();
+        // Run the startup script before calling toProperties() so that extensions like
+        // ducklake and arrow are loaded before DuckLakeIngestionHandler queries DuckLake metadata.
+        CollectorConfig config = new CollectorConfig(args.configFile);
+        String startupScript = config.getStartupScript();
+        if (startupScript != null && !startupScript.isBlank()) {
+            log.info("Executing startup script");
+            ConnectionPool.executeOnSingleton(startupScript);
+        }
+
+        CollectorProperties props = config.toProperties();
         OtelCollectorServer server = new OtelCollectorServer(props);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorServer.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorServer.java
@@ -1,6 +1,6 @@
 package io.dazzleduck.sql.otel.collector;
 
-import io.dazzleduck.sql.commons.ConnectionPool;
+
 import io.dazzleduck.sql.commons.auth.Validator;
 import io.dazzleduck.sql.otel.collector.auth.JwtServerInterceptor;
 import io.dazzleduck.sql.otel.collector.config.CollectorProperties;
@@ -33,12 +33,6 @@ public class OtelCollectorServer implements Closeable {
     }
 
     public void start() throws IOException {
-        String startupScript = props.getStartupScript();
-        if (startupScript != null && !startupScript.isBlank()) {
-            log.info("Executing startup script");
-            ConnectionPool.executeOnSingleton(startupScript);
-        }
-
         var handler = props.getIngestionHandler();
         var ingestionConfig = props.getIngestionConfig();
         logWriter     = new SignalWriter("logs",    handler, ingestionConfig);

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorLoginDelegationTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorLoginDelegationTest.java
@@ -51,6 +51,15 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class OtelCollectorLoginDelegationTest {
 
+    @org.junit.jupiter.api.BeforeAll
+    static void loadExtensions() throws Exception {
+        // Arrow must be loaded before OtelCollectorServer starts — the server no longer
+        // runs the startup script internally; Main handles it in production.
+        io.dazzleduck.sql.commons.ConnectionPool.executeBatch(new String[]{
+                "INSTALL arrow FROM community", "LOAD arrow"
+        });
+    }
+
     static final String SECRET_KEY_BASE64 =
             "VGhpcyBpcyBhIDY0IGJpdCBsb25nIGtleSB3aGljaCBzaG91bGQgYmUgY2hhbmdlZCBpbiBwcm9kdWN0aW9uLiBTbyBjaGFuZ2UgbWUgYW5kIG1ha2Ugc3VyZSBpdHMgMTI4IGJpdCBsb25nIG9yIG1vcmU";
     static final String VALID_USER = "admin";


### PR DESCRIPTION
… race condition

DuckLakeIngestionHandler queries DuckLake metadata (fetchPath, fetchPartitionColumns) during construction inside toProperties(). Previously the startup script (INSTALL/LOAD ducklake, LOAD arrow) only ran inside OtelCollectorServer.start(), which is after toProperties() — causing a race where DuckLake wasn't loaded yet.

Fix:
- Main now reads the startup script from CollectorConfig and runs it via ConnectionPool.executeOnSingleton() before calling toProperties()
- OtelCollectorServer.start() no longer runs the startup script (responsibility belongs to the caller now that handler construction requires extensions)
- OtelCollectorLoginDelegationTest: added static @BeforeAll to load the Arrow extension before nested test servers start (previously relied on the server)