### PR TITLE
Fix fail-open RLS & authorization gaps in AST traversal

### DIFF
--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ExpressionConstants.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ExpressionConstants.java
@@ -37,7 +37,11 @@ public class ExpressionConstants {
     public static final String NODE_TYPE_SUBQUERY = "SUBQUERY";
     public static final String NODE_TYPE_SELECT_NODE = "SELECT_NODE";
     public static final String NODE_TYPE_SET_OPERATION_NODE = "SET_OPERATION_NODE";
+    public static final String NODE_TYPE_RECURSIVE_CTE_NODE = "RECURSIVE_CTE_NODE";
     public static final String NODE_TYPE_JOIN = "JOIN";
+    public static final String NODE_TYPE_PIVOT = "PIVOT";
+    public static final String NODE_TYPE_EXPRESSION_LIST = "EXPRESSION_LIST";
+    public static final String NODE_TYPE_EMPTY = "EMPTY";
 
     // Field name constants for JSON AST nodes
     public static final String FIELD_CLASS = "class";
@@ -78,6 +82,15 @@ public class ExpressionConstants {
     public static final String FIELD_MODIFIERS = "modifiers";
     public static final String FIELD_LIMIT = "limit";
     public static final String FIELD_OFFSET = "offset";
+    public static final String FIELD_EXPRESSION = "expression";
+    public static final String FIELD_SOURCE = "source";
+    public static final String FIELD_VALUES = "values";
+    public static final String FIELD_AGGREGATES = "aggregates";
+    public static final String FIELD_CTE_MAP = "cte_map";
+    public static final String FIELD_MAP = "map";
+    public static final String FIELD_KEY = "key";
+    public static final String FIELD_QUERY = "query";
+    public static final String FIELD_CTE_NAME = "cte_name";
 
     // Type ID constants for data types
     public static final String TYPE_VARCHAR = "VARCHAR";

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -1434,8 +1434,12 @@ public class Transformations {
                 walkExpressionsForSubqueries(fromNode.get("condition"), userCteNames, tablesToWrap);
             }
             case NODE_TYPE_SUBQUERY -> {
-                ObjectNode innerSelect = (ObjectNode) fromNode.get(FIELD_SUBQUERY).get(FIELD_NODE);
-                renameBaseTablesInSelect(innerSelect, userCteNames, tablesToWrap);
+                // The derived-table body may be a SELECT or a set operation (UNION/INTERSECT/EXCEPT);
+                // dispatch on its type so base tables inside a UNION are filtered too. Calling
+                // renameBaseTablesInSelect directly would silently skip a set-operation body, letting
+                // its base tables pass through UNFILTERED (an RLS bypass).
+                ObjectNode inner = (ObjectNode) fromNode.get(FIELD_SUBQUERY).get(FIELD_NODE);
+                renameBaseTablesInStatementNode(inner, userCteNames, tablesToWrap);
             }
             case NODE_TYPE_SET_OPERATION_NODE -> {
                 renameBaseTablesInFromNode(fromNode.get(FIELD_LEFT), userCteNames, tablesToWrap);

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -705,6 +705,43 @@ public class Transformations {
         } else if (NODE_TYPE_SET_OPERATION_NODE.equals(type)) {
             collectAllTableRefsFromStatement(statement.get(FIELD_LEFT), catalogName, schemaName, collector, visibleCteNames);
             collectAllTableRefsFromStatement(statement.get(FIELD_RIGHT), catalogName, schemaName, collector, visibleCteNames);
+            collectAllTableRefsFromModifiers(statement.get(FIELD_MODIFIERS), catalogName, schemaName, collector, visibleCteNames);
+        } else if (NODE_TYPE_RECURSIVE_CTE_NODE.equals(type)) {
+            // WITH RECURSIVE body: recurse into both arms. Keep the CTE's own name visible so the
+            // recursive self-reference is treated as a CTE reference, not a hidden base table.
+            Set<String> localCteNames = visibleCteNames;
+            JsonNode cteName = statement.get(FIELD_CTE_NAME);
+            if (cteName != null) {
+                localCteNames = new HashSet<>(visibleCteNames);
+                localCteNames.add(cteName.asText());
+            }
+            collectAllTableRefsFromStatement(statement.get(FIELD_LEFT), catalogName, schemaName, collector, localCteNames);
+            collectAllTableRefsFromStatement(statement.get(FIELD_RIGHT), catalogName, schemaName, collector, localCteNames);
+            collectAllTableRefsFromModifiers(statement.get(FIELD_MODIFIERS), catalogName, schemaName, collector, localCteNames);
+        } else {
+            // Fail closed: an unrecognized query node type must abort authorization rather than
+            // silently hide the tables it contains (which would let them bypass the access check).
+            throw new IllegalStateException(
+                    "collectAllTableReferences: unsupported query node type '" + type + "'; refusing to "
+                            + "authorize a query whose tables cannot all be enumerated");
+        }
+    }
+
+    /** Walks ORDER BY / LIMIT / OFFSET modifiers for table references inside their subqueries. */
+    private static void collectAllTableRefsFromModifiers(JsonNode modifiers, String catalogName,
+                                                         String schemaName,
+                                                         List<CatalogSchemaTable> collector,
+                                                         Set<String> cteNames) {
+        if (modifiers == null || !modifiers.isArray()) return;
+        for (JsonNode modifier : modifiers) {
+            JsonNode orders = modifier.get(FIELD_ORDERS);
+            if (orders != null && orders.isArray()) {
+                for (JsonNode order : orders) {
+                    collectAllTableRefsFromExpression(order.get(FIELD_EXPRESSION), catalogName, schemaName, collector, cteNames);
+                }
+            }
+            collectAllTableRefsFromExpression(modifier.get(FIELD_LIMIT), catalogName, schemaName, collector, cteNames);
+            collectAllTableRefsFromExpression(modifier.get(FIELD_OFFSET), catalogName, schemaName, collector, cteNames);
         }
     }
 
@@ -741,10 +778,22 @@ public class Transformations {
                 collectAllTableRefsFromStatement(
                         fromNode.get(FIELD_SUBQUERY).get(FIELD_NODE), catalogName, schemaName, collector, cteNames);
             }
-            case NODE_TYPE_SET_OPERATION_NODE -> {
-                collectAllTableRefsFromFromNode(fromNode.get(FIELD_LEFT), catalogName, schemaName, collector, cteNames);
-                collectAllTableRefsFromFromNode(fromNode.get(FIELD_RIGHT), catalogName, schemaName, collector, cteNames);
+            case NODE_TYPE_PIVOT -> {
+                // PIVOT / UNPIVOT: the scanned relation is under `source`; recurse into it so the
+                // pivoted table is seen by the access check. Aggregate expressions may hold subqueries.
+                collectAllTableRefsFromFromNode(fromNode.get(FIELD_SOURCE), catalogName, schemaName, collector, cteNames);
+                collectAllTableRefsFromExpression(fromNode.get(FIELD_AGGREGATES), catalogName, schemaName, collector, cteNames);
             }
+            case NODE_TYPE_EXPRESSION_LIST -> {
+                // VALUES list: each value expression may embed a subquery over a base table.
+                collectAllTableRefsFromExpression(fromNode.get(FIELD_VALUES), catalogName, schemaName, collector, cteNames);
+            }
+            case NODE_TYPE_EMPTY -> {
+                // FROM-less SELECT (e.g. SELECT 1): no relation to enumerate.
+            }
+            default -> throw new IllegalStateException(
+                    "collectAllTableReferences: unsupported FROM node type '" + type + "'; refusing to "
+                            + "authorize a query whose tables cannot all be enumerated");
         }
     }
 
@@ -757,7 +806,8 @@ public class Transformations {
         collectAllTableRefsFromExpression(selectNode.get("qualify"), catalogName, schemaName, collector, cteNames);
         collectAllTableRefsFromExpression(selectNode.get("select_list"), catalogName, schemaName, collector, cteNames);
         collectAllTableRefsFromExpression(selectNode.get("group_expressions"), catalogName, schemaName, collector, cteNames);
-        collectAllTableRefsFromExpression(selectNode.get("order_bys"), catalogName, schemaName, collector, cteNames);
+        // ORDER BY / LIMIT / OFFSET live under modifiers[], not a top-level "order_bys" field.
+        collectAllTableRefsFromModifiers(selectNode.get(FIELD_MODIFIERS), catalogName, schemaName, collector, cteNames);
     }
 
     private static void collectAllTableRefsFromExpression(JsonNode expr, String catalogName,
@@ -1268,28 +1318,14 @@ public class Transformations {
         var result = query.deepCopy();
         var statementNode = (ObjectNode) getFirstStatementNode(result);
 
-        Set<String> userCteNames = collectUserCteNames(statementNode);
         // Ordered map: cteKey → original BASE_TABLE node (schema/catalog preserved for CTE body)
         Map<String, ObjectNode> tablesToWrap = new LinkedHashMap<>();
 
-        // Inject into CTE bodies first so user CTEs reference filtered tables.
-        // Each CTE body is walked with its own name removed from the visible-CTE set:
-        // in a non-recursive CTE, the CTE cannot reference itself, so a same-named
-        // reference inside the body is a base-table reference and must be filtered.
-        JsonNode cteMapNode = statementNode.get("cte_map");
-        if (cteMapNode != null) {
-            JsonNode mapArray = cteMapNode.get("map");
-            if (mapArray != null && mapArray.isArray()) {
-                for (JsonNode entry : mapArray) {
-                    String cteName = entry.get("key").asText();
-                    Set<String> namesVisibleInBody = new HashSet<>(userCteNames);
-                    namesVisibleInBody.remove(cteName);
-                    ObjectNode cteBody = (ObjectNode) entry.get("value").get("query").get("node");
-                    renameBaseTablesInStatementNode(cteBody, namesVisibleInBody, tablesToWrap);
-                }
-            }
-        }
-        renameBaseTablesInStatementNode(statementNode, userCteNames, tablesToWrap);
+        // Walk the whole statement — its FROM clause, expression subqueries, and any WITH clause
+        // (top-level or nested) — collecting every real base table and rewriting each reference to
+        // its filter-CTE name. CTE bodies are handled inside the dispatcher so nesting at any depth
+        // is filtered uniformly.
+        renameBaseTablesInStatementNode(statementNode, new HashSet<>(), tablesToWrap);
 
         if (!tablesToWrap.isEmpty()) {
             ArrayNode newMap = JsonNodeFactory.instance.arrayNode();
@@ -1297,40 +1333,107 @@ public class Transformations {
                 String qualifiedLookupKey = buildQualifiedLookupKey(e.getValue());
                 newMap.add(buildFilterCteEntry(e.getKey(), e.getValue(), filterForTable.apply(qualifiedLookupKey)));
             }
-            JsonNode existingMap = statementNode.get("cte_map").get("map");
+            JsonNode existingMap = statementNode.get(FIELD_CTE_MAP).get(FIELD_MAP);
             if (existingMap != null && existingMap.isArray()) {
                 for (JsonNode existing : existingMap) {
                     newMap.add(existing);
                 }
             }
-            ((ObjectNode) statementNode.get("cte_map")).set("map", newMap);
+            ((ObjectNode) statementNode.get(FIELD_CTE_MAP)).set(FIELD_MAP, newMap);
         }
 
         return result;
     }
 
-    private static Set<String> collectUserCteNames(JsonNode statementNode) {
-        Set<String> names = new HashSet<>();
-        JsonNode cteMap = statementNode.get("cte_map");
-        if (cteMap == null) return names;
-        JsonNode map = cteMap.get("map");
-        if (map == null || !map.isArray()) return names;
-        for (JsonNode entry : map) {
-            JsonNode key = entry.get("key");
-            if (key != null) names.add(key.asText());
+    /**
+     * Processes a query node's own WITH clause: registers every CTE name it declares (so references
+     * to them are treated as CTE references, not base tables) and injects the filter into each CTE
+     * body. Returns {@code visibleCteNames} augmented with the names declared here.
+     *
+     * <p>Each CTE body is walked with its OWN name removed from the visible set: a non-recursive CTE
+     * cannot reference itself, so a same-named reference inside the body is the real base table and
+     * MUST be filtered. A recursive CTE body ({@code RECURSIVE_CTE_NODE}) re-adds its own name for the
+     * self-reference in {@link #renameBaseTablesInStatementNode}.
+     */
+    private static Set<String> walkNestedCtes(ObjectNode node, Set<String> visibleCteNames,
+                                              Map<String, ObjectNode> tablesToWrap) {
+        JsonNode cteMapNode = node.get(FIELD_CTE_MAP);
+        if (cteMapNode == null) return visibleCteNames;
+        JsonNode mapArray = cteMapNode.get(FIELD_MAP);
+        if (mapArray == null || !mapArray.isArray() || mapArray.isEmpty()) return visibleCteNames;
+
+        Set<String> withDeclared = new HashSet<>(visibleCteNames);
+        for (JsonNode entry : mapArray) {
+            withDeclared.add(entry.get(FIELD_KEY).asText());
         }
-        return names;
+        for (JsonNode entry : mapArray) {
+            String cteName = entry.get(FIELD_KEY).asText();
+            Set<String> namesVisibleInBody = new HashSet<>(withDeclared);
+            namesVisibleInBody.remove(cteName);
+            ObjectNode cteBody = (ObjectNode) entry.get(FIELD_VALUE).get(FIELD_QUERY).get(FIELD_NODE);
+            renameBaseTablesInStatementNode(cteBody, namesVisibleInBody, tablesToWrap);
+        }
+        return withDeclared;
     }
 
-    /** Dispatches to the correct handler based on whether the node is SELECT or UNION/INTERSECT/EXCEPT. */
-    private static void renameBaseTablesInStatementNode(ObjectNode statementNode, Set<String> userCteNames,
+    /**
+     * Dispatches a query node (a statement body or CTE body) to the correct handler by type.
+     *
+     * <p>Fails closed: an unrecognized node type throws rather than silently passing its base tables
+     * through unfiltered (which would be an RLS bypass). This mechanism guards row-level security, so
+     * any shape it does not understand must abort the query, not leak.
+     */
+    private static void renameBaseTablesInStatementNode(ObjectNode statementNode, Set<String> visibleCteNames,
                                                          Map<String, ObjectNode> tablesToWrap) {
         String type = statementNode.get(FIELD_TYPE).asText();
-        if (NODE_TYPE_SELECT_NODE.equals(type)) {
-            renameBaseTablesInSelect(statementNode, userCteNames, tablesToWrap);
-        } else if (NODE_TYPE_SET_OPERATION_NODE.equals(type)) {
-            renameBaseTablesInStatementNode((ObjectNode) statementNode.get(FIELD_LEFT), userCteNames, tablesToWrap);
-            renameBaseTablesInStatementNode((ObjectNode) statementNode.get(FIELD_RIGHT), userCteNames, tablesToWrap);
+        switch (type) {
+            case NODE_TYPE_SELECT_NODE -> {
+                Set<String> visible = walkNestedCtes(statementNode, visibleCteNames, tablesToWrap);
+                renameBaseTablesInSelect(statementNode, visible, tablesToWrap);
+            }
+            case NODE_TYPE_SET_OPERATION_NODE -> {
+                Set<String> visible = walkNestedCtes(statementNode, visibleCteNames, tablesToWrap);
+                renameBaseTablesInStatementNode((ObjectNode) statementNode.get(FIELD_LEFT), visible, tablesToWrap);
+                renameBaseTablesInStatementNode((ObjectNode) statementNode.get(FIELD_RIGHT), visible, tablesToWrap);
+                walkModifiersForSubqueries(statementNode.get(FIELD_MODIFIERS), visible, tablesToWrap);
+            }
+            case NODE_TYPE_RECURSIVE_CTE_NODE -> {
+                Set<String> visible = walkNestedCtes(statementNode, visibleCteNames, tablesToWrap);
+                // The recursive self-reference (FROM r inside the CTE body) is a CTE reference, not a
+                // base table; keep the CTE's own name visible so it is not wrapped as a phantom table.
+                JsonNode cteName = statementNode.get(FIELD_CTE_NAME);
+                if (cteName != null) {
+                    visible = new HashSet<>(visible);
+                    visible.add(cteName.asText());
+                }
+                renameBaseTablesInStatementNode((ObjectNode) statementNode.get(FIELD_LEFT), visible, tablesToWrap);
+                renameBaseTablesInStatementNode((ObjectNode) statementNode.get(FIELD_RIGHT), visible, tablesToWrap);
+                walkModifiersForSubqueries(statementNode.get(FIELD_MODIFIERS), visible, tablesToWrap);
+            }
+            default -> throw new IllegalStateException(
+                    "injectFilterCtes: unsupported query node type '" + type + "'; refusing to run to "
+                            + "avoid producing an unfiltered (RLS-bypassing) query");
+        }
+    }
+
+    /**
+     * Walks the result modifiers of a SELECT or set-operation node (ORDER BY, LIMIT, OFFSET) for
+     * subqueries, so a base table referenced only inside e.g. {@code ORDER BY (SELECT ... FROM t)}
+     * is still filtered. DuckDB serializes these under {@code modifiers[]} (ORDER BY expressions live
+     * in {@code orders[].expression}), NOT a top-level {@code order_bys} field.
+     */
+    private static void walkModifiersForSubqueries(JsonNode modifiers, Set<String> visibleCteNames,
+                                                    Map<String, ObjectNode> tablesToWrap) {
+        if (modifiers == null || !modifiers.isArray()) return;
+        for (JsonNode modifier : modifiers) {
+            JsonNode orders = modifier.get(FIELD_ORDERS);
+            if (orders != null && orders.isArray()) {
+                for (JsonNode order : orders) {
+                    walkExpressionsForSubqueries(order.get(FIELD_EXPRESSION), visibleCteNames, tablesToWrap);
+                }
+            }
+            walkExpressionsForSubqueries(modifier.get(FIELD_LIMIT), visibleCteNames, tablesToWrap);
+            walkExpressionsForSubqueries(modifier.get(FIELD_OFFSET), visibleCteNames, tablesToWrap);
         }
     }
 
@@ -1355,7 +1458,8 @@ public class Transformations {
         walkExpressionsForSubqueries(selectNode.get("qualify"), userCteNames, tablesToWrap);
         walkExpressionsForSubqueries(selectNode.get("select_list"), userCteNames, tablesToWrap);
         walkExpressionsForSubqueries(selectNode.get("group_expressions"), userCteNames, tablesToWrap);
-        walkExpressionsForSubqueries(selectNode.get("order_bys"), userCteNames, tablesToWrap);
+        // ORDER BY / LIMIT / OFFSET live under modifiers[], not a top-level "order_bys" field.
+        walkModifiersForSubqueries(selectNode.get(FIELD_MODIFIERS), userCteNames, tablesToWrap);
     }
 
     /**
@@ -1434,17 +1538,27 @@ public class Transformations {
                 walkExpressionsForSubqueries(fromNode.get("condition"), userCteNames, tablesToWrap);
             }
             case NODE_TYPE_SUBQUERY -> {
-                // The derived-table body may be a SELECT or a set operation (UNION/INTERSECT/EXCEPT);
-                // dispatch on its type so base tables inside a UNION are filtered too. Calling
-                // renameBaseTablesInSelect directly would silently skip a set-operation body, letting
-                // its base tables pass through UNFILTERED (an RLS bypass).
+                // The derived-table body may be a SELECT, a set operation, or a recursive CTE;
+                // dispatch on its type so nested base tables are filtered too.
                 ObjectNode inner = (ObjectNode) fromNode.get(FIELD_SUBQUERY).get(FIELD_NODE);
                 renameBaseTablesInStatementNode(inner, userCteNames, tablesToWrap);
             }
-            case NODE_TYPE_SET_OPERATION_NODE -> {
-                renameBaseTablesInFromNode(fromNode.get(FIELD_LEFT), userCteNames, tablesToWrap);
-                renameBaseTablesInFromNode(fromNode.get(FIELD_RIGHT), userCteNames, tablesToWrap);
+            case NODE_TYPE_PIVOT -> {
+                // PIVOT / UNPIVOT: the scanned relation is under `source`; recurse into it so the
+                // pivoted base table is filtered. Aggregate expressions may hold subqueries.
+                renameBaseTablesInFromNode(fromNode.get(FIELD_SOURCE), userCteNames, tablesToWrap);
+                walkExpressionsForSubqueries(fromNode.get(FIELD_AGGREGATES), userCteNames, tablesToWrap);
             }
+            case NODE_TYPE_EXPRESSION_LIST -> {
+                // VALUES list: each value expression may embed a subquery over a base table.
+                walkExpressionsForSubqueries(fromNode.get(FIELD_VALUES), userCteNames, tablesToWrap);
+            }
+            case NODE_TYPE_EMPTY -> {
+                // FROM-less SELECT (e.g. SELECT 1): no relation to filter.
+            }
+            default -> throw new IllegalStateException(
+                    "injectFilterCtes: unsupported FROM node type '" + type + "'; refusing to run to "
+                            + "avoid producing an unfiltered (RLS-bypassing) query");
         }
     }
 

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/TransformationsInjectFilterTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/TransformationsInjectFilterTest.java
@@ -12,9 +12,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -258,6 +260,58 @@ public class TransformationsInjectFilterTest {
         String out = Transformations.parseToSql(conn, result);
         List<Object> ids = execFirstColumn(out);
         assertEquals(4, ids.size(), "UNION ALL: 2 rows × 2 arms");
+    }
+
+    // --- set operation nested inside a derived table (regression: RLS bypass) ---
+
+    @Test
+    void unionInsideDerivedTable_filterInjectedIntoBothArms() throws SQLException, JsonProcessingException {
+        // Regression: a UNION nested inside a FROM-subquery (derived table). Previously the SUBQUERY
+        // branch of renameBaseTablesInFromNode dispatched a set-operation body to the SELECT-only
+        // handler, so base tables inside the UNION were never wrapped — an RLS bypass that leaked
+        // every row. They must now be filtered.
+        String sql = "SELECT id FROM ("
+                + "SELECT id, tenant_id FROM orders WHERE amount > 0 "
+                + "UNION ALL "
+                + "SELECT id, tenant_id FROM orders WHERE amount < 1000) sub";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"), "orders inside the nested UNION must get a filter CTE");
+        List<Object> ids = execFirstColumn(out);
+        // Each arm filtered to tenant abc {1,3}; UNION ALL → 4 rows, all abc.
+        assertEquals(4, ids.size(), "both arms return only tenant abc rows: " + ids);
+        assertTrue(ids.stream().allMatch(v -> v.equals(1) || v.equals(3)),
+                "tenant xyz (id 2) must not leak: " + ids);
+    }
+
+    // --- lateral VALUES unpivot (single-scan distinct-values pattern) ---
+
+    @Test
+    void lateralValuesUnpivot_filterInjected() throws SQLException, JsonProcessingException {
+        // Mirrors the single-scan distinct-values query: the fact table is scanned once and each row
+        // is unpivoted into (column, value) tuples via a lateral VALUES list. The base table must
+        // still be filtered, and only authorized rows' values may appear.
+        String sql = "SELECT DISTINCT v.col, v.val FROM orders, (VALUES "
+                + "('id', CAST(id AS VARCHAR)), "
+                + "('amount', CAST(amount AS VARCHAR))"
+                + ") AS v(col, val) WHERE v.val IS NOT NULL";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"), "orders must get a filter CTE in the lateral-VALUES query");
+
+        Set<String> pairs = new HashSet<>();
+        try (ResultSet rs = conn.createStatement().executeQuery(out)) {
+            while (rs.next()) {
+                pairs.add(rs.getString(1) + ":" + rs.getString(2));
+            }
+        }
+        // tenant abc rows: (id 1, amount 100), (id 3, amount 300). xyz (id 2 / amount 200) excluded.
+        assertEquals(Set.of("id:1", "id:3", "amount:100", "amount:300"), pairs,
+                "only tenant abc values may appear: " + pairs);
     }
 
     // --- per-table map with fully-qualified keys (security tests) ---

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/TransformationsInjectFilterTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/TransformationsInjectFilterTest.java
@@ -415,4 +415,131 @@ public class TransformationsInjectFilterTest {
         assertEquals(List.of(1, 3), ids,
                 "CTE name shadowing the authorized table must not bypass the row filter");
     }
+
+    // --- fail-open node-type gaps in the filter-injection traversal (RLS-bypass regressions) ---
+
+    private List<Object> sorted(List<Object> in) {
+        List<Object> copy = new ArrayList<>(in);
+        copy.sort((a, b) -> ((Comparable) a).compareTo(b));
+        return copy;
+    }
+
+    @Test
+    void recursiveCte_topLevel_filterInjectedIntoAnchor() throws SQLException, JsonProcessingException {
+        // Regression: a WITH RECURSIVE body serializes as RECURSIVE_CTE_NODE, a type the statement
+        // dispatcher previously ignored — the anchor's base table passed through UNFILTERED.
+        // The recursive term (WHERE false) adds no rows, so r is exactly the filtered anchor.
+        String sql = "WITH RECURSIVE r(id) AS ("
+                + "SELECT id FROM orders "
+                + "UNION ALL "
+                + "SELECT id FROM r WHERE false) "
+                + "SELECT id FROM r";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"), "recursive CTE anchor must get a filter CTE: " + out);
+        assertEquals(List.of(1, 3), sorted(execFirstColumn(out)),
+                "only tenant abc rows may seed the recursion; xyz (id 2) must not leak");
+    }
+
+    @Test
+    void recursiveCte_nestedInDerivedTable_filterInjected() throws SQLException, JsonProcessingException {
+        String sql = "SELECT id FROM (WITH RECURSIVE r(id) AS ("
+                + "SELECT id FROM orders UNION ALL SELECT id FROM r WHERE false) "
+                + "SELECT id FROM r) sub";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"), "recursive CTE inside a derived table must be filtered: " + out);
+        assertEquals(List.of(1, 3), sorted(execFirstColumn(out)), "xyz (id 2) must not leak");
+    }
+
+    @Test
+    void nestedWithInsideDerivedTable_filterInjected() throws SQLException, JsonProcessingException {
+        // Regression: renameBaseTablesInSelect did not walk a derived-table body's own WITH clause,
+        // so orders inside the inner CTE leaked and the inner CTE name got mis-wrapped (broken SQL).
+        String sql = "SELECT id FROM (WITH s AS (SELECT id, tenant_id FROM orders) SELECT id FROM s) sub";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"), "orders inside the nested WITH must be filtered: " + out);
+        assertFalse(out.contains("___s"), "the inner CTE name must not be wrapped as a phantom base table: " + out);
+        assertEquals(List.of(1, 3), sorted(execFirstColumn(out)), "xyz (id 2) must not leak");
+    }
+
+    @Test
+    void unpivot_filterInjected() throws SQLException, JsonProcessingException {
+        // Regression: a PIVOT/UNPIVOT FROM node was not handled, so the base table under `source`
+        // was never wrapped. tenant_id is the kept (non-unpivoted) column; only abc must survive.
+        String sql = "SELECT tenant_id FROM orders UNPIVOT (val FOR col IN (id, amount))";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"), "unpivoted base table must get a filter CTE: " + out);
+        List<Object> tenants = execFirstColumn(out);
+        assertTrue(tenants.stream().allMatch(t -> t.equals("abc")),
+                "only tenant abc rows may appear after unpivot: " + tenants);
+        assertEquals(4, tenants.size(), "2 abc rows × 2 unpivoted columns");
+    }
+
+    @Test
+    void valuesListScalarSubquery_filterInjected() throws SQLException, JsonProcessingException {
+        // Regression: an EXPRESSION_LIST (VALUES) FROM node's value expressions were never walked,
+        // so a scalar subquery over a base table inside VALUES bypassed the filter.
+        String sql = "SELECT x FROM (VALUES ((SELECT sum(amount) FROM orders))) v(x)";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"), "scalar subquery over orders in VALUES must be filtered: " + out);
+        List<Object> vals = execFirstColumn(out);
+        assertEquals("400", String.valueOf(vals.get(0)),
+                "filtered sum is 100+300=400 (all-tenant 600 would mean the filter was bypassed): " + vals);
+    }
+
+    @Test
+    void orderByScalarSubquery_filterInjected() throws SQLException, JsonProcessingException {
+        // Regression: ORDER BY subqueries live under modifiers[].orders[].expression, not a top-level
+        // "order_bys" field the code used to read (always null) — so they were never filtered.
+        String sql = "SELECT order_id FROM items ORDER BY (SELECT max(amount) FROM orders)";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"),
+                "orders referenced only in an ORDER BY subquery must still be filtered: " + out);
+    }
+
+    @Test
+    void setOperationOrderBySubquery_filterInjected() throws SQLException, JsonProcessingException {
+        // Regression: the set-operation branch never walked the union's own ORDER BY/LIMIT modifiers,
+        // so a base table referenced only there bypassed the filter. orders appears ONLY in ORDER BY.
+        String sql = "SELECT x FROM ("
+                + "SELECT order_id AS x FROM items "
+                + "UNION ALL "
+                + "SELECT order_id AS x FROM items "
+                + "ORDER BY (SELECT max(amount) FROM orders)) s";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        JsonNode result = Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'"));
+        String out = Transformations.parseToSql(conn, result);
+
+        assertTrue(out.contains("___orders"),
+                "orders referenced only in a UNION's ORDER BY subquery must still be filtered: " + out);
+    }
+
+    @Test
+    void unsupportedFromNode_failsClosed() throws SQLException, JsonProcessingException {
+        // A FROM node type the traversal does not recognize (here a table function) must ABORT rather
+        // than silently pass base tables through unfiltered. RESTRICT_READ_ONLY blocks table functions
+        // upstream; this guards the injector's own fail-closed contract regardless of caller.
+        String sql = "SELECT * FROM generate_series(1, 3)";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        assertThrows(IllegalStateException.class,
+                () -> Transformations.injectFilterCtes(tree, filter("tenant_id = 'abc'")),
+                "an unhandled FROM node type must fail closed, not produce an unfiltered query");
+    }
 }

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/authorization/RestrictedDatasourceOnlyAuthorizerSecurityTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/authorization/RestrictedDatasourceOnlyAuthorizerSecurityTest.java
@@ -148,4 +148,46 @@ public class RestrictedDatasourceOnlyAuthorizerSecurityTest {
         assertThrows(UnauthorizedException.class, () ->
                 authorizer.authorize("user", DB, SCHEMA, tree, claims("orders", "tenant_id='abc'")));
     }
+
+    // ── Gap 2: node-type coverage — tables hidden by exotic shapes must still be caught ──
+
+    @Test
+    void recursiveCte_unauthorizedTable_rejected() throws SQLException, JsonProcessingException {
+        // Regression: the enumerator ignored RECURSIVE_CTE_NODE, so 'payments' in the anchor was
+        // invisible to the access check — the query was wrongly authorized.
+        String sql = "WITH RECURSIVE r(x) AS ("
+                + "SELECT order_id FROM payments UNION ALL SELECT x FROM r WHERE false) "
+                + "SELECT x FROM r";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        assertThrows(UnauthorizedException.class, () ->
+                authorizer.authorize("user", DB, SCHEMA, tree, claims("orders", "tenant_id='abc'")));
+    }
+
+    @Test
+    void unpivot_unauthorizedTable_rejected() throws SQLException, JsonProcessingException {
+        // Regression: a PIVOT/UNPIVOT FROM node was not enumerated, hiding its `source` table.
+        String sql = "SELECT tenant_id FROM payments UNPIVOT (val FOR col IN (order_id, paid))";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        assertThrows(UnauthorizedException.class, () ->
+                authorizer.authorize("user", DB, SCHEMA, tree, claims("orders", "tenant_id='abc'")));
+    }
+
+    @Test
+    void valuesListScalarSubquery_unauthorizedTable_rejected() throws SQLException, JsonProcessingException {
+        // Regression: an EXPRESSION_LIST (VALUES) FROM node's value expressions were not walked.
+        String sql = "SELECT x FROM (VALUES ((SELECT count(*) FROM sensitive))) v(x)";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        assertThrows(UnauthorizedException.class, () ->
+                authorizer.authorize("user", DB, SCHEMA, tree, claims("orders", "tenant_id='abc'")));
+    }
+
+    @Test
+    void orderBySubquery_unauthorizedTable_rejected() throws SQLException, JsonProcessingException {
+        // Regression: ORDER BY subqueries live under modifiers[], not the "order_bys" field the
+        // enumerator used to read (always null), so 'payments' here was invisible to the check.
+        String sql = "SELECT id FROM orders ORDER BY (SELECT max(paid) FROM payments)";
+        JsonNode tree = Transformations.parseToTree(conn, sql);
+        assertThrows(UnauthorizedException.class, () ->
+                authorizer.authorize("user", DB, SCHEMA, tree, claims("orders", "tenant_id='abc'")));
+    }
 }


### PR DESCRIPTION
## Summary

The row-level-security filter injection (`injectFilterCtes`) and the authorization table enumeration (`collectAllTableReferences`) both dispatched on a hardcoded couple of AST node types and **silently ignored everything else**. Any unrecognized query/FROM shape therefore passed its base tables through **unfiltered** (RLS bypass) or **hid them from the access check** (authorization bypass).

The original fix on this branch (base tables inside a `UNION` within a derived table) was one instance of this class. This PR now closes the whole class on both traversal paths and makes them **fail closed**.

## Confirmed bypass shapes (each reproduced, then fixed)

| Shape | Path | Effect before fix |
|-------|------|-------------------|
| `WITH RECURSIVE` body (`RECURSIVE_CTE_NODE`) | enumerator | unauthorized table invisible to access check (**auth bypass**) |
| `WITH RECURSIVE` body | injector | anchor's base table unfiltered |
| `ORDER BY (SELECT … FROM t)` | both | code read a top-level `order_bys` field DuckDB never emits (always null) → never filtered/enumerated |
| nested `WITH` inside a derived table | injector | inner CTE body's table unfiltered; inner CTE name mis-wrapped (broken SQL) |
| `PIVOT` / `UNPIVOT` | both | pivoted `source` table unfiltered / unchecked |
| `VALUES` scalar subquery (`EXPRESSION_LIST`) | both | subquery over a base table unfiltered / unchecked |
| set-operation `ORDER BY`/`LIMIT` modifiers | both | subquery there never walked |

## Changes

**Injector (`renameBaseTables*`)**
- Handle `RECURSIVE_CTE_NODE` (recurse both arms; keep the recursive self-reference visible so it isn't wrapped as a phantom table).
- Walk `ORDER BY`/`LIMIT`/`OFFSET` via `modifiers[]` (the real DuckDB serialization).
- Handle nested `WITH` clauses at any depth via a shared `walkNestedCtes` — preserving the security rule that a CTE's own name is removed while walking its body.
- Handle `PIVOT`/`UNPIVOT` (recurse `source`) and `VALUES`/`EXPRESSION_LIST` (walk value subqueries).
- **Fail closed**: unrecognized query-node/FROM-node types throw; `EMPTY` (FROM-less `SELECT`) is an explicit no-op.
- Remove the dead `SET_OPERATION_NODE` FROM-node case (set ops in FROM are always `SUBQUERY`-wrapped).

**Enumerator (`collectAllTableRefs*`), made symmetric with the injector**
- Handle `RECURSIVE_CTE_NODE`, `PIVOT`/`UNPIVOT`, `VALUES`/`EXPRESSION_LIST`, and modifier subqueries.
- **Fail closed** on unrecognized node types so an un-enumerable query is denied rather than silently authorized.

Both paths now traverse the same complete node-type set and fail closed on anything else, so the "unhandled shape leaks silently" class is closed rather than patched shape-by-shape.

## Testing

- 12 new regression tests (8 filter-injection in `TransformationsInjectFilterTest`, 4 access-check in `RestrictedDatasourceOnlyAuthorizerSecurityTest`), one per confirmed shape, plus a fail-closed assertion.
- Full suites green: `dazzleduck-sql-commons` 306 tests, `dazzleduck-sql-http` 93 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)