### PR TITLE
refactor(namedquery): extract Flight-free named-query parts to commons

### DIFF
--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryDefinition.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryDefinition.java
@@ -1,4 +1,4 @@
-package io.dazzleduck.sql.flight.namedquery;
+package io.dazzleduck.sql.commons.namedquery;
 
 import java.util.Map;
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryRequest.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryRequest.java
@@ -1,4 +1,4 @@
-package io.dazzleduck.sql.flight.namedquery;
+package io.dazzleduck.sql.commons.namedquery;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryResponse.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryResponse.java
@@ -1,4 +1,4 @@
-package io.dazzleduck.sql.flight.namedquery;
+package io.dazzleduck.sql.commons.namedquery;
 
 import java.util.List;
 import java.util.Map;

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryStore.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryStore.java
@@ -1,0 +1,42 @@
+package io.dazzleduck.sql.commons.namedquery;
+
+import io.dazzleduck.sql.commons.ConnectionPool;
+import org.duckdb.DuckDBConnection;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+/**
+ * Loads {@link NamedQueryDefinition} rows from a DuckDB-backed template table via
+ * {@link ConnectionPool}. Pure data access — no Flight or templating dependency — so any
+ * named-query consumer can resolve a template by name and then render/execute it however it likes.
+ */
+public final class NamedQueryStore {
+
+    private static final String LOAD_BY_NAME =
+            "SELECT id, name, template, validators, description, parameter_descriptions, preferred_display, query_group FROM %s WHERE name = '%s'";
+
+    private NamedQueryStore() {
+    }
+
+    /**
+     * Loads the named query {@code name} from {@code table}, or {@link Optional#empty()} when no row
+     * matches. The name is single-quote-escaped before interpolation; the caller owns {@code table}
+     * (it is interpolated verbatim, so it must be a trusted identifier).
+     */
+    public static Optional<NamedQueryDefinition> loadByName(String table, String name) throws SQLException {
+        String safeName = name.replace("'", "''");
+        String sql = LOAD_BY_NAME.formatted(table, safeName);
+        try (DuckDBConnection connection = ConnectionPool.getConnection()) {
+            var iterable = ConnectionPool.collectAll(connection, sql, NamedQueryDefinition.class);
+            var iter = iterable.iterator();
+            try {
+                return iter.hasNext() ? Optional.of(iter.next()) : Optional.empty();
+            } finally {
+                if (iter instanceof AutoCloseable ac) {
+                    try { ac.close(); } catch (Exception ignored) {}
+                }
+            }
+        }
+    }
+}

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryValidators.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/namedquery/NamedQueryValidators.java
@@ -1,0 +1,90 @@
+package io.dazzleduck.sql.commons.namedquery;
+
+import io.dazzleduck.sql.common.NamedQueryParameterValidator;
+import io.dazzleduck.sql.common.ParameterValidationException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Instantiates, caches, and runs {@link NamedQueryParameterValidator} implementations referenced
+ * by a named query (by fully-qualified class name). Framework-agnostic — no Flight or templating
+ * dependency — so it can be reused by any named-query consumer.
+ */
+public final class NamedQueryValidators {
+
+    private static final int MAX_VALIDATOR_CACHE_SIZE = 500;
+
+    /** Validator instance cache: fully-qualified class name → singleton instance. */
+    private final ConcurrentHashMap<String, NamedQueryParameterValidator> validatorCache = new ConcurrentHashMap<>();
+
+    /**
+     * Runs every validator named in {@code validatorClassNames} against {@code parameters},
+     * aggregating all failures into a single {@link ParameterValidationException}. A {@code null}
+     * or empty array is a no-op.
+     */
+    public void validate(String[] validatorClassNames, Map<String, String> parameters)
+            throws ParameterValidationException {
+        if (validatorClassNames == null || validatorClassNames.length == 0) {
+            return;
+        }
+        Map<String, String> safeParams = parameters != null ? parameters : Map.of();
+        List<String> errors = new ArrayList<>();
+        for (String className : validatorClassNames) {
+            try {
+                getOrCreateValidator(className).validate(safeParams);
+            } catch (ParameterValidationException e) {
+                errors.add(e.getMessage());
+            } catch (RuntimeException e) {
+                errors.add("Validator configuration error: " + className + " — " + e.getMessage());
+            }
+        }
+        if (!errors.isEmpty()) {
+            throw new ParameterValidationException(String.join("; ", errors));
+        }
+    }
+
+    /**
+     * Returns the human-readable {@link NamedQueryParameterValidator#description()} for each validator
+     * class, falling back to the class name when a validator cannot be instantiated. Useful for
+     * exposing a named query's parameter contract without leaking implementation class names.
+     */
+    public List<String> describe(String[] validatorClassNames) {
+        if (validatorClassNames == null || validatorClassNames.length == 0) {
+            return List.of();
+        }
+        List<String> descriptions = new ArrayList<>(validatorClassNames.length);
+        for (String className : validatorClassNames) {
+            try {
+                descriptions.add(getOrCreateValidator(className).description());
+            } catch (RuntimeException e) {
+                descriptions.add(className);
+            }
+        }
+        return descriptions;
+    }
+
+    private NamedQueryParameterValidator getOrCreateValidator(String className) {
+        NamedQueryParameterValidator cached = validatorCache.get(className);
+        if (cached != null) {
+            return cached;
+        }
+        NamedQueryParameterValidator instance = instantiateValidator(className);
+        if (validatorCache.size() < MAX_VALIDATOR_CACHE_SIZE) {
+            NamedQueryParameterValidator existing = validatorCache.putIfAbsent(className, instance);
+            return existing != null ? existing : instance;
+        }
+        return instance;
+    }
+
+    private NamedQueryParameterValidator instantiateValidator(String className) {
+        try {
+            return (NamedQueryParameterValidator) Class.forName(className)
+                    .getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to instantiate validator: " + className, e);
+        }
+    }
+}

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/namedquery/DefaultNamedQueryServiceAdaptor.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/namedquery/DefaultNamedQueryServiceAdaptor.java
@@ -2,36 +2,29 @@ package io.dazzleduck.sql.flight.namedquery;
 
 import com.google.protobuf.ByteString;
 import com.hubspot.jinjava.Jinjava;
-import io.dazzleduck.sql.common.NamedQueryParameterValidator;
 import io.dazzleduck.sql.common.ParameterValidationException;
-import io.dazzleduck.sql.commons.ConnectionPool;
+import io.dazzleduck.sql.commons.namedquery.NamedQueryDefinition;
+import io.dazzleduck.sql.commons.namedquery.NamedQueryValidators;
+import io.dazzleduck.sql.commons.namedquery.NamedQueryStore;
 import io.dazzleduck.sql.flight.server.HttpFlightAdaptor;
 import io.dazzleduck.sql.flight.server.StatementHandle;
 import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.flight.sql.impl.FlightSql;
-import org.duckdb.DuckDBConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultNamedQueryServiceAdaptor implements NamedQueryServiceAdaptor {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultNamedQueryServiceAdaptor.class);
-    private static final int MAX_VALIDATOR_CACHE_SIZE = 500;
-    private static final String LOAD_FROM_DB_QUERY = "SELECT id, name, template, validators, description, parameter_descriptions, preferred_display, query_group FROM %s WHERE name = '%s'";
 
     private final String name;
     private final HttpFlightAdaptor httpFlightAdaptor;
     private final Jinjava jinjava;
-
-    /** Validator instance cache: fully-qualified class name → singleton instance. */
-    private final ConcurrentHashMap<String, NamedQueryParameterValidator> validatorCache = new ConcurrentHashMap<>();
+    private final NamedQueryValidators validators = new NamedQueryValidators();
 
     public DefaultNamedQueryServiceAdaptor(String name,
                                            HttpFlightAdaptor httpFlightAdaptor) {
@@ -51,21 +44,8 @@ public class DefaultNamedQueryServiceAdaptor implements NamedQueryServiceAdaptor
     }
 
     private NamedQueryDefinition loadFromDb(String name) throws SQLException, NamedQueryServiceAdaptor.TemplateNotFoundException {
-        String safeName = name.replace("'", "''");
-        String sql = LOAD_FROM_DB_QUERY.formatted(this.name, safeName);
-        try (DuckDBConnection connection = ConnectionPool.getConnection()) {
-            var iter = ConnectionPool.collectAll(connection, sql, NamedQueryDefinition.class).iterator();
-            try {
-                if (!iter.hasNext()) {
-                    throw new NamedQueryServiceAdaptor.TemplateNotFoundException("Named query not found: " + name);
-                }
-                return iter.next();
-            } finally {
-                if (iter instanceof AutoCloseable ac) {
-                    try { ac.close(); } catch (Exception ignored) {}
-                }
-            }
-        }
+        return NamedQueryStore.loadByName(this.name, name)
+                .orElseThrow(() -> new NamedQueryServiceAdaptor.TemplateNotFoundException("Named query not found: " + name));
     }
 
     @Override
@@ -74,7 +54,7 @@ public class DefaultNamedQueryServiceAdaptor implements NamedQueryServiceAdaptor
                                     FlightProducer.ServerStreamListener listener) {
         try {
             NamedQueryDefinition queryTemplate = loadFromDb(name);
-            runValidators(queryTemplate, parameters);
+            validators.validate(queryTemplate.validators(), parameters);
             Map<String, Object> jinjavaContext = new HashMap<>(parameters != null ? parameters : Map.of());
             String sql = jinjava.render(queryTemplate.template(), jinjavaContext);
             logger.debug("Rendered SQL for named query '{}': {}", name, sql);
@@ -87,55 +67,11 @@ public class DefaultNamedQueryServiceAdaptor implements NamedQueryServiceAdaptor
         } catch (NamedQueryServiceAdaptor.TemplateNotFoundException e) {
             listener.error(org.apache.arrow.flight.CallStatus.NOT_FOUND
                     .withDescription(e.getMessage()).toRuntimeException());
-        } catch (io.dazzleduck.sql.common.ParameterValidationException e) {
+        } catch (ParameterValidationException e) {
             listener.error(org.apache.arrow.flight.CallStatus.INVALID_ARGUMENT
                     .withDescription(e.getMessage()).toRuntimeException());
         } catch (Exception e) {
             listener.error(e);
-        }
-    }
-
-    private void runValidators(NamedQueryDefinition queryTemplate, Map<String, String> parameters)
-            throws ParameterValidationException {
-        String[] validatorClassNames = queryTemplate.validators();
-        if (validatorClassNames == null || validatorClassNames.length == 0) {
-            return;
-        }
-        Map<String, String> safeParams = parameters != null ? parameters : Map.of();
-        List<String> errors = new ArrayList<>();
-        for (String className : validatorClassNames) {
-            try {
-                getOrCreateValidator(className).validate(safeParams);
-            } catch (ParameterValidationException e) {
-                errors.add(e.getMessage());
-            } catch (RuntimeException e) {
-                errors.add("Validator configuration error: " + className + " — " + e.getMessage());
-            }
-        }
-        if (!errors.isEmpty()) {
-            throw new ParameterValidationException(String.join("; ", errors));
-        }
-    }
-
-    private NamedQueryParameterValidator getOrCreateValidator(String className) {
-        NamedQueryParameterValidator cached = validatorCache.get(className);
-        if (cached != null) {
-            return cached;
-        }
-        NamedQueryParameterValidator instance = instantiateValidator(className);
-        if (validatorCache.size() < MAX_VALIDATOR_CACHE_SIZE) {
-            NamedQueryParameterValidator existing = validatorCache.putIfAbsent(className, instance);
-            return existing != null ? existing : instance;
-        }
-        return instance;
-    }
-
-    private NamedQueryParameterValidator instantiateValidator(String className) {
-        try {
-            return (NamedQueryParameterValidator) Class.forName(className)
-                    .getDeclaredConstructor().newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to instantiate validator: " + className, e);
         }
     }
 }

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
@@ -2,7 +2,7 @@ package io.dazzleduck.sql.http.server;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dazzleduck.sql.common.ParameterValidationException;
-import io.dazzleduck.sql.flight.namedquery.NamedQueryRequest;
+import io.dazzleduck.sql.commons.namedquery.NamedQueryRequest;
 import io.dazzleduck.sql.flight.namedquery.NamedQueryServiceAdaptor;
 import io.dazzleduck.sql.flight.server.TsvOutputStreamListener;
 import io.dazzleduck.sql.common.ContentTypes;

--- a/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/NamedQueryServiceTest.java
+++ b/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/NamedQueryServiceTest.java
@@ -3,7 +3,7 @@ package io.dazzleduck.sql.http.server;
 import io.dazzleduck.sql.common.ParameterValidationException;
 import io.dazzleduck.sql.common.NamedQueryParameterValidator;
 import io.dazzleduck.sql.commons.ConnectionPool;
-import io.dazzleduck.sql.flight.namedquery.NamedQueryRequest;
+import io.dazzleduck.sql.commons.namedquery.NamedQueryRequest;
 import io.dazzleduck.sql.commons.util.TestUtils;
 import io.dazzleduck.sql.common.ContentTypes;
 import org.apache.arrow.memory.RootAllocator;


### PR DESCRIPTION
## What

Move the reusable, Flight-free parts of the named-query feature out of `dazzleduck-sql-flight` so non-Flight consumers can reuse them **without depending on the Flight module** (Arrow Flight + gRPC + jinjava).

### Moved to `dazzleduck-sql-commons` (`io.dazzleduck.sql.commons.namedquery`)
- `NamedQueryDefinition`, `NamedQueryRequest`, `NamedQueryResponse` — the DTOs (relocated from `flight.namedquery`).
- **`NamedQueryStore`** (new) — `loadByName(table, name)` over `ConnectionPool.collectAll`, returning `Optional<NamedQueryDefinition>` (no exception class to drag across modules).
- **`NamedQueryValidators`** (new) — extracted validator instantiate/cache/run + `describe(...)`, depending only on `common`'s `NamedQueryParameterValidator` / `ParameterValidationException`.

### Stayed in `dazzleduck-sql-flight`
`NamedQueryServiceAdaptor` and `DefaultNamedQueryServiceAdaptor`, now reduced to orchestration:
`NamedQueryStore.loadByName` → `NamedQueryValidators.validate` → **Jinjava render** → Flight execute.

## Why
- `dazzleduck-sql-common` is intentionally Java 11, and records require Java 16+, so the types live in `commons` (Java 21), not `common`.
- **Jinjava rendering is deliberately left in `flight`** (caller-supplied) to keep `commons` dependency-light — no jinjava pushed down the stack.

## Notes
- No behavior change for the Flight/HTTP named-query path; the adaptor delegates to the moved pieces.
- Enables reuse by other services (e.g. an HTTP service can load+validate templates via `commons` and run them through its own authorizer/streaming, with no Flight dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)