### PR TITLE
Extract reusable result streaming (Arrow/TSV) + ContentTypes into commons/common

### DIFF
--- a/dazzleduck-sql-client-grpc/pom.xml
+++ b/dazzleduck-sql-client-grpc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>dazzleduck-sql-client-grpc</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
@@ -48,13 +48,13 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-client/pom.xml
+++ b/dazzleduck-sql-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>dazzleduck-sql-client</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
@@ -38,13 +38,13 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-client/src/main/java/io/dazzleduck/sql/client/HttpArrowProducer.java
+++ b/dazzleduck-sql-client/src/main/java/io/dazzleduck/sql/client/HttpArrowProducer.java
@@ -262,8 +262,8 @@ public final class HttpArrowProducer extends ArrowProducer.AbstractArrowProducer
                 .uri(URI.create(baseUrl + "/v1/login"))
                 .timeout(httpClientTimeout)
                 .POST(HttpRequest.BodyPublishers.ofByteArray(body))
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json")
+                .header("Content-Type", io.dazzleduck.sql.common.ContentTypes.APPLICATION_JSON)
+                .header("Accept", io.dazzleduck.sql.common.ContentTypes.APPLICATION_JSON)
                 .build();
 
         HttpResponse<String> resp;
@@ -459,7 +459,7 @@ public final class HttpArrowProducer extends ArrowProducer.AbstractArrowProducer
                 .timeout(httpClientTimeout)
                 .POST(HttpRequest.BodyPublishers.ofByteArray(payload))
                 .header("Authorization", getJwt())
-                .header("Content-Type", "application/vnd.apache.arrow.stream");
+                .header("Content-Type", io.dazzleduck.sql.common.ContentTypes.APPLICATION_ARROW);
 
         if (!getPartitionBy().isEmpty()) {
             String partitionByValue = String.join(",", getPartitionBy());

--- a/dazzleduck-sql-common/pom.xml
+++ b/dazzleduck-sql-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
     <artifactId>dazzleduck-sql-common</artifactId>
     <name>DazzleDuck Project Common</name>

--- a/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ContentTypes.java
+++ b/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ContentTypes.java
@@ -1,8 +1,13 @@
-package io.dazzleduck.sql.http.server.model;
+package io.dazzleduck.sql.common;
 
-public class ContentTypes {
+/** Canonical content types for query results, shared across modules and reusable by consumers. */
+public final class ContentTypes {
+
     public static final String APPLICATION_JSON = "application/json";
     public static final String APPLICATION_ARROW = "application/vnd.apache.arrow.stream";
     public static final String TEXT_TSV = "text/tab-separated-values";
     public static final String TEXT_TSV_UTF8 = "text/tab-separated-values; charset=utf-8";
+
+    private ContentTypes() {
+    }
 }

--- a/dazzleduck-sql-commons/pom.xml
+++ b/dazzleduck-sql-commons/pom.xml
@@ -156,6 +156,14 @@
             <artifactId>dazzleduck-sql-common</artifactId>
             <version>0.2.9</version>
         </dependency>
+        <!-- Test only: ResultStreamsTest exercises ZSTD Arrow round-trip via CommonsCompressionFactory
+             (brings zstd-jni transitively). commons main code stays compression-impl-free. -->
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-compression</artifactId>
+            <version>${arrow.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dazzleduck-sql-commons/pom.xml
+++ b/dazzleduck-sql-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
     <artifactId>dazzleduck-sql-commons</artifactId>
     <name>DazzleDuck Project Commons</name>
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <!-- Test only: ResultStreamsTest exercises ZSTD Arrow round-trip via CommonsCompressionFactory
              (brings zstd-jni transitively). commons main code stays compression-impl-free. -->

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/io/ResultStreams.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/io/ResultStreams.java
@@ -1,0 +1,202 @@
+package io.dazzleduck.sql.commons.io;
+
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DateMilliVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMilliTZVector;
+import org.apache.arrow.vector.TimeStampNanoTZVector;
+import org.apache.arrow.vector.TimeStampSecTZVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.compression.CompressionCodec;
+import org.apache.arrow.vector.compression.CompressionUtil;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.message.IpcOption;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * Serializes Arrow query results to a client {@link OutputStream} as Arrow IPC (optionally
+ * compressed) or TSV, flushing per batch. Dependency-light: uses only {@code arrow-vector}, with
+ * the compression {@link CompressionCodec.Factory} injected by the caller — so this module does
+ * not pull {@code arrow-compression}/{@code commons-compress}/{@code zstd-jni}. Callers that want
+ * ZSTD/LZ4 pass {@code CommonsCompressionFactory.INSTANCE} (from {@code arrow-compression}).
+ *
+ * <p>Two layers are exposed:
+ * <ul>
+ *   <li><b>Pull</b> helpers ({@link #writeArrow}, {@link #writeTsv}) drive an {@link ArrowReader}
+ *       to completion — convenient for JDBC/DuckDB callers.</li>
+ *   <li><b>Per-batch</b> primitives ({@link #newArrowStreamWriter}, {@link #writeTsvHeader},
+ *       {@link #writeTsvRows}, {@link #formatValue}) — for push-based callers (e.g. Flight
+ *       listeners) that receive one {@link VectorSchemaRoot} at a time.</li>
+ * </ul>
+ */
+public final class ResultStreams {
+
+    private static final char TAB = '\t';
+    private static final char NEWLINE = '\n';
+
+    private ResultStreams() {
+    }
+
+    /**
+     * Streams every batch of {@code reader} to {@code out} as Arrow IPC, flushing per batch.
+     *
+     * @param codec   compression codec ({@code NO_COMPRESSION} to disable)
+     * @param factory codec implementation factory (ignored when {@code codec} is NO_COMPRESSION)
+     * @return total rows written
+     */
+    public static long writeArrow(ArrowReader reader, OutputStream out,
+                                  CompressionUtil.CodecType codec,
+                                  CompressionCodec.Factory factory) throws IOException {
+        VectorSchemaRoot root = reader.getVectorSchemaRoot();
+        long rows = 0;
+        try (ArrowStreamWriter writer = newArrowStreamWriter(root, null, out, codec, factory)) {
+            writer.start();
+            while (reader.loadNextBatch()) {
+                rows += root.getRowCount();
+                writer.writeBatch();
+                out.flush();
+            }
+            writer.end();
+            out.flush();
+        }
+        return rows;
+    }
+
+    /**
+     * Streams every batch of {@code reader} to {@code out} as TSV (header row + tab-separated
+     * rows), flushing per batch.
+     *
+     * @return total rows written
+     */
+    public static long writeTsv(ArrowReader reader, OutputStream out) throws IOException {
+        VectorSchemaRoot root = reader.getVectorSchemaRoot();
+        long rows = 0;
+        try (Writer writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
+            writeTsvHeader(root, writer);
+            while (reader.loadNextBatch()) {
+                writeTsvRows(root, writer);
+                rows += root.getRowCount();
+                writer.flush();
+            }
+        }
+        return rows;
+    }
+
+    /**
+     * Creates an {@link ArrowStreamWriter} for {@code root}, with compression when {@code codec}
+     * is not {@code NO_COMPRESSION}. The caller supplies the codec factory.
+     */
+    public static ArrowStreamWriter newArrowStreamWriter(VectorSchemaRoot root,
+                                                         DictionaryProvider dictionaries,
+                                                         OutputStream out,
+                                                         CompressionUtil.CodecType codec,
+                                                         CompressionCodec.Factory factory) {
+        return newArrowStreamWriter(root, dictionaries, out, codec, factory, IpcOption.DEFAULT);
+    }
+
+    /** As above, with an explicit {@link IpcOption} (used by Flight, which carries one). */
+    public static ArrowStreamWriter newArrowStreamWriter(VectorSchemaRoot root,
+                                                         DictionaryProvider dictionaries,
+                                                         OutputStream out,
+                                                         CompressionUtil.CodecType codec,
+                                                         CompressionCodec.Factory factory,
+                                                         IpcOption option) {
+        if (codec == null || codec == CompressionUtil.CodecType.NO_COMPRESSION) {
+            return new ArrowStreamWriter(root, dictionaries, out);
+        }
+        return new ArrowStreamWriter(root, dictionaries, Channels.newChannel(out),
+                option != null ? option : IpcOption.DEFAULT, factory, codec);
+    }
+
+    /** Writes the TSV header row (column names, tab-separated). */
+    public static void writeTsvHeader(VectorSchemaRoot root, Writer writer) throws IOException {
+        List<FieldVector> vectors = root.getFieldVectors();
+        for (int i = 0; i < vectors.size(); i++) {
+            if (i > 0) {
+                writer.write(TAB);
+            }
+            writer.write(vectors.get(i).getName());
+        }
+        writer.write(NEWLINE);
+    }
+
+    /** Writes all rows of {@code root} as TSV lines (null cells become empty strings). */
+    public static void writeTsvRows(VectorSchemaRoot root, Writer writer) throws IOException {
+        List<FieldVector> vectors = root.getFieldVectors();
+        int rowCount = root.getRowCount();
+        for (int row = 0; row < rowCount; row++) {
+            for (int col = 0; col < vectors.size(); col++) {
+                if (col > 0) {
+                    writer.write(TAB);
+                }
+                String value = formatValue(vectors.get(col), row);
+                if (value != null) {
+                    writer.write(value);
+                }
+            }
+            writer.write(NEWLINE);
+        }
+    }
+
+    /**
+     * Formats a single cell as a string. Date/time vectors backed by raw integers are converted to
+     * ISO-8601; all other types fall back to {@code getObject().toString()} (readable for numerics,
+     * strings, booleans, non-TZ timestamps, lists, structs, maps). Null returns {@code null}.
+     */
+    public static String formatValue(FieldVector vector, int row) {
+        if (vector.isNull(row)) {
+            return null;
+        }
+        return switch (vector.getMinorType()) {
+            case DATEDAY ->
+                    LocalDate.ofEpochDay(((DateDayVector) vector).get(row)).toString();
+            case DATEMILLI ->
+                    LocalDate.ofEpochDay(((DateMilliVector) vector).get(row) / 86_400_000L).toString();
+            case TIMESEC ->
+                    LocalTime.ofSecondOfDay(((TimeSecVector) vector).get(row)).toString();
+            case TIMEMILLI ->
+                    LocalTime.ofNanoOfDay((long) ((TimeMilliVector) vector).get(row) * 1_000_000L).toString();
+            case TIMEMICRO ->
+                    LocalTime.ofNanoOfDay(((TimeMicroVector) vector).get(row) * 1_000L).toString();
+            case TIMENANO ->
+                    LocalTime.ofNanoOfDay(((TimeNanoVector) vector).get(row)).toString();
+            case TIMESTAMPSECTZ ->
+                    Instant.ofEpochSecond(((TimeStampSecTZVector) vector).get(row)).toString();
+            case TIMESTAMPMILLITZ ->
+                    Instant.ofEpochMilli(((TimeStampMilliTZVector) vector).get(row)).toString();
+            case TIMESTAMPMICROTZ -> {
+                long micros = ((TimeStampMicroTZVector) vector).get(row);
+                yield Instant.ofEpochSecond(
+                        Math.floorDiv(micros, 1_000_000L),
+                        Math.floorMod(micros, 1_000_000L) * 1_000L).toString();
+            }
+            case TIMESTAMPNANOTZ -> {
+                long nanos = ((TimeStampNanoTZVector) vector).get(row);
+                yield Instant.ofEpochSecond(
+                        Math.floorDiv(nanos, 1_000_000_000L),
+                        Math.floorMod(nanos, 1_000_000_000L)).toString();
+            }
+            default -> {
+                Object value = vector.getObject(row);
+                yield value != null ? value.toString() : null;
+            }
+        };
+    }
+}

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/io/ResultStreamsTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/io/ResultStreamsTest.java
@@ -1,0 +1,90 @@
+package io.dazzleduck.sql.commons.io;
+
+import io.dazzleduck.sql.commons.ConnectionPool;
+import org.apache.arrow.compression.CommonsCompressionFactory;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.compression.CompressionUtil;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.duckdb.DuckDBConnection;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResultStreamsTest {
+
+    // Two rows, including a DATE column to exercise the temporal formatValue path.
+    private static final String SQL =
+            "SELECT * FROM (VALUES (1, 'a', DATE '2020-01-02'), (2, 'b', DATE '2020-01-03')) "
+                    + "t(id, name, d) ORDER BY id";
+
+    private interface ReaderConsumer<T> {
+        T apply(ArrowReader reader) throws SQLException, IOException;
+    }
+
+    /** Opens a fresh reader for SQL, applies fn, and closes everything. */
+    private static <T> T withReader(ReaderConsumer<T> fn) throws SQLException, IOException {
+        try (DuckDBConnection conn = ConnectionPool.getConnection();
+             BufferAllocator allocator = new RootAllocator();
+             ArrowReader reader = ConnectionPool.getReader(conn, allocator, SQL, 1024)) {
+            return fn.apply(reader);
+        }
+    }
+
+    /** Drains an Arrow IPC stream and returns the row count. */
+    private static long readArrowRows(byte[] bytes, CompressionUtil.CodecType codec) throws IOException {
+        try (BufferAllocator allocator = new RootAllocator();
+             ArrowReader reader = codec == CompressionUtil.CodecType.NO_COMPRESSION
+                     ? new ArrowStreamReader(new ByteArrayInputStream(bytes), allocator)
+                     : new ArrowStreamReader(new ByteArrayInputStream(bytes), allocator,
+                             CommonsCompressionFactory.INSTANCE)) {
+            long rows = 0;
+            while (reader.loadNextBatch()) {
+                rows += reader.getVectorSchemaRoot().getRowCount();
+            }
+            return rows;
+        }
+    }
+
+    @Test
+    void writeTsvWritesHeaderRowsAndIsoTemporal() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        long rows = withReader(r -> ResultStreams.writeTsv(r, out));
+
+        assertEquals(2, rows);
+        String[] lines = out.toString(StandardCharsets.UTF_8).strip().split("\n");
+        assertEquals("id\tname\td", lines[0]);
+        assertEquals("1\ta\t2020-01-02", lines[1]); // DATE -> ISO-8601 via formatValue
+        assertEquals("2\tb\t2020-01-03", lines[2]);
+    }
+
+    @Test
+    void writeArrowUncompressedRoundTrips() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        long rows = withReader(r -> ResultStreams.writeArrow(
+                r, out, CompressionUtil.CodecType.NO_COMPRESSION, null));
+
+        assertEquals(2, rows);
+        assertEquals(2, readArrowRows(out.toByteArray(), CompressionUtil.CodecType.NO_COMPRESSION));
+    }
+
+    @Test
+    void writeArrowZstdRoundTrips() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        long rows = withReader(r -> ResultStreams.writeArrow(
+                r, out, CompressionUtil.CodecType.ZSTD, CommonsCompressionFactory.INSTANCE));
+
+        assertEquals(2, rows);
+        // Decodes only with a compression-aware reader.
+        assertEquals(2, readArrowRows(out.toByteArray(), CompressionUtil.CodecType.ZSTD));
+        assertTrue(out.size() > 0);
+    }
+}

--- a/dazzleduck-sql-ducklake-compactor/pom.xml
+++ b/dazzleduck-sql-ducklake-compactor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>dazzleduck-sql-ducklake-compactor</artifactId>

--- a/dazzleduck-sql-examples/pom.xml
+++ b/dazzleduck-sql-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>dazzleduck-sql-examples</artifactId>

--- a/dazzleduck-sql-flight/pom.xml
+++ b/dazzleduck-sql-flight/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>dazzleduck-sql-flight</artifactId>
@@ -43,19 +43,19 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId> <!-- ✅ fixed -->
             <artifactId>dazzleduck-sql-login</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/DirectOutputStreamListener.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/DirectOutputStreamListener.java
@@ -1,5 +1,6 @@
 package io.dazzleduck.sql.flight.server;
 
+import io.dazzleduck.sql.commons.io.ResultStreams;
 import org.apache.arrow.compression.CommonsCompressionFactory;
 import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.memory.ArrowBuf;
@@ -14,7 +15,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.channels.Channels;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
@@ -97,18 +97,9 @@ public class DirectOutputStreamListener implements FlightProducer.ServerStreamLi
             // Only do this when we're ready to write data
             this.outputStream = outputStreamSupplier.get();
 
-            // Handle NO_COMPRESSION separately - use constructor without compression factory
-            if (compressionCodec == CompressionUtil.CodecType.NO_COMPRESSION) {
-                this.writer = new ArrowStreamWriter(root, dictionaries, outputStream);
-            } else {
-                this.writer = new ArrowStreamWriter(
-                        root,
-                        dictionaries,
-                        Channels.newChannel(outputStream),
-                        option != null ? option : IpcOption.DEFAULT,
-                        CommonsCompressionFactory.INSTANCE,
-                        compressionCodec);
-            }
+            this.writer = ResultStreams.newArrowStreamWriter(
+                    root, dictionaries, outputStream,
+                    compressionCodec, CommonsCompressionFactory.INSTANCE, option);
             writer.start();
             outputStream.flush();
             logger.debug("writer.start() and flush completed successfully with compression: {}", compressionCodec);

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/TsvOutputStreamListener.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/TsvOutputStreamListener.java
@@ -1,9 +1,10 @@
 package io.dazzleduck.sql.flight.server;
 
+import io.dazzleduck.sql.commons.io.ResultStreams;
 import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.*;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.ipc.message.IpcOption;
@@ -17,10 +18,6 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -35,8 +32,6 @@ import java.util.function.Supplier;
 public class TsvOutputStreamListener implements FlightProducer.ServerStreamListener {
 
     private static final Logger logger = LoggerFactory.getLogger(TsvOutputStreamListener.class);
-    private static final char TAB = '\t';
-    private static final char NEWLINE = '\n';
 
     private final Supplier<OutputStream> outputStreamSupplier;
     private final CompletableFuture<Void> future;
@@ -134,16 +129,11 @@ public class TsvOutputStreamListener implements FlightProducer.ServerStreamListe
     }
 
     private void writeHeader() throws IOException {
-        List<FieldVector> vectors = root.getFieldVectors();
-        for (int i = 0; i < vectors.size(); i++) {
-            if (i > 0) writer.write(TAB);
-            writer.write(vectors.get(i).getName());
-        }
-        writer.write(NEWLINE);
+        ResultStreams.writeTsvHeader(root, writer);
     }
 
     private void writeRows() throws IOException {
-        writeRootToWriter(root, writer);
+        ResultStreams.writeTsvRows(root, writer);
     }
 
     /**
@@ -183,73 +173,9 @@ public class TsvOutputStreamListener implements FlightProducer.ServerStreamListe
         return tsvFuture;
     }
 
+    /** @deprecated use {@link ResultStreams#writeTsvRows(VectorSchemaRoot, Writer)}. */
+    @Deprecated
     public static void writeRootToWriter(VectorSchemaRoot root, Writer writer) throws IOException {
-        List<FieldVector> vectors = root.getFieldVectors();
-        int rowCount = root.getRowCount();
-        for (int row = 0; row < rowCount; row++) {
-            for (int col = 0; col < vectors.size(); col++) {
-                if (col > 0) writer.write(TAB);
-                String value = formatValue(vectors.get(col), row);
-                if (value != null) {
-                    writer.write(value);
-                }
-            }
-            writer.write(NEWLINE);
-        }
-    }
-
-    /**
-     * Formats a single cell value as a string.
-     *
-     * Arrow vectors for date/time types backed by raw integers are converted to
-     * ISO-8601 strings. All other types fall back to {@code getObject().toString()},
-     * which already produces readable output for numerics, strings, booleans,
-     * non-TZ timestamps (LocalDateTime), lists (JsonStringArrayList), and
-     * structs (JsonStringHashMap).
-     */
-    private static String formatValue(FieldVector vector, int row) {
-        if (vector.isNull(row)) return null;
-        return switch (vector.getMinorType()) {
-            // Date types — getObject() returns Integer (days since epoch)
-            case DATEDAY ->
-                LocalDate.ofEpochDay(((DateDayVector) vector).get(row)).toString();
-            case DATEMILLI ->
-                LocalDate.ofEpochDay(((DateMilliVector) vector).get(row) / 86_400_000L).toString();
-
-            // Time types — getObject() returns raw Integer/Long
-            case TIMESEC ->
-                LocalTime.ofSecondOfDay(((TimeSecVector) vector).get(row)).toString();
-            case TIMEMILLI ->
-                LocalTime.ofNanoOfDay((long) ((TimeMilliVector) vector).get(row) * 1_000_000L).toString();
-            case TIMEMICRO ->
-                LocalTime.ofNanoOfDay(((TimeMicroVector) vector).get(row) * 1_000L).toString();
-            case TIMENANO ->
-                LocalTime.ofNanoOfDay(((TimeNanoVector) vector).get(row)).toString();
-
-            // Timezone-aware timestamp types — getObject() returns Long (raw units since epoch)
-            case TIMESTAMPSECTZ ->
-                Instant.ofEpochSecond(((TimeStampSecTZVector) vector).get(row)).toString();
-            case TIMESTAMPMILLITZ ->
-                Instant.ofEpochMilli(((TimeStampMilliTZVector) vector).get(row)).toString();
-            case TIMESTAMPMICROTZ -> {
-                long micros = ((TimeStampMicroTZVector) vector).get(row);
-                yield Instant.ofEpochSecond(
-                        Math.floorDiv(micros, 1_000_000L),
-                        Math.floorMod(micros, 1_000_000L) * 1_000L).toString();
-            }
-            case TIMESTAMPNANOTZ -> {
-                long nanos = ((TimeStampNanoTZVector) vector).get(row);
-                yield Instant.ofEpochSecond(
-                        Math.floorDiv(nanos, 1_000_000_000L),
-                        Math.floorMod(nanos, 1_000_000_000L)).toString();
-            }
-
-            // All other types (numerics, strings, booleans, non-TZ timestamps,
-            // lists, structs, maps) — getObject() already returns a readable value
-            default -> {
-                Object value = vector.getObject(row);
-                yield value != null ? value.toString() : null;
-            }
-        };
+        ResultStreams.writeTsvRows(root, writer);
     }
 }

--- a/dazzleduck-sql-http/pom.xml
+++ b/dazzleduck-sql-http/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
     <artifactId>dazzleduck-sql-http</artifactId>
     <name>DazzleDuck Project Http Sql</name>
@@ -19,17 +19,17 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-login</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-flight</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/dazzleduck-sql-http/pom.xml
+++ b/dazzleduck-sql-http/pom.xml
@@ -27,6 +27,11 @@
             <version>0.2.9</version>
         </dependency>
         <dependency>
+            <groupId>io.dazzleduck.sql</groupId>
+            <artifactId>dazzleduck-sql-common</artifactId>
+            <version>0.2.9</version>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
             <version>${helidon.version}</version>

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/IngestionService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/IngestionService.java
@@ -3,7 +3,7 @@ package io.dazzleduck.sql.http.server;
 import io.dazzleduck.sql.commons.ingestion.PendingWriteExceededException;
 import io.dazzleduck.sql.flight.ingestion.IngestionParameters;
 import io.dazzleduck.sql.flight.server.HttpFlightAdaptor;
-import io.dazzleduck.sql.http.server.model.ContentTypes;
+import io.dazzleduck.sql.common.ContentTypes;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
@@ -5,7 +5,7 @@ import io.dazzleduck.sql.common.ParameterValidationException;
 import io.dazzleduck.sql.flight.namedquery.NamedQueryRequest;
 import io.dazzleduck.sql.flight.namedquery.NamedQueryServiceAdaptor;
 import io.dazzleduck.sql.flight.server.TsvOutputStreamListener;
-import io.dazzleduck.sql.http.server.model.ContentTypes;
+import io.dazzleduck.sql.common.ContentTypes;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
 import io.helidon.webserver.http.HttpRules;

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/QueryService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/QueryService.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.protobuf.ByteString;
 import io.dazzleduck.sql.flight.server.HttpFlightAdaptor;
 import io.dazzleduck.sql.flight.server.StatementHandle;
-import io.dazzleduck.sql.http.server.model.ContentTypes;
+import io.dazzleduck.sql.common.ContentTypes;
 import io.dazzleduck.sql.http.server.model.HttpConfig;
 import io.dazzleduck.sql.http.server.model.QueryRequest;
 import io.helidon.http.HeaderNames;

--- a/dazzleduck-sql-logback/pom.xml
+++ b/dazzleduck-sql-logback/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
     <artifactId>dazzleduck-sql-logback</artifactId>
     <name>DazzleDuck Project Logback</name>

--- a/dazzleduck-sql-login/pom.xml
+++ b/dazzleduck-sql-login/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
     <artifactId>dazzleduck-sql-login</artifactId>
     <name>DazzleDuck Project Login</name>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/dazzleduck-sql-micrometer/pom.xml
+++ b/dazzleduck-sql-micrometer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>dazzleduck-sql-micrometer</artifactId>
@@ -62,18 +62,18 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-otel-collector/pom.xml
+++ b/dazzleduck-sql-otel-collector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>dazzleduck-sql-otel-collector</artifactId>
@@ -86,12 +86,12 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
 
         <!-- Logging -->

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelServiceBase.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelServiceBase.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -74,7 +73,9 @@ class OtelServiceBase implements Closeable {
         try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
             batchWriter.accept(entries, root);
             try (FileOutputStream fos = new FileOutputStream(tempFile.toFile());
-                 ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(fos))) {
+                 ArrowStreamWriter writer = io.dazzleduck.sql.commons.io.ResultStreams.newArrowStreamWriter(
+                         root, null, fos,
+                         org.apache.arrow.vector.compression.CompressionUtil.CodecType.NO_COMPRESSION, null)) {
                 writer.start();
                 writer.writeBatch();
                 writer.end();

--- a/dazzleduck-sql-runtime/pom.xml
+++ b/dazzleduck-sql-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
     <name>DazzleDuck Project Runtime</name>
     <artifactId>dazzleduck-sql-runtime</artifactId>

--- a/dazzleduck-sql-scrapper/pom.xml
+++ b/dazzleduck-sql-scrapper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>dazzleduck-sql-scrapper</artifactId>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/dazzleduck-sql-search/pom.xml
+++ b/dazzleduck-sql-search/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.9</version>
+        <version>0.2.10-SNAPSHOT</version>
     </parent>
     <name>DazzleDuck Project Search</name>
     <artifactId>dazzleduck-sql-search</artifactId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.9</version>
+            <version>0.2.10-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.dazzleduck.sql</groupId>
     <artifactId>dazzleduck-parent</artifactId>
-    <version>0.2.9</version>
+    <version>0.2.10-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DazzleDuck Project Parent POM</name>
     <url>https://github.com/dazzleduck-web/dazzleduck-sql-server</url>


### PR DESCRIPTION
Extracts result serialization (Arrow IPC + TSV) and `ContentTypes` out of the heavy
`flight`/`http` modules into a dependency-light, reusable layer so consumers can stream
DuckDB/Arrow results without pulling Flight/gRPC or Helidon.

Closes #348.

## Changes
- **commons** `io.dazzleduck.sql.commons.io.ResultStreams` — Arrow IPC (compression via an
  injected `CompressionCodec.Factory`, so `commons` gains **no** `arrow-compression` dependency)
  and TSV. Pull helpers (`writeArrow`/`writeTsv` over an `ArrowReader`) + per-batch primitives
  (`writeTsvHeader`/`writeTsvRows`/`formatValue`/`newArrowStreamWriter`, incl. an `IpcOption` overload).
- **common** `io.dazzleduck.sql.common.ContentTypes` — canonical wire content types (moved from
  `http .../server/model/ContentTypes`, which is deleted).
- **flight** `TsvOutputStreamListener` and `DirectOutputStreamListener` now delegate to `ResultStreams`.
- **http** `QueryService`/`IngestionService`/`NamedQueryService` use `common.ContentTypes`; added a
  direct `dazzleduck-sql-common` dependency.
- **otel-collector**, **client** reuse `ResultStreams.newArrowStreamWriter` / `common.ContentTypes`.
- **Test** `ResultStreamsTest` (NO_COMPRESSION + ZSTD round-trip, TSV temporal formatting);
  `arrow-compression` added at **test** scope only.

## Testing
`common`, `commons`, `login`, `flight`, `http`, `otel-collector` test suites pass.

Pre-existing, unrelated failures were excluded from the run (not caused by this change):
- Delta `getSubject is not supported` (JDK 25): `SplitPlannerTest`, `PartitionPruningTest`,
  `DuckDBFlightSqlProducerTest.testStatementSplittableDelta`
- `BulkIngestQueueTest.testSmallLargeBatchToFillTheBucket` (ingestion bucket assertion)
- `DuckLakePostgresLoadTest` (requires Docker)

## Note
Version left at `0.2.9` for local iteration; bump to e.g. `0.2.10-SNAPSHOT` before merging if desired.
