### PR TITLE
ingestion: graceful drain with bounded variants and parallel shutdown

### DIFF
--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/BulkIngestQueue.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/BulkIngestQueue.java
@@ -2,6 +2,8 @@ package io.dazzleduck.sql.commons.ingestion;
 
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -20,6 +22,21 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.LongAccumulator;
 
 public abstract class BulkIngestQueue<T, R> implements BulkIngestQueueInterface<T, R> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BulkIngestQueue.class);
+
+    /**
+     * Upper bound for {@link #close()} to wait on the write thread after cancelling/interrupting it.
+     * cancel() + interrupt should unblock a responsive write almost immediately; this bound keeps a
+     * forceful close from hanging on a write that ignores cancellation. The write thread is a daemon,
+     * so a writer still stuck past this bound cannot block JVM exit.
+     */
+    private static final Duration CLOSE_JOIN_TIMEOUT = Duration.ofSeconds(5);
+
+    /** Bound used by {@link #close()} when waiting on the write thread. Overridable for tests. */
+    protected Duration closeJoinTimeout() {
+        return CLOSE_JOIN_TIMEOUT;
+    }
 
 
 
@@ -94,11 +111,18 @@ public abstract class BulkIngestQueue<T, R> implements BulkIngestQueueInterface<
     private Instant lastWrite = Instant.EPOCH;
     private Bucket<T, R> currentBucket;
     private volatile boolean terminating;
+    private volatile boolean draining;
 
     private volatile WriteTask<T, R> runningWrite;
     private long writeTaskId;
 
     private final BlockingQueue<WriteTask<T, R>> writeQueue = new LinkedBlockingQueue<>();
+    /**
+     * Sentinel offered to {@link #writeQueue} by {@link #drain()}. Because the queue is FIFO,
+     * the write thread only reaches it after every previously enqueued task has been written,
+     * at which point it stops. Its bucket is {@code null} and must never be dereferenced.
+     */
+    private final WriteTask<T, R> poisonPill = new WriteTask<>(-1L, Instant.EPOCH, null);
     private final Thread writeThread;
     private final LongAccumulator totalWriteBatches = new LongAccumulator(Long::sum, 0L);
     private final LongAccumulator totalWriteBuckets = new LongAccumulator(Long::sum, 0L);
@@ -142,24 +166,35 @@ public abstract class BulkIngestQueue<T, R> implements BulkIngestQueueInterface<
             try {
                 var task = writeQueue.take();
 
+                // drain() enqueues the poison pill after the final real task; reaching it means
+                // every accepted batch has been written, so the drain is complete and we stop.
+                if (task == poisonPill) {
+                    break;
+                }
+
                 // Try to combine with additional buckets from the queue
                 var bucketsToCombine = new ArrayList<Bucket<T, R>>();
                 bucketsToCombine.add(task.bucket());
                 long combinedSize = task.bucket().size();
                 int combinedBatchCount = task.bucket().batchCount();
 
-                // Poll additional tasks while they can be combined
+                // Poll additional tasks while they can be combined. Combine on the task actually
+                // returned by poll() — not the peeked one — so this stays correct even if close()
+                // concurrently drains the queue after a timed-out join: each task is then consumed
+                // by exactly one of {writer, close}, never written and abandoned at once.
                 WriteTask<T, R> nextTask;
-                while ((nextTask = writeQueue.peek()) != null) {
-                    var nextBucket = nextTask.bucket();
-                    if (canCombine(combinedSize, combinedBatchCount, nextBucket, maxBucketSize, maxBatches)) {
-                        writeQueue.poll(); // Remove from queue
-                        bucketsToCombine.add(nextBucket);
-                        combinedSize += nextBucket.size();
-                        combinedBatchCount += nextBucket.batchCount();
-                    } else {
+                while ((nextTask = writeQueue.peek()) != null && nextTask != poisonPill) {
+                    if (!canCombine(combinedSize, combinedBatchCount, nextTask.bucket(), maxBucketSize, maxBatches)) {
                         break; // Can't combine more
                     }
+                    var polled = writeQueue.poll();
+                    if (polled == null || polled == poisonPill) {
+                        break; // lost the race to a concurrent consumer, or reached the pill
+                    }
+                    var polledBucket = polled.bucket();
+                    bucketsToCombine.add(polledBucket);
+                    combinedSize += polledBucket.size();
+                    combinedBatchCount += polledBucket.batchCount();
                 }
 
                 // Create combined bucket if we have multiple, otherwise use original
@@ -267,7 +302,7 @@ public abstract class BulkIngestQueue<T, R> implements BulkIngestQueueInterface<
     }
 
     public synchronized CompletableFuture<R> add(Batch<T> batch) {
-        if (terminating) {
+        if (terminating || draining) {
             throw new IllegalStateException("The queue is closed");
         }
         long currentPending = pendingWrite();
@@ -297,7 +332,9 @@ public abstract class BulkIngestQueue<T, R> implements BulkIngestQueueInterface<
     }
 
     private synchronized void triggerWriteIfRequired() {
-        if (terminating) {
+        if (terminating || draining) {
+            // Once draining, drain() owns the final flush and the write thread is stopping; any
+            // further scheduled trigger is a no-op so the executor stops rescheduling this task.
             return;
         }
         var now = clock.instant();
@@ -335,10 +372,43 @@ public abstract class BulkIngestQueue<T, R> implements BulkIngestQueueInterface<
         var writeTask = new WriteTask<>(writeTaskId++, clock.instant(), toWrite);
         lastWrite = clock.instant();
         writeQueue.offer(writeTask);
-        if (!terminating) {
+        if (!terminating && !draining) {
             scheduleNextTrigger(clock.instant());
         }
     }
+    /**
+     * Initiates draining: marks the queue as draining (so {@link #add} is rejected and scheduled
+     * triggers become no-ops), finalizes and enqueues the current bucket, then enqueues the poison
+     * pill. FIFO ordering guarantees the write thread drains that bucket — and every task still
+     * queued ahead of it — before it reaches the pill and stops. Idempotent and a no-op once
+     * {@code terminating} (close already abandoned everything) or already draining.
+     */
+    private synchronized void initiateDrain() {
+        if (!terminating && !draining) {
+            draining = true;
+            submitWriteTask();
+            writeQueue.offer(poisonPill);
+        }
+    }
+
+    @Override
+    public void drain() throws InterruptedException {
+        initiateDrain();
+        writeThread.join();
+    }
+
+    @Override
+    public boolean drain(Duration timeout) throws InterruptedException {
+        initiateDrain();
+        long millis = timeout.toMillis();
+        // join(0) blocks forever, so only wait when the bound is positive; a non-positive
+        // timeout means "don't wait" and we report whether the writer happens to be done.
+        if (millis > 0) {
+            writeThread.join(millis);
+        }
+        return !writeThread.isAlive();
+    }
+
     @Override
     public synchronized void close() throws Exception {
         terminating = true;
@@ -347,11 +417,18 @@ public abstract class BulkIngestQueue<T, R> implements BulkIngestQueueInterface<
             c.cancel();
         }
 
-        // Interrupt and wait for write thread to finish processing
-        // The write thread will exit the loop when it sees terminating=true,
-        // or when interrupted if it's blocked waiting for a task
+        // Interrupt and wait (bounded) for the write thread to finish processing. It exits the loop
+        // when it sees terminating=true, or when interrupted while blocked waiting for a task. The
+        // bound guarantees a forceful close cannot hang forever on a write that ignores cancellation;
+        // a writer still stuck past it is left running (it is a daemon and cannot block JVM exit) and
+        // only owns its own in-flight bucket, which the cleanup below deliberately does not touch.
         writeThread.interrupt();
-        writeThread.join();
+        var joinTimeout = closeJoinTimeout();
+        writeThread.join(joinTimeout.toMillis());
+        if (writeThread.isAlive()) {
+            logger.atWarn().log("Write thread {} did not terminate within {} of close(); abandoning it",
+                    writeThread.getName(), joinTimeout);
+        }
 
         // Fail any futures in the current bucket and release their resources
         var exception = new IllegalStateException("Server shutting down before batch could be written");
@@ -360,9 +437,13 @@ public abstract class BulkIngestQueue<T, R> implements BulkIngestQueueInterface<
             currentBucket.futures().forEach(f -> f.completeExceptionally(exception));
         }
 
-        // Fail any remaining tasks that weren't processed and release their resources
+        // Fail any remaining tasks that weren't processed and release their resources. A timed-out
+        // drain() can leave its poison pill (null bucket) in the queue, so skip it here.
         WriteTask<T, R> remaining;
         while ((remaining = writeQueue.poll()) != null) {
+            if (remaining == poisonPill) {
+                continue;
+            }
             remaining.bucket().batches().forEach(this::onBatchAbandoned);
             remaining.bucket().futures().forEach(f -> f.completeExceptionally(exception));
         }

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/BulkIngestQueueInterface.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/BulkIngestQueueInterface.java
@@ -1,6 +1,7 @@
 package io.dazzleduck.sql.commons.ingestion;
 
 
+import java.time.Duration;
 import java.util.concurrent.Future;
 
 public interface BulkIngestQueueInterface<T, R> extends AutoCloseable, IngestionStatsMBean {
@@ -13,4 +14,32 @@ public interface BulkIngestQueueInterface<T, R> extends AutoCloseable, Ingestion
      * @return bytes which are pending to be written
      */
     long pendingWrite();
+
+    /**
+     * Gracefully flushes the queue: stops accepting new batches, finalizes the current bucket,
+     * and blocks until every accepted batch has been written and its future completed (normally
+     * or exceptionally by the write itself). Unlike {@link AutoCloseable#close()}, which abandons
+     * buffered data and fails its futures, {@code drain} guarantees no accepted data is lost.
+     *
+     * <p>Idempotent and safe to call before {@link AutoCloseable#close()}. After it returns the
+     * write thread has stopped, so any subsequent {@link #add(Batch)} is rejected.
+     *
+     * @throws InterruptedException if interrupted while waiting for pending writes to complete
+     */
+    void drain() throws InterruptedException;
+
+    /**
+     * Bounded variant of {@link #drain()} for shutdown paths that cannot block indefinitely on a
+     * stalled write backend. Initiates the same flush, but waits at most {@code timeout} for it to
+     * complete. A non-positive {@code timeout} initiates the flush without waiting.
+     *
+     * <p>Returns {@code false} if the writer is still running when the bound elapses — the caller
+     * should then fall through to {@link AutoCloseable#close()}, which cancels the in-flight write
+     * and releases resources.
+     *
+     * @param timeout maximum time to wait for pending writes to complete
+     * @return {@code true} if all pending writes finished within {@code timeout}
+     * @throws InterruptedException if interrupted while waiting
+     */
+    boolean drain(Duration timeout) throws InterruptedException;
 }

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 
 /**
  * {@link IngestionHandler} backed by DuckLake metadata.
@@ -219,12 +220,49 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
 
     @Override
     public void closeQueues() {
-        queueCache.forEach((id, queue) -> {
-            try { queue.close(); } catch (Exception e) {
-                logger.atWarn().setCause(e).log("Failed to close ingestion queue: {}", id);
-            }
-        });
+        closeQueues(DEFAULT_DRAIN_TIMEOUT);
+    }
+
+    @Override
+    public void closeQueues(Duration drainTimeout) {
+        // Snapshot and clear first so nothing is routed to these queues while they shut down.
+        var queues = new ArrayList<>(queueCache.values());
         queueCache.clear();
+        if (queues.isEmpty()) {
+            return;
+        }
+        // Drain queues concurrently: total shutdown time is bounded by the slowest queue
+        // (~drainTimeout), not the sum across all queues. Virtual threads keep this cheap even with
+        // many queues; the executor's close() blocks until every drain+close task has finished.
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (var queue : queues) {
+                executor.submit(() -> drainAndClose(queue, drainTimeout));
+            }
+        }
+    }
+
+    /**
+     * Drains a single queue within {@code drainTimeout}, then closes it. Drains buffered-but-unwritten
+     * batches gracefully and bounds the wait so a stalled write backend can't hang shutdown; the
+     * following close releases resources (and cancels/abandons anything the drain didn't finish).
+     * All failures are isolated so one bad queue cannot block the others.
+     */
+    private void drainAndClose(ParquetIngestionQueue queue, Duration drainTimeout) {
+        String id = queue.identifier();
+        try {
+            if (!queue.drain(drainTimeout)) {
+                logger.atWarn().log("Drain timed out after {} for ingestion queue: {}; forcing close",
+                        drainTimeout, id);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.atWarn().setCause(e).log("Interrupted while draining ingestion queue: {}", id);
+        }
+        try {
+            queue.close();
+        } catch (Exception e) {
+            logger.atWarn().setCause(e).log("Failed to close ingestion queue: {}", id);
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DynamicIngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DynamicIngestionHandler.java
@@ -124,10 +124,13 @@ public class DynamicIngestionHandler extends DuckLakeIngestionHandler {
         DuckLakeTableManager.ensureTable(mapping);
     }
 
+    // Override the Duration overload (the one shutdown callers invoke) rather than the no-arg form,
+    // so this handler's extra cleanup runs no matter which entry point is used. The inherited
+    // no-arg closeQueues() delegates here via DuckLakeIngestionHandler.
     @Override
-    public void closeQueues() {
-        scheduler.shutdownNow();
-        super.closeQueues(); // close + clear the cached queues
+    public void closeQueues(Duration drainTimeout) {
+        scheduler.shutdownNow(); // stop the reconcile thread first so no new queues are created mid-drain
+        super.closeQueues(drainTimeout); // drain + close + clear the cached queues
         if (schemaVersionStmt != null) {
             try { schemaVersionStmt.close(); } catch (SQLException e) {
                 logger.warn("Failed to close schema_version statement", e);

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionHandler.java
@@ -35,6 +35,16 @@ public interface IngestionHandler {
     /** Closes and clears all cached queues on producer shutdown. */
     default void closeQueues() {}
 
+    /** Default per-queue bound for flushing in-flight batches on shutdown before forcing the close. */
+    java.time.Duration DEFAULT_DRAIN_TIMEOUT = java.time.Duration.ofSeconds(30);
+
+    /**
+     * Like {@link #closeQueues()}, but flushes each queue gracefully, waiting at most
+     * {@code drainTimeout} per queue before forcing the close. Override in handlers that own
+     * queues; the default delegates to {@link #closeQueues()}.
+     */
+    default void closeQueues(java.time.Duration drainTimeout) { closeQueues(); }
+
     /**
      * Returns the set of queue IDs this handler currently knows about — the single source of
      * truth for which queues are routable. Callers (e.g. the OTLP collector's signal services)

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/BulkIngestQueueTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/BulkIngestQueueTest.java
@@ -134,6 +134,158 @@ public class BulkIngestQueueTest {
         });
     }
 
+    @Test
+    public void testDrainFlushesPendingBatches() throws Exception {
+        var list = new ArrayList<Future<MockWriteResult>>();
+        var numBatches = 5; // below min bucket size and maxBatches, so the bucket stays buffered
+        withServiceAndQueue((service, queue, clock) -> {
+            for (int i = 0; i < numBatches; i++) {
+                list.add(queue.add(mockBatch("123", i, DEFAULT_SMALL_BATCH_SIZE)));
+            }
+            // No tick and the bucket is not full, so nothing has been written yet.
+            for (var f : list) {
+                assertFalse(f.isDone());
+            }
+
+            queue.drain();
+
+            // drain() guarantees every accepted batch is written and its future completed.
+            for (var f : list) {
+                assertTrue(f.isDone());
+                assertNotNull(f.get());
+            }
+            assertEquals(numBatches, queue.getStats().totalWriteBatches());
+            assertEquals(0, queue.getStats().pendingBatches());
+            assertEquals(0, queue.pendingWrite());
+
+            // A drained queue no longer accepts work.
+            assertThrows(IllegalStateException.class,
+                    () -> queue.add(mockBatch("123", 99, DEFAULT_SMALL_BATCH_SIZE)));
+        });
+    }
+
+    @Test
+    public void testDrainEmptyQueueDoesNotHang() throws Exception {
+        withServiceAndQueue((service, queue, clock) -> {
+            // Nothing was ever added; drain must still return promptly.
+            queue.drain();
+            assertEquals(0, queue.getStats().totalWriteBatches());
+            // Idempotent: a second drain (and a following close) are safe.
+            queue.drain();
+            queue.close();
+        });
+    }
+
+    @Test
+    public void testCloseAfterDrainIsClean() throws Exception {
+        withServiceAndQueue((service, queue, clock) -> {
+            var f = queue.add(mockBatch("123", 0, DEFAULT_SMALL_BATCH_SIZE));
+            queue.drain();
+            assertTrue(f.isDone());
+            assertNotNull(f.get());
+            // close() after a successful drain finds nothing to abandon.
+            queue.close();
+            assertTrue(f.isDone());
+        });
+    }
+
+    @Test
+    public void testDrainWithTimeoutCompletes() throws Exception {
+        withServiceAndQueue((service, queue, clock) -> {
+            var f = queue.add(mockBatch("123", 0, DEFAULT_SMALL_BATCH_SIZE));
+            // Writes complete promptly, so a generous bound returns true well before it elapses.
+            assertTrue(queue.drain(Duration.ofSeconds(5)));
+            assertTrue(f.isDone());
+            assertNotNull(f.get());
+        });
+    }
+
+    @Test
+    public void testDrainWithTimeoutExpiresThenCloseReleases() throws Exception {
+        var service = new DeterministicScheduler();
+        var clock = new MutableClock(Instant.now(), ZoneId.systemDefault());
+        var release = new java.util.concurrent.CountDownLatch(1);
+        var queue = new BlockingMockQueue(release, service, clock);
+
+        var f = queue.add(mockBatch("123", 0, DEFAULT_SMALL_BATCH_SIZE));
+
+        // The writer is stuck inside write(), so a short bound elapses and drain reports failure
+        // without hanging.
+        long start = System.nanoTime();
+        boolean completed = queue.drain(Duration.ofMillis(100));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        assertFalse(completed);
+        assertFalse(f.isDone());
+        assertTrue(elapsedMs < 5_000, "drain(timeout) must not block past its bound");
+
+        // Unblock the write so the in-flight task can finish, then close() releases cleanly.
+        release.countDown();
+        queue.close();
+        assertTrue(f.isDone());
+    }
+
+    @Test
+    public void testCloseDoesNotHangOnStuckWriter() throws Exception {
+        var service = new DeterministicScheduler();
+        var clock = new MutableClock(Instant.now(), ZoneId.systemDefault());
+        var release = new java.util.concurrent.CountDownLatch(1);
+        var queue = new BlockingMockQueue(release, service, clock);
+
+        try {
+            queue.add(mockBatch("123", 0, DEFAULT_SMALL_BATCH_SIZE));
+            // drain submits the bucket; the writer enters write() and gets stuck (and ignores the
+            // interrupt close() will send, mimicking a native COPY that doesn't respond to cancellation).
+            queue.drain(Duration.ofMillis(50));
+            queue.started.await();
+
+            long start = System.nanoTime();
+            queue.close(); // must return within the bounded join, not block on the stuck writer
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            assertTrue(elapsedMs < 5_000, "close() must not hang on a stuck writer");
+        } finally {
+            // Always let the abandoned writer thread finish and exit, even if an assertion fails.
+            release.countDown();
+        }
+    }
+
+    /** Queue whose write() blocks until a latch is released — used to exercise drain/close timeouts. */
+    private static final class BlockingMockQueue extends BulkIngestQueue<String, MockWriteResult> {
+        private final java.util.concurrent.CountDownLatch release;
+        final java.util.concurrent.CountDownLatch started = new java.util.concurrent.CountDownLatch(1);
+
+        BlockingMockQueue(java.util.concurrent.CountDownLatch release,
+                          ScheduledExecutorService executorService, Clock clock) {
+            super("", DEFAULT_MIN_BATCH_SIZE, Long.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE,
+                    DEFAULT_MAX_DELAY, executorService, clock);
+            this.release = release;
+        }
+
+        // Short bound so the stuck-writer test doesn't wait the production 5s.
+        @Override
+        protected Duration closeJoinTimeout() {
+            return Duration.ofMillis(200);
+        }
+
+        @Override
+        public void write(WriteTask<String, MockWriteResult> writeTask) {
+            started.countDown();
+            // Wait uninterruptibly — a native write (e.g. DuckDB COPY) does not unblock on
+            // Thread.interrupt(), so the close() bound, not the interrupt, must cap the wait.
+            boolean released = false;
+            while (!released) {
+                try {
+                    release.await();
+                    released = true;
+                } catch (InterruptedException e) {
+                    // swallow and keep waiting, mimicking an uninterruptible native call
+                }
+            }
+            for (var future : writeTask.bucket().futures()) {
+                future.complete(new MockWriteResult(writeTask.taskId(), writeTask.size()));
+            }
+        }
+    }
+
     private MockBulkIngestQueue createMockQueue(ScheduledExecutorService executorService, Clock clock) {
         return new MockBulkIngestQueue("", DEFAULT_MIN_BATCH_SIZE, Long.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE, DEFAULT_MAX_DELAY,
                 executorService,

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorServer.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorServer.java
@@ -181,9 +181,12 @@ public class OtelCollectorServer implements Closeable {
                 Thread.currentThread().interrupt();
             }
         }
-        // Flush and close all queues the handler owns, then stop the shared flush scheduler.
+        // Flush and close all queues the handler owns, then stop the shared flush scheduler. The
+        // drain bound (IngestionHandler.DEFAULT_DRAIN_TIMEOUT) is distinct from the LB-drain
+        // shutdownGracePeriod: it bounds the actual data flush and returns as soon as writes
+        // complete, so it only limits how long a stalled write backend can delay shutdown.
         if (handler != null) {
-            try { handler.closeQueues(); } catch (Exception e) { log.warn("Error closing ingestion queues", e); }
+            try { handler.closeQueues(IngestionHandler.DEFAULT_DRAIN_TIMEOUT); } catch (Exception e) { log.warn("Error closing ingestion queues", e); }
         }
         if (flushScheduler != null) {
             flushScheduler.shutdownNow();


### PR DESCRIPTION
## Summary

Adds a graceful **drain** path to the bulk ingest queue so accepted-but-unwritten batches are flushed (their futures completed normally) on shutdown, instead of being abandoned by `close()`. A bounded variant keeps a stalled write backend from hanging shutdown.

## Changes

- **`BulkIngestQueue`**
  - `drain()` — flushes the current bucket and blocks until every accepted batch is written, via a FIFO **poison-pill** sentinel (the writer reaches it only after all prior tasks are written).
  - `drain(Duration timeout)` — same flush, bounded; returns `false` if the writer is still running when the bound elapses, so the caller can fall through to `close()`.
  - Bounded `close()` join as a backstop for a write that ignores cancellation (the thread is a daemon, so it can't block JVM exit).
  - Combine-loop hardening: uses `poll()`'s actual return so a concurrent `close()`-drain after a timed-out join consumes each task exactly once (no write-and-abandon race).
- **`DuckLakeIngestionHandler.closeQueues(Duration)`** — drains then closes, **in parallel** across queues (virtual threads), so total teardown is bounded by the slowest queue rather than the sum.
- **`DynamicIngestionHandler`** — overrides `closeQueues(Duration)` so its scheduler/SQLite cleanup runs regardless of which `closeQueues` entry point is used (fixes a leak where the no-arg-only override was bypassed).
- **`IngestionHandler`** — shared `DEFAULT_DRAIN_TIMEOUT` constant.
- **`OtelCollectorServer`** — flushes via the bounded drain on shutdown.

## Semantics
`drain()` = graceful (flush, complete futures, wait) vs `close()` = forceful (abandon, fail futures, release). Callers compose them: graceful shutdown drains then closes; error/eviction paths close directly.

## Test plan
- [x] `BulkIngestQueueTest` (+ drain/bounded-drain/stuck-writer cases), `BulkIngestQueueV2Test`, `DuckLakeIngestionHandlerTest`, `DuckLakeIngestionIntegrationTest` — all green
- [x] `dazzleduck-sql-otel-collector` shutdown path compiles and runs
- [x] Rebased onto current upstream `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)