### PR TITLE
ingestion: support DuckLake time-transform partition columns

### DIFF
--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
@@ -2,6 +2,7 @@ package io.dazzleduck.sql.commons.ingestion;
 
 import io.dazzleduck.sql.commons.ConnectionPool;
 import io.dazzleduck.sql.commons.Transformations;
+import io.dazzleduck.sql.commons.util.HeaderUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +12,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -67,7 +69,15 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
      * {@code refreshedAt} is the clock instant when this state was last confirmed/rebuilt.
      */
     private record QueueState(String targetPath, String transformation, String[] partitionColumns,
-                               long schemaChangeId, Instant refreshedAt) {}
+                               String[] partitionProjections, long schemaChangeId, Instant refreshedAt) {}
+
+    /**
+     * A resolved partition column: {@code token} is the identifier placed in COPY's
+     * {@code PARTITION_BY} clause; {@code projection} is the derived-column expression that must be
+     * added to the COPY relation for the token to resolve, or {@code null} for identity columns
+     * (which already exist in the relation).
+     */
+    private record ResolvedPartition(String token, String projection) {}
 
     private final ConcurrentHashMap<String, QueueState> stateCache = new ConcurrentHashMap<>();
 
@@ -154,6 +164,12 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
     public String[] getPartitionBy(String queueId) {
         QueueState s = getOrRefreshState(queueId);
         return s != null ? s.partitionColumns() : new String[0];
+    }
+
+    @Override
+    public String[] getPartitionProjections(String queueId) {
+        QueueState s = getOrRefreshState(queueId);
+        return s != null ? s.partitionProjections() : new String[0];
     }
 
     @Override
@@ -321,7 +337,8 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
             logger.atDebug().log("Schema unchanged (id={}) for {}.{}.{}, skipping full refresh",
                     currentSchemaChangeId, mapping.catalog(), mapping.schema(), mapping.table());
             return new QueueState(existing.targetPath(), existing.transformation(),
-                    existing.partitionColumns(), existing.schemaChangeId(), clock.instant());
+                    existing.partitionColumns(), existing.partitionProjections(),
+                    existing.schemaChangeId(), clock.instant());
         }
         return buildState(mapping, currentSchemaChangeId, clock.instant());
     }
@@ -334,8 +351,11 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
     private static QueueState buildState(QueueIdToTableMapping mapping, long schemaChangeId, Instant refreshedAt) {
         String path           = fetchPath(mapping.catalog(), mapping.schema(), mapping.table());
         String transformation = resolveTransformation(mapping);
-        String[] partitions   = fetchPartitionColumns(mapping.catalog(), mapping.schema(), mapping.table());
-        return new QueueState(path, transformation, partitions, schemaChangeId, refreshedAt);
+        List<ResolvedPartition> partitions = fetchPartitions(mapping.catalog(), mapping.schema(), mapping.table());
+        String[] tokens      = partitions.stream().map(ResolvedPartition::token).toArray(String[]::new);
+        String[] projections = partitions.stream().map(ResolvedPartition::projection)
+                .filter(java.util.Objects::nonNull).toArray(String[]::new);
+        return new QueueState(path, transformation, tokens, projections, schemaChangeId, refreshedAt);
     }
 
     /** Convenience overload that fetches schema change ID itself (used at construction time). */
@@ -366,7 +386,8 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
     }
 
     public static String[] getPartitionColumns(String catalogName, String schema, String table) {
-        return fetchPartitionColumns(catalogName, schema, table);
+        return fetchPartitions(catalogName, schema, table).stream()
+                .map(ResolvedPartition::token).toArray(String[]::new);
     }
 
     /**
@@ -387,7 +408,7 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
         }
     }
 
-    private static String[] fetchPartitionColumns(String catalogName, String schema, String table) {
+    private static List<ResolvedPartition> fetchPartitions(String catalogName, String schema, String table) {
         String metadataDatabase = "__ducklake_metadata_" + catalogName;
         String query = """
                 SELECT
@@ -409,15 +430,32 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
                 ORDER BY pc.partition_key_index ASC
                 """.formatted(metadataDatabase, table);
         try (var connection = ConnectionPool.getConnection()) {
-            Iterable<String> columns = ConnectionPool.collectAll(connection, query,
-                    rs -> rs.getString("column_name"));
-            List<String> columnList = new ArrayList<>();
-            columns.forEach(columnList::add);
-            return columnList.toArray(new String[0]);
+            Iterable<ResolvedPartition> rows = ConnectionPool.collectAll(connection, query,
+                    rs -> resolvePartition(rs.getString("column_name"), rs.getString("transform")));
+            List<ResolvedPartition> partitions = new ArrayList<>();
+            rows.forEach(partitions::add);
+            return partitions;
         } catch (SQLException e) {
             logger.atDebug().setCause(e).log("Failed to get partition columns for table {}.{}.{}", catalogName, schema, table);
-            return new String[0];
+            return List.of();
         }
+    }
+
+    /**
+     * Resolves a {@code ducklake_partition_column} row into a {@link ResolvedPartition}. Identity
+     * columns partition by the column directly. Time transforms ({@code year}/{@code month}/{@code
+     * day}/{@code hour}) map to the DuckDB scalar function of the same name; since COPY's
+     * {@code PARTITION_BY} accepts only column names, the transform is projected as a derived column
+     * aliased to the transform name and partitioned by that alias.
+     */
+    private static ResolvedPartition resolvePartition(String columnName, String transform) {
+        if (transform == null || transform.isBlank() || transform.equalsIgnoreCase("identity")) {
+            return new ResolvedPartition(columnName, null);
+        }
+        String fn = transform.toLowerCase(Locale.ROOT);
+        String projection = "%s(%s) AS %s".formatted(fn,
+                HeaderUtils.quoteIdentifier(columnName), HeaderUtils.quoteIdentifier(fn));
+        return new ResolvedPartition(fn, projection);
     }
 
     // -----------------------------------------------------------------------

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionHandler.java
@@ -10,6 +10,13 @@ public interface IngestionHandler {
 
     String[] getPartitionBy(String queueId);
 
+    /**
+     * Derived-column projections added to the COPY relation so the identifiers returned by
+     * {@link #getPartitionBy} resolve — each a full expression, e.g. {@code day("timestamp") AS "day"}.
+     * Empty when the table has no non-identity partition transforms.
+     */
+    default String[] getPartitionProjections(String queueId) { return new String[0]; }
+
     default boolean supportPartitionByHeader() { return true; }
 
     // -----------------------------------------------------------------------

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/ParquetIngestionQueue.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/ParquetIngestionQueue.java
@@ -121,7 +121,8 @@ public class ParquetIngestionQueue extends BulkIngestQueue<String, IngestionResu
         // All Arrow files
         var arrowFiles = batches.stream().map(Batch::record).map("'%s'"::formatted).collect(Collectors.joining(","));
         String[] batchPartitionBy = batches.get(0).partitionBy();
-        String[] effectivePartitionBy = (batchPartitionBy != null && batchPartitionBy.length > 0)
+        boolean hasBatchPartitionBy = batchPartitionBy != null && batchPartitionBy.length > 0;
+        String[] effectivePartitionBy = hasBatchPartitionBy
                 ? batchPartitionBy
                 : postIngestionHandler.getPartitionBy(queueId);
         String partitionByClause = getClause(effectivePartitionBy, ", PARTITION_BY(%s)");
@@ -145,6 +146,17 @@ public class ParquetIngestionQueue extends BulkIngestQueue<String, IngestionResu
         var querySql = (transformation != null && !transformation.isBlank())
                 ? "WITH __this AS (%s) %s".formatted(innerSql, transformation)
                 : innerSql;
+
+        // Add handler-supplied derived-column projections (e.g. day(timestamp) AS day) so the
+        // PARTITION_BY tokens resolve. Not needed for header-supplied partitionBy, which names
+        // columns that already exist in the relation.
+        if (!hasBatchPartitionBy) {
+            String[] partitionProjections = postIngestionHandler.getPartitionProjections(queueId);
+            if (partitionProjections.length > 0) {
+                querySql = "SELECT *, %s FROM (%s)".formatted(
+                        String.join(", ", partitionProjections), querySql);
+            }
+        }
 
         // Build SQL
         // https://duckdb.org/docs/stable/sql/statements/copy


### PR DESCRIPTION
## Summary

Resolves DuckLake time-transform partition columns (`year`/`month`/`day`/`hour`) into derived-column projections so that COPY's `PARTITION_BY` tokens resolve correctly, while identity columns continue to be partitioned directly.

## Details

- `DuckLakeIngestionHandler` now reads the `transform` from `ducklake_partition_column` and resolves each partition into a `ResolvedPartition(token, projection)`:
  - **Identity** columns → partition by the column directly (no projection).
  - **Time transforms** (`year`/`month`/`day`/`hour`) → map to the DuckDB scalar function of the same name, projected as a derived column aliased to the transform name, and partitioned by that alias (since `PARTITION_BY` accepts only column names).
- `IngestionHandler` gains a `getPartitionProjections(queueId)` default method returning the derived-column expressions.
- `ParquetIngestionQueue` adds the handler-supplied projections to the COPY relation when partitionBy is handler-derived (not needed for header-supplied partitionBy, which names existing columns).

## Test plan

- [x] `./mvnw test -pl dazzleduck-sql-commons`

🤖 Generated with [Claude Code](https://claude.com/claude-code)