### PR TITLE
otel-collector: /health endpoint with graceful-shutdown lifecycle

### DIFF
--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -28,6 +28,7 @@ Each incoming export request is:
 - **DuckLake integration**: Optional post-ingestion task registration via `IngestionTaskFactory`
 - **SQL transformations**: Derive columns (e.g. partition keys) before writing
 - **Micrometer metrics**: Export counters, latency timers, and writer queue gauges
+- **Health check**: Embedded HTTP `/health` endpoint with a graceful shutdown lifecycle (see [Health Check](#health-check))
 
 ## Configuration
 
@@ -103,6 +104,46 @@ grpcurl -plaintext \
 ```
 
 **Login delegation:** Set `login_url` to forward Basic auth credentials to an external HTTP service (same pattern as the DazzleDuck Flight SQL server).
+
+## Health Check
+
+The collector runs a small embedded HTTP server (plain JDK `HttpServer`, no extra dependency)
+exposing `GET /health`. It reports one of three statuses, each with a matching HTTP code so a
+readiness probe or load balancer reacts correctly:
+
+| Status | HTTP code | Meaning |
+|--------|-----------|---------|
+| `HEALTHY` | 200 | gRPC server is up and accepting requests |
+| `MAINTENANCE` | 503 | Graceful shutdown in progress — draining, not accepting new traffic |
+| `DOWN` | 503 | Shutdown complete (briefly visible right before the process exits) |
+
+```json
+{
+  "status": "HEALTHY",
+  "uptimeSeconds": 1234,
+  "grpcPort": 4317,
+  "knownQueues": 3,
+  "batchesProcessed": 5821
+}
+```
+
+Configure the port and shutdown grace period under `otel_collector.health`:
+
+```hocon
+otel_collector {
+    health {
+        port = 8081                    # GET /health
+        shutdown_grace_period_ms = 2000   # MAINTENANCE/LB-drain window; 0 to skip
+    }
+}
+```
+
+On shutdown (SIGTERM via the JVM shutdown hook), the collector immediately flips to `MAINTENANCE`
+— so a Kubernetes readiness probe or load balancer stops routing new traffic right away — then
+stays in `MAINTENANCE` for `shutdown_grace_period_ms` before stopping the gRPC server itself.
+Already-accepted in-flight calls then get up to 10s more (`awaitTermination`) to finish, during which
+the flush scheduler is still running, so a batch buffered when shutdown begins is written to Parquet
+and its export ack returned rather than the call being cut off mid-RPC.
 
 ## Arrow Schemas
 

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorMetrics.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorMetrics.java
@@ -49,6 +49,13 @@ public class OtelCollectorMetrics implements Closeable {
     private final ConcurrentHashMap<String, LongAdder> errorsPerQueue   = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Timer>     timersPerQueue   = new ConcurrentHashMap<>();
 
+    // Not per-queue and never removed by unregisterQueue/close — unlike the writer FunctionCounters
+    // above (which are bound to a live ParquetIngestionQueue and intentionally dropped on eviction
+    // so the queue can be GC'd), this must keep counting across queue eviction/recreation and
+    // shutdown drain, since it backs the /health batchesProcessed field queried right up until the
+    // collector goes DOWN.
+    private final LongAdder totalBatchesProcessed = new LongAdder();
+
     /** All meters created for a given queue ID, so {@link #unregisterQueue} can remove them. */
     private final ConcurrentHashMap<String, List<Meter>> metersByQueue = new ConcurrentHashMap<>();
 
@@ -79,6 +86,7 @@ public class OtelCollectorMetrics implements Closeable {
         getOrCreateRequests(queueId).increment();
         getOrCreateRecords(queueId).add(count);
         sample.stop(getOrCreateTimer(queueId));
+        totalBatchesProcessed.increment();
     }
 
     public void recordError(String queueId, Timer.Sample sample) {
@@ -196,6 +204,11 @@ public class OtelCollectorMetrics implements Closeable {
     public long getErrors(String queueId) {
         var a = errorsPerQueue.get(queueId);
         return a != null ? a.sum() : 0L;
+    }
+
+    /** Cumulative count of batches successfully written, across all queues, past and present. */
+    public long getTotalBatchesProcessed() {
+        return totalBatchesProcessed.sum();
     }
 
     public MeterRegistry getRegistry() { return registry; }

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorServer.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorServer.java
@@ -4,6 +4,9 @@ import io.dazzleduck.sql.commons.auth.Validator;
 import io.dazzleduck.sql.commons.ingestion.IngestionHandler;
 import io.dazzleduck.sql.otel.collector.auth.JwtServerInterceptor;
 import io.dazzleduck.sql.otel.collector.config.CollectorProperties;
+import io.dazzleduck.sql.otel.collector.health.CollectorHealth;
+import io.dazzleduck.sql.otel.collector.health.CollectorHealthStatus;
+import io.dazzleduck.sql.otel.collector.health.HealthServer;
 import io.grpc.Server;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -13,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +46,10 @@ public class OtelCollectorServer implements Closeable {
     private OtelTraceService traceService;
     private OtelMetricsService metricsService;
     private OtelCollectorMetrics collectorMetrics;
+    private CollectorHealth health;
+    private HealthServer healthServer;
+    private boolean started = false;
+    private boolean closed = false;
 
     public OtelCollectorServer(CollectorProperties props) {
         this.props = props;
@@ -57,6 +65,15 @@ public class OtelCollectorServer implements Closeable {
             // All queues share one flush scheduler; an evicted queue's stray flush is a no-op.
             setupCommonTags(props.getMeterRegistry(), props.getServiceName());
             collectorMetrics = new OtelCollectorMetrics(props.getMeterRegistry());
+            health = new CollectorHealth(
+                    () -> handler.getKnownQueues().size(),
+                    // Sourced from collectorMetrics, not handler.getQueueStats(): the latter only
+                    // sums currently-cached queues, so it drops a queue's contribution the instant
+                    // it's evicted or the cache is cleared on drain — wrong for a counter queried
+                    // right up until the collector reports DOWN. collectorMetrics' total is a plain
+                    // LongAdder bumped once per successfully written batch, independent of queue
+                    // lifecycle.
+                    collectorMetrics::getTotalBatchesProcessed);
             flushScheduler = Executors.newScheduledThreadPool(2, r -> {
                 Thread t = new Thread(r, "otel-flush-scheduler");
                 t.setDaemon(true);
@@ -94,6 +111,11 @@ public class OtelCollectorServer implements Closeable {
 
             grpcServer = builder.build().start();
 
+            healthServer = new HealthServer(props.getHealthPort(), health, props.getGrpcPort());
+            healthServer.start();
+            health.transitionTo(CollectorHealthStatus.HEALTHY);
+            started = true;
+
             log.info("OTLP gRPC server started on port {} — known queues: {} (writers created lazily on first use)",
                     props.getGrpcPort(), handler.getKnownQueues());
         } catch (Exception e) {
@@ -128,9 +150,28 @@ public class OtelCollectorServer implements Closeable {
 
     @Override
     public void close() {
+        // Idempotent: a JVM shutdown hook and an explicit close() can race (and tests close twice),
+        // and re-running would re-enter MAINTENANCE and sleep the grace period again. First caller wins.
+        synchronized (this) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+        }
+        // Enter MAINTENANCE and give readiness probes/load balancers a grace period to notice the
+        // 503 and stop routing new traffic before the gRPC server actually stops accepting calls.
+        // Skipped on a failed-startup cleanup path (healthServer was never started).
+        if (started) {
+            health.transitionTo(CollectorHealthStatus.MAINTENANCE);
+            sleepForGracePeriod();
+        }
         if (grpcServer != null) {
             log.info("Shutting down gRPC server...");
             grpcServer.shutdown();
+            // Await termination with the flush scheduler still running: an already-accepted call
+            // only gets its response once its batch is written, and the time-based flush
+            // (max_delay) fires within this window, so in-flight calls can complete normally
+            // before we force-cancel anything past the timeout.
             try {
                 if (!grpcServer.awaitTermination(10, TimeUnit.SECONDS)) {
                     grpcServer.shutdownNow();
@@ -151,7 +192,33 @@ public class OtelCollectorServer implements Closeable {
         closeQuietly("traceService",     traceService);
         closeQuietly("metricsService",   metricsService);
         closeQuietly("collectorMetrics", collectorMetrics);
+        if (started) {
+            health.transitionTo(CollectorHealthStatus.DOWN);
+        }
+        closeQuietly("healthServer", healthServer);
         log.info("OtelCollectorServer stopped.");
+    }
+
+    private void sleepForGracePeriod() {
+        // Small, bounded LB-drain window: stay in MAINTENANCE (503) long enough for readiness probes
+        // to stop routing before the gRPC server stops. Independent of max_delay — in-flight batches
+        // are flushed by the awaitTermination window in close(). ZERO skips the wait (e.g. tests).
+        Duration grace = props.getShutdownGracePeriod();
+        long graceMs = grace == null ? 0 : grace.toMillis();
+        if (graceMs <= 0) {
+            return;
+        }
+        log.info("Entering MAINTENANCE — draining for up to {}ms before shutdown", graceMs);
+        try {
+            Thread.sleep(graceMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** Current health status; {@code MAINTENANCE} before {@link #start()} completes successfully. */
+    public CollectorHealthStatus getHealthStatus() {
+        return health == null ? CollectorHealthStatus.MAINTENANCE : health.getStatus();
     }
 
     private void closeQuietly(String name, Closeable c) {

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/config/CollectorConfig.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/config/CollectorConfig.java
@@ -111,6 +111,14 @@ public class CollectorConfig {
         return getInt("grpc_port", 4317);
     }
 
+    public int getHealthPort() {
+        return getInt("health.port", 8081);
+    }
+
+    public Duration getShutdownGracePeriod() {
+        return Duration.ofMillis(getLong("health.shutdown_grace_period_ms", 2_000L));
+    }
+
     /**
      * Returns the startup SQL to execute on the singleton DuckDB connection.
      * Delegates to {@link StartupScriptProvider#load} which reads from the
@@ -219,6 +227,8 @@ public class CollectorConfig {
     public CollectorProperties toProperties() {
         CollectorProperties props = new CollectorProperties();
         props.setGrpcPort(getGrpcPort());
+        props.setHealthPort(getHealthPort());
+        props.setShutdownGracePeriod(getShutdownGracePeriod());
         props.setStartupScript(getStartupScript());
         props.setAuthentication(getAuthentication());
         props.setSecretKey(getSecretKey());

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/config/CollectorProperties.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/config/CollectorProperties.java
@@ -13,6 +13,12 @@ import java.util.Map;
 public class CollectorProperties {
 
     private int grpcPort = 4317;
+    private int healthPort = 8081;
+    // Absolute time to stay in MAINTENANCE (serving 503s so the load balancer stops routing) before
+    // stopping the gRPC server. Deliberately a small, bounded LB-drain window independent of the
+    // ingestion max_delay — in-flight batches are flushed by the awaitTermination window in close(),
+    // not by this sleep. Set to ZERO to skip the wait entirely (e.g. in tests).
+    private Duration shutdownGracePeriod = Duration.ofSeconds(2);
     private IngestionHandler ingestionHandler =
             new NOOPIngestionTaskFactoryProvider("./otel-output").getIngestionHandler();
     private IngestionConfig ingestionConfig = new IngestionConfig(
@@ -36,6 +42,22 @@ public class CollectorProperties {
 
     public void setGrpcPort(int grpcPort) {
         this.grpcPort = grpcPort;
+    }
+
+    public int getHealthPort() {
+        return healthPort;
+    }
+
+    public void setHealthPort(int healthPort) {
+        this.healthPort = healthPort;
+    }
+
+    public Duration getShutdownGracePeriod() {
+        return shutdownGracePeriod;
+    }
+
+    public void setShutdownGracePeriod(Duration shutdownGracePeriod) {
+        this.shutdownGracePeriod = shutdownGracePeriod;
     }
 
     public IngestionHandler getIngestionHandler() {

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/health/CollectorHealth.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/health/CollectorHealth.java
@@ -1,0 +1,48 @@
+package io.dazzleduck.sql.otel.collector.health;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+
+/**
+ * Thread-safe holder for the collector's current {@link CollectorHealthStatus}, read by
+ * {@link HealthServer} on every request.
+ *
+ * <p>Starts at {@code MAINTENANCE}: the server isn't ready to take traffic until
+ * {@code OtelCollectorServer.start()} successfully binds the gRPC port and flips it to
+ * {@code HEALTHY}.
+ */
+public class CollectorHealth {
+
+    private final AtomicReference<CollectorHealthStatus> status =
+            new AtomicReference<>(CollectorHealthStatus.MAINTENANCE);
+    private final Instant startTime = Instant.now();
+    private final IntSupplier knownQueueCountSupplier;
+    private final LongSupplier batchesProcessedSupplier;
+
+    public CollectorHealth(IntSupplier knownQueueCountSupplier, LongSupplier batchesProcessedSupplier) {
+        this.knownQueueCountSupplier = knownQueueCountSupplier;
+        this.batchesProcessedSupplier = batchesProcessedSupplier;
+    }
+
+    public CollectorHealthStatus getStatus() {
+        return status.get();
+    }
+
+    public void transitionTo(CollectorHealthStatus newStatus) {
+        status.set(newStatus);
+    }
+
+    public long uptimeSeconds() {
+        return Instant.now().getEpochSecond() - startTime.getEpochSecond();
+    }
+
+    public int knownQueueCount() {
+        return knownQueueCountSupplier.getAsInt();
+    }
+
+    public long batchesProcessed() {
+        return batchesProcessedSupplier.getAsLong();
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/health/CollectorHealthStatus.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/health/CollectorHealthStatus.java
@@ -1,0 +1,14 @@
+package io.dazzleduck.sql.otel.collector.health;
+
+/**
+ * Lifecycle status of the collector, surfaced via {@link HealthServer}.
+ *
+ * <p>{@code MAINTENANCE} is entered at the start of a graceful shutdown — readiness probes should
+ * fail and traffic should stop routing here, while the gRPC server itself keeps draining in-flight
+ * calls for a short grace period before actually stopping ({@code DOWN}).
+ */
+public enum CollectorHealthStatus {
+    HEALTHY,
+    MAINTENANCE,
+    DOWN
+}

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/health/HealthServer.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/health/HealthServer.java
@@ -1,0 +1,70 @@
+package io.dazzleduck.sql.otel.collector.health;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Embedded HTTP health endpoint for the otel-collector. {@code GET /health} reports the current
+ * {@link CollectorHealthStatus}: {@code 200} for {@code HEALTHY}, {@code 503} for
+ * {@code MAINTENANCE}/{@code DOWN} — so a readiness probe or load balancer stops routing traffic
+ * the instant the collector leaves {@code HEALTHY}, ahead of the gRPC server actually stopping.
+ */
+public class HealthServer implements Closeable {
+
+    private static final Logger logger = LoggerFactory.getLogger(HealthServer.class);
+
+    private final HttpServer server;
+
+    public HealthServer(int port, CollectorHealth health, int grpcPort) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/health", exchange -> handle(exchange, health, grpcPort));
+        server.setExecutor(null);
+    }
+
+    public void start() {
+        server.start();
+        logger.info("Health server listening on port {}", server.getAddress().getPort());
+    }
+
+    public int getPort() {
+        return server.getAddress().getPort();
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+
+    private void handle(HttpExchange exchange, CollectorHealth health, int grpcPort) throws IOException {
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+        CollectorHealthStatus status = health.getStatus();
+        int statusCode = status == CollectorHealthStatus.HEALTHY ? 200 : 503;
+        byte[] body = toJson(status, health, grpcPort).getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, body.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+        }
+    }
+
+    private String toJson(CollectorHealthStatus status, CollectorHealth health, int grpcPort) {
+        return "{\n"
+                + "  \"status\": \"" + status + "\",\n"
+                + "  \"uptimeSeconds\": " + health.uptimeSeconds() + ",\n"
+                + "  \"grpcPort\": " + grpcPort + ",\n"
+                + "  \"knownQueues\": " + health.knownQueueCount() + ",\n"
+                + "  \"batchesProcessed\": " + health.batchesProcessed() + "\n"
+                + "}";
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -1,6 +1,16 @@
 otel_collector {
     grpc_port = 4317
 
+    # Embedded HTTP health endpoint (GET /health). 200 while HEALTHY; 503 during MAINTENANCE
+    # (entered at the start of a graceful shutdown drain) and DOWN.
+    health {
+        port = 8081
+        # Time to stay in MAINTENANCE (serving 503 on /health) before stopping the gRPC server, so a
+        # readiness probe / load balancer can stop routing first. A small LB-drain window; in-flight
+        # batches are flushed by the gRPC awaitTermination window, not by this. Set 0 to skip it.
+        shutdown_grace_period_ms = 2000
+    }
+
     # SQL executed once on startup (on the singleton DuckDB connection).
     # 'content'         — inline SQL, executed first.
     # 'script_location' — path to a .sql file, appended after content.

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorConfigDuckLakeTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorConfigDuckLakeTest.java
@@ -121,7 +121,9 @@ class OtelCollectorConfigDuckLakeTest {
                         tempDir.resolve("metrics"));
 
         var collectorConfig = new CollectorConfig(ConfigFactory.parseString(hocon));
-        otelServer = new OtelCollectorServer(collectorConfig.toProperties());
+        var props = collectorConfig.toProperties();
+        props.setShutdownGracePeriod(java.time.Duration.ZERO); // no LB-drain wait in tests
+        otelServer = new OtelCollectorServer(props);
         otelServer.start();
 
         channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorCustomQueueTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorCustomQueueTest.java
@@ -167,6 +167,7 @@ public class OtelCollectorCustomQueueTest {
             Files.createDirectories(outputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(port);
             // Writers map contains "app-logs" plus traces/metrics defaults
             props.setIngestionHandler(noopHandler(outputPath.toString(), "app-logs", "traces", "metrics"));
@@ -233,6 +234,7 @@ public class OtelCollectorCustomQueueTest {
             Files.createDirectories(outputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(port);
             // Default queues — "logs" present, so fallback works
             props.setIngestionHandler(noopHandler(outputPath.toString(), "logs", "traces", "metrics"));
@@ -300,6 +302,7 @@ public class OtelCollectorCustomQueueTest {
             Files.createDirectories(outputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(port);
             props.setIngestionHandler(noopHandler(outputPath.toString(), "logs", "traces", "metrics"));
             props.setIngestionConfig(smallBucketConfig());
@@ -392,6 +395,7 @@ public class OtelCollectorCustomQueueTest {
             Files.createDirectories(outputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(port);
             props.setIngestionHandler(noopHandler(outputPath.toString(), "logs", "traces", "metrics"));
             props.setIngestionConfig(smallBucketConfig());

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorDuckLakeTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorDuckLakeTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.sql.Connection;
 import java.util.Calendar;
 import java.util.Map;
@@ -102,6 +103,7 @@ class OtelCollectorDuckLakeTest {
                 "metrics", new QueueIdToTableMapping("metrics", CATALOG, "main", "metrics", Map.of(), null)));
 
         CollectorProperties props = new CollectorProperties();
+        props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
         props.setGrpcPort(freePort());
         props.setAuthentication("jwt");
         props.setSecretKey(SECRET_KEY_BASE64);

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorLoginDelegationTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorLoginDelegationTest.java
@@ -133,6 +133,7 @@ public class OtelCollectorLoginDelegationTest {
             Files.createDirectories(outputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(otelPort);
             props.setIngestionHandler(noopHandler(outputPath.toString()));
             props.setAuthentication("jwt");
@@ -264,6 +265,7 @@ public class OtelCollectorLoginDelegationTest {
             Files.createDirectories(outputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(otelPort);
             props.setIngestionHandler(noopHandler(outputPath.toString()));
             props.setAuthentication("jwt");
@@ -343,6 +345,7 @@ public class OtelCollectorLoginDelegationTest {
             Files.createDirectories(outputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(otelPort);
             props.setIngestionHandler(noopHandler(outputPath.toString(),
                     "SELECT *, severity_number * 2 as doubled_severity FROM __this"));
@@ -419,6 +422,7 @@ public class OtelCollectorLoginDelegationTest {
             Files.createDirectories(tracesOutputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(otelPort);
             props.setIngestionHandler(noopHandler(tracesOutputPath.toString()));
             props.setIngestionConfig(ingestionConfig(1L, 60_000L));
@@ -499,6 +503,7 @@ public class OtelCollectorLoginDelegationTest {
             Files.createDirectories(metricsOutputPath); // operator provisions the output dir
 
             CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
             props.setGrpcPort(otelPort);
             props.setIngestionHandler(noopHandler(metricsOutputPath.toString()));
             props.setIngestionConfig(ingestionConfig(1L, 60_000L));

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorManageTablesTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorManageTablesTest.java
@@ -100,6 +100,7 @@ class OtelCollectorManageTablesTest {
         handler = new DynamicIngestionHandler(dbPath, readConn, initial, Duration.ofSeconds(60), true);
 
         CollectorProperties props = new CollectorProperties();
+        props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
         props.setGrpcPort(freePort());
         props.setAuthentication("jwt");
         props.setSecretKey(SECRET_KEY_BASE64);

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorMetricsTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorMetricsTest.java
@@ -1,0 +1,29 @@
+package io.dazzleduck.sql.otel.collector;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for the {@code /health} {@code batchesProcessed} field's data source: it must
+ * keep counting across queue eviction, unlike the per-queue {@code batches_written}
+ * {@code FunctionCounter}s, which {@link OtelCollectorMetrics#unregisterQueue} deliberately removes
+ * so an evicted queue's {@code ParquetIngestionQueue} can be garbage-collected.
+ */
+class OtelCollectorMetricsTest {
+
+    @Test
+    void totalBatchesProcessedSurvivesQueueUnregistration() {
+        var metrics = new OtelCollectorMetrics(new SimpleMeterRegistry());
+
+        metrics.recordExport("q1", 5, metrics.startSample());
+        assertEquals(1, metrics.getTotalBatchesProcessed());
+
+        metrics.unregisterQueue("q1"); // simulates eviction/drain — must not reset the total
+        assertEquals(1, metrics.getTotalBatchesProcessed());
+
+        metrics.recordExport("q1", 3, metrics.startSample()); // queue recreated under the same id
+        assertEquals(2, metrics.getTotalBatchesProcessed());
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorServerHealthTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorServerHealthTest.java
@@ -1,0 +1,68 @@
+package io.dazzleduck.sql.otel.collector;
+
+import io.dazzleduck.sql.otel.collector.config.CollectorProperties;
+import io.dazzleduck.sql.otel.collector.health.CollectorHealthStatus;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the otel-collector's health status walks HEALTHY -&gt; MAINTENANCE -&gt; DOWN across its
+ * start/close lifecycle, and that the HTTP {@code /health} endpoint reflects each state.
+ */
+class OtelCollectorServerHealthTest {
+
+    static final String SECRET_KEY_BASE64 =
+            "VGhpcyBpcyBhIDY0IGJpdCBsb25nIGtleSB3aGljaCBzaG91bGQgYmUgY2hhbmdlZCBpbiBwcm9kdWN0aW9uLiBTbyBjaGFuZ2UgbWUgYW5kIG1ha2Ugc3VyZSBpdHMgMTI4IGJpdCBsb25nIG9yIG1vcmU";
+
+    @Test
+    void healthWalksHealthyMaintenanceDownAcrossLifecycle() throws Exception {
+        CollectorProperties props = new CollectorProperties();
+        props.setGrpcPort(freePort());
+        props.setHealthPort(freePort());
+        props.setAuthentication("jwt");
+        props.setSecretKey(SECRET_KEY_BASE64);
+        // Small grace so the MAINTENANCE window is observable mid-sleep without slowing the test.
+        props.setShutdownGracePeriod(Duration.ofMillis(300));
+
+        OtelCollectorServer server = new OtelCollectorServer(props);
+        try {
+            server.start();
+            assertEquals(CollectorHealthStatus.HEALTHY, server.getHealthStatus());
+            assertEquals(200, getHealth(props.getHealthPort()).statusCode());
+
+            Thread closer = new Thread(server::close, "test-closer");
+            closer.start();
+            // Mid-grace-period (300ms): should already be draining, well before close() returns.
+            Thread.sleep(100);
+            assertEquals(CollectorHealthStatus.MAINTENANCE, server.getHealthStatus());
+            assertEquals(503, getHealth(props.getHealthPort()).statusCode());
+
+            closer.join(Duration.ofSeconds(10).toMillis());
+            assertEquals(CollectorHealthStatus.DOWN, server.getHealthStatus());
+        } finally {
+            server.close();
+        }
+    }
+
+    private static HttpResponse<String> getHealth(int port) throws Exception {
+        HttpRequest req = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/health"))
+                .GET().build();
+        return HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static int freePort() throws IOException {
+        try (var s = new ServerSocket(0)) {
+            s.setReuseAddress(true);
+            return s.getLocalPort();
+        }
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/health/CollectorHealthTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/health/CollectorHealthTest.java
@@ -1,0 +1,43 @@
+package io.dazzleduck.sql.otel.collector.health;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CollectorHealthTest {
+
+    @Test
+    void startsInMaintenanceAndTransitionsAcrossStates() {
+        CollectorHealth health = new CollectorHealth(() -> 3, () -> 0);
+
+        assertEquals(CollectorHealthStatus.MAINTENANCE, health.getStatus());
+
+        health.transitionTo(CollectorHealthStatus.HEALTHY);
+        assertEquals(CollectorHealthStatus.HEALTHY, health.getStatus());
+
+        health.transitionTo(CollectorHealthStatus.MAINTENANCE);
+        assertEquals(CollectorHealthStatus.MAINTENANCE, health.getStatus());
+
+        health.transitionTo(CollectorHealthStatus.DOWN);
+        assertEquals(CollectorHealthStatus.DOWN, health.getStatus());
+    }
+
+    @Test
+    void reportsKnownQueueCountFromSupplier() {
+        CollectorHealth health = new CollectorHealth(() -> 7, () -> 0);
+        assertEquals(7, health.knownQueueCount());
+    }
+
+    @Test
+    void reportsBatchesProcessedFromSupplier() {
+        CollectorHealth health = new CollectorHealth(() -> 0, () -> 42);
+        assertEquals(42, health.batchesProcessed());
+    }
+
+    @Test
+    void uptimeSecondsIsNonNegative() {
+        CollectorHealth health = new CollectorHealth(() -> 0, () -> 0);
+        assertTrue(health.uptimeSeconds() >= 0);
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/health/HealthServerTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/health/HealthServerTest.java
@@ -1,0 +1,68 @@
+package io.dazzleduck.sql.otel.collector.health;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HealthServerTest {
+
+    private static final int GRPC_PORT = 4317;
+
+    CollectorHealth health;
+    HealthServer server;
+    HttpClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        health = new CollectorHealth(() -> 2, () -> 5);
+        server = new HealthServer(0, health, GRPC_PORT);
+        server.start();
+        client = HttpClient.newHttpClient();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.close();
+    }
+
+    @Test
+    void healthyReturns200() throws Exception {
+        health.transitionTo(CollectorHealthStatus.HEALTHY);
+        HttpResponse<String> resp = get();
+        assertEquals(200, resp.statusCode());
+        assertTrue(resp.body().contains("\"status\": \"HEALTHY\""));
+        assertTrue(resp.body().contains("\"grpcPort\": " + GRPC_PORT));
+        assertTrue(resp.body().contains("\"knownQueues\": 2"));
+        assertTrue(resp.body().contains("\"batchesProcessed\": 5"));
+    }
+
+    @Test
+    void maintenanceReturns503() throws Exception {
+        health.transitionTo(CollectorHealthStatus.MAINTENANCE);
+        HttpResponse<String> resp = get();
+        assertEquals(503, resp.statusCode());
+        assertTrue(resp.body().contains("\"status\": \"MAINTENANCE\""));
+    }
+
+    @Test
+    void downReturns503() throws Exception {
+        health.transitionTo(CollectorHealthStatus.DOWN);
+        HttpResponse<String> resp = get();
+        assertEquals(503, resp.statusCode());
+        assertTrue(resp.body().contains("\"status\": \"DOWN\""));
+    }
+
+    private HttpResponse<String> get() throws Exception {
+        HttpRequest req = HttpRequest.newBuilder(URI.create("http://localhost:" + server.getPort() + "/health"))
+                .GET().build();
+        return client.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+}


### PR DESCRIPTION
## Summary
Adds an embedded HTTP health endpoint to the OTLP collector and a graceful-shutdown lifecycle so a readiness probe / load balancer can stop routing before the gRPC server stops.

- **`GET /health`** via a plain JDK `HttpServer` on `otel_collector.health.port` (default 8081), returning `HEALTHY` (200) / `MAINTENANCE` (503) / `DOWN` (503), plus `uptimeSeconds`, `grpcPort`, `knownQueues`, and `batchesProcessed`.
- New `health` package: `CollectorHealth`, `CollectorHealthStatus`, `HealthServer`.
- `OtelCollectorServer` drives `HEALTHY → MAINTENANCE → DOWN` across `start()`/`close()`:
  - `close()` enters `MAINTENANCE`, waits `shutdown_grace_period_ms` (absolute LB-drain window, default 2000ms, `0` to skip), then shuts down the gRPC server. In-flight calls are flushed during the existing `awaitTermination` window.
  - `close()` is **idempotent** (a JVM shutdown hook and an explicit `close()` can race).
- `batchesProcessed` is backed by a queue-lifecycle-independent `LongAdder` in `OtelCollectorMetrics`, so it keeps counting across queue eviction (unlike the per-queue writer counters).

## Config (`otel_collector.health`)
```hocon
health {
    port = 8081
    shutdown_grace_period_ms = 2000   # MAINTENANCE/LB-drain window; 0 to skip
}
```

## Tests
- New: `CollectorHealthTest`, `HealthServerTest`, `OtelCollectorMetricsTest` (asserts the counter survives queue unregistration), `OtelCollectorServerHealthTest` (HEALTHY → MAINTENANCE → DOWN over the lifecycle).
- Existing server tests set `shutdown_grace_period = 0` so `close()` doesn't sleep during tests.
- Full `dazzleduck-sql-otel-collector` module green on JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)