### PR TITLE
feat(http): add JSONL/NDJSON output to query and named-query endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,13 +69,14 @@ Key files: `QueryService.java`, `IngestionService.java`, `PlanningService.java`,
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/v1/login` | POST | Authenticate, get JWT token |
-| `/v1/query` | GET/POST | Execute SQL — Arrow IPC (default) or TSV (`Accept: text/tab-separated-values`) |
+| `/v1/query` | GET/POST | Execute SQL — Arrow IPC (default), TSV (`Accept: text/tab-separated-values`), or JSONL/NDJSON (`Accept: application/jsonl` or `application/x-ndjson`) |
 | `/v1/plan` | POST | Generate query execution plan |
 | `/v1/ingest` | POST | Ingest Arrow data to Parquet |
 | `/v1/cancel` | POST | Cancel running query |
 | `/health` | GET | Health check |
 
 TSV format: header row + tab-separated string values. Ideal for LLM agents and scripts.
+JSONL format: one JSON object per row, per line (newline-delimited, no enclosing array). Numbers/booleans/nulls keep their JSON types; temporal values are ISO-8601 strings; lists/structs/maps are real nested JSON. Streamable and append-friendly.
 
 ### dazzleduck-sql-commons
 Core DuckDB abstraction. Key classes:

--- a/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ContentTypes.java
+++ b/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ContentTypes.java
@@ -8,6 +8,12 @@ public final class ContentTypes {
     public static final String TEXT_TSV = "text/tab-separated-values";
     public static final String TEXT_TSV_UTF8 = "text/tab-separated-values; charset=utf-8";
 
+    /** JSON Lines / newline-delimited JSON: one JSON object per row, per line. */
+    public static final String APPLICATION_JSONL = "application/jsonl";
+    public static final String APPLICATION_JSONL_UTF8 = "application/jsonl; charset=utf-8";
+    /** De-facto NDJSON media type; treated as an alias for {@link #APPLICATION_JSONL}. */
+    public static final String APPLICATION_X_NDJSON = "application/x-ndjson";
+
     private ContentTypes() {
     }
 }

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/namedquery/NamedQueryServiceAdaptor.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/namedquery/NamedQueryServiceAdaptor.java
@@ -92,6 +92,17 @@ public interface NamedQueryServiceAdaptor {
                 outputStreamSupplier);
     }
 
+    /** Streams named query results as JSON Lines (NDJSON) — one JSON object per row, per line. */
+    default CompletableFuture<Void> streamJsonlNamedQuery(String name, Map<String, String> parameters,
+                                                          FlightProducer.CallContext context,
+                                                          Supplier<OutputStream> outputStreamSupplier) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        JsonOutputStreamListener listener = new JsonOutputStreamListener(
+                outputStreamSupplier, future, JsonOutputStreamListener.Format.JSONL);
+        getStreamNamedQuery(name, parameters, context, listener);
+        return future;
+    }
+
     /** Signals that a named query template could not be found in the DB. */
     class TemplateNotFoundException extends Exception {
         public TemplateNotFoundException(String message) {

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/HttpFlightAdaptor.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/HttpFlightAdaptor.java
@@ -146,6 +146,25 @@ public interface HttpFlightAdaptor {
     }
 
     /**
+     * Gets the stream for a statement query ticket, writing directly to an OutputStream as
+     * JSON Lines (NDJSON) — one JSON object per row, per line.
+     *
+     * @param ticket the statement query ticket
+     * @param context the call context
+     * @param outputStreamSupplier supplier that provides the output stream when data is ready to write
+     * @return a CompletableFuture that completes when streaming is done, or exceptionally on error
+     */
+    default CompletableFuture<Void> streamJsonl(FlightSql.TicketStatementQuery ticket,
+                                                FlightProducer.CallContext context,
+                                                Supplier<OutputStream> outputStreamSupplier) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        JsonOutputStreamListener listener = new JsonOutputStreamListener(
+                outputStreamSupplier, future, JsonOutputStreamListener.Format.JSONL);
+        getStreamStatement(ticket, context, listener);
+        return future;
+    }
+
+    /**
      * Gets the stream for a statement query ticket, writing directly to an OutputStream,
      * with configurable compression.
      *

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/JsonOutputStreamListener.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/JsonOutputStreamListener.java
@@ -2,7 +2,10 @@ package io.dazzleduck.sql.flight.server;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.*;
@@ -24,31 +27,56 @@ import java.util.function.Supplier;
 /**
  * A ServerStreamListener that writes Arrow batches as JSON to an OutputStream.
  *
- * <p>Can write either a JSON array of objects or a single JSON object (first row only).
+ * <p>Supports three {@link Format}s:
+ * <ul>
+ *   <li>{@link Format#ARRAY} — a single JSON array of row objects (default).</li>
+ *   <li>{@link Format#SINGLE_OBJECT} — the first row only, as a bare object
+ *       (errors with {@link NoSuchElementException} if there are no rows).</li>
+ *   <li>{@link Format#JSONL} — JSON Lines / NDJSON: one row object per line,
+ *       newline-terminated, with no enclosing array.</li>
+ * </ul>
  */
 public class JsonOutputStreamListener implements FlightProducer.ServerStreamListener {
 
+    /** Output shape written by this listener. */
+    public enum Format {
+        /** One JSON array of row objects. */
+        ARRAY,
+        /** Only the first row, as a bare JSON object. */
+        SINGLE_OBJECT,
+        /** JSON Lines / NDJSON: one newline-terminated object per row. */
+        JSONL
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(JsonOutputStreamListener.class);
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    // JavaTimeModule + ISO output so java.time values (e.g. non-TZ TIMESTAMP -> LocalDateTime),
+    // including those nested inside structs/lists, serialize as strings rather than failing.
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
     private final Supplier<OutputStream> outputStreamSupplier;
     private final CompletableFuture<Void> future;
-    private final boolean includeArrayBrackets;
-    
+    private final Format format;
+
     private OutputStream outputStream;
     private JsonGenerator generator;
     private VectorSchemaRoot root;
     private boolean firstRowWritten = false;
 
     public JsonOutputStreamListener(Supplier<OutputStream> outputStreamSupplier, CompletableFuture<Void> future) {
-        this(outputStreamSupplier, future, true);
+        this(outputStreamSupplier, future, Format.ARRAY);
     }
 
     public JsonOutputStreamListener(Supplier<OutputStream> outputStreamSupplier, CompletableFuture<Void> future, boolean includeArrayBrackets) {
+        this(outputStreamSupplier, future, includeArrayBrackets ? Format.ARRAY : Format.SINGLE_OBJECT);
+    }
+
+    public JsonOutputStreamListener(Supplier<OutputStream> outputStreamSupplier, CompletableFuture<Void> future, Format format) {
         this.outputStreamSupplier = outputStreamSupplier;
         this.future = future;
-        this.includeArrayBrackets = includeArrayBrackets;
+        this.format = format;
     }
 
     @Override
@@ -71,11 +99,14 @@ public class JsonOutputStreamListener implements FlightProducer.ServerStreamList
     public synchronized void start(VectorSchemaRoot root, DictionaryProvider dictionaries, IpcOption option) {
         this.root = root;
         try {
-            if (includeArrayBrackets) {
+            // ARRAY and JSONL commit the response eagerly so an empty result still
+            // produces a valid body ("[]" / empty stream). SINGLE_OBJECT defers until
+            // the first row so a missing row can surface as an error status.
+            if (format == Format.ARRAY || format == Format.JSONL) {
                 ensureGenerator();
             }
-            logger.debug("JsonOutputStreamListener started with schema: {}, includeArrayBrackets: {}", 
-                    root.getSchema(), includeArrayBrackets);
+            logger.debug("JsonOutputStreamListener started with schema: {}, format: {}",
+                    root.getSchema(), format);
         } catch (Exception e) {
             logger.error("Error in start()", e);
             future.completeExceptionally(e);
@@ -86,8 +117,12 @@ public class JsonOutputStreamListener implements FlightProducer.ServerStreamList
         if (generator == null) {
             this.outputStream = outputStreamSupplier.get();
             this.generator = JSON_FACTORY.createGenerator(outputStream);
-            if (includeArrayBrackets) {
-                this.generator.writeStartArray();
+            switch (format) {
+                case ARRAY -> generator.writeStartArray();
+                // Suppress the default single-space separator between root-level values;
+                // JSONL writes its own newline after each object instead.
+                case JSONL -> generator.setRootValueSeparator(new SerializedString(""));
+                case SINGLE_OBJECT -> { /* bare object, no wrapper */ }
             }
         }
     }
@@ -131,11 +166,11 @@ public class JsonOutputStreamListener implements FlightProducer.ServerStreamList
     @Override
     public synchronized void completed() {
         try {
-            if (!firstRowWritten && !includeArrayBrackets) {
+            if (!firstRowWritten && format == Format.SINGLE_OBJECT) {
                 throw new NoSuchElementException("No rows found");
             }
             if (generator != null) {
-                if (includeArrayBrackets) {
+                if (format == Format.ARRAY) {
                     generator.writeEndArray();
                 }
                 generator.flush();
@@ -154,14 +189,17 @@ public class JsonOutputStreamListener implements FlightProducer.ServerStreamList
         List<FieldVector> vectors = root.getFieldVectors();
         int rowCount = root.getRowCount();
         for (int row = 0; row < rowCount; row++) {
-            if (!includeArrayBrackets && firstRowWritten) {
-                break; // Only write one row if not using array brackets
+            if (format == Format.SINGLE_OBJECT && firstRowWritten) {
+                break; // Only write the first row in single-object mode
             }
             generator.writeStartObject();
             for (FieldVector vector : vectors) {
                 writeField(vector, row);
             }
             generator.writeEndObject();
+            if (format == Format.JSONL) {
+                generator.writeRaw('\n'); // newline-delimit each row object
+            }
             firstRowWritten = true;
         }
     }

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/NamedQueryService.java
@@ -100,7 +100,10 @@ public class NamedQueryService implements HttpService, ControllerService {
 
         var callContext = ControllerService.createContext(request);
         var acceptHeader = request.headers().value(HeaderNames.ACCEPT);
-        boolean wantsTsv = acceptHeader.isPresent() && acceptHeader.get().contains(ContentTypes.TEXT_TSV);
+        String accept = acceptHeader.orElse("");
+        boolean wantsTsv = accept.contains(ContentTypes.TEXT_TSV);
+        boolean wantsJsonl = accept.contains(ContentTypes.APPLICATION_JSONL)
+                || accept.contains(ContentTypes.APPLICATION_X_NDJSON);
 
         CompletableFuture<Void> future;
         if (wantsTsv) {
@@ -108,6 +111,10 @@ public class NamedQueryService implements HttpService, ControllerService {
             future = new CompletableFuture<>();
             var listener = new TsvOutputStreamListener(() -> response.outputStream(), future);
             adaptor.getStreamNamedQuery(namedQuery.name(), namedQuery.parameters(), callContext, listener);
+        } else if (wantsJsonl) {
+            response.headers().set(HeaderNames.CONTENT_TYPE, ContentTypes.APPLICATION_JSONL_UTF8);
+            future = adaptor.streamJsonlNamedQuery(namedQuery.name(), namedQuery.parameters(),
+                    callContext, () -> response.outputStream());
         } else {
             response.headers().set(HeaderNames.CONTENT_TYPE, ContentTypes.APPLICATION_ARROW);
             var compressionCodec = ParameterUtils.getArrowCompression(request);

--- a/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/QueryService.java
+++ b/dazzleduck-sql-http/src/main/java/io/dazzleduck/sql/http/server/QueryService.java
@@ -50,13 +50,20 @@ public class QueryService extends AbstractQueryBasedService {
             var ticket = createTicket(statementHandle);
 
             var acceptHeader = request.headers().value(HeaderNames.ACCEPT);
-            boolean wantsTsv = acceptHeader.isPresent() && acceptHeader.get().contains(ContentTypes.TEXT_TSV);
+            String accept = acceptHeader.orElse("");
+            boolean wantsTsv = accept.contains(ContentTypes.TEXT_TSV);
+            boolean wantsJsonl = accept.contains(ContentTypes.APPLICATION_JSONL)
+                    || accept.contains(ContentTypes.APPLICATION_X_NDJSON);
 
             CompletableFuture<Void> future;
             if (wantsTsv) {
                 logger.debug("TSV output requested for query: {}", query.query());
                 response.header("Content-Type", ContentTypes.TEXT_TSV_UTF8);
                 future = httpFlightAdaptor.streamTsv(ticket, context, () -> response.outputStream());
+            } else if (wantsJsonl) {
+                logger.debug("JSONL output requested for query: {}", query.query());
+                response.header("Content-Type", ContentTypes.APPLICATION_JSONL_UTF8);
+                future = httpFlightAdaptor.streamJsonl(ticket, context, () -> response.outputStream());
             } else {
                 // Get Arrow compression codec from header (defaults to ZSTD)
                 CompressionUtil.CodecType compressionCodec = ParameterUtils.getArrowCompression(request);

--- a/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/HttpServerJsonlTest.java
+++ b/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/HttpServerJsonlTest.java
@@ -1,0 +1,270 @@
+package io.dazzleduck.sql.http.server;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.dazzleduck.sql.commons.ConnectionPool;
+import io.dazzleduck.sql.common.ContentTypes;
+import io.dazzleduck.sql.http.server.model.QueryRequest;
+import io.helidon.http.HeaderValues;
+import org.junit.jupiter.api.*;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HttpServerJsonlTest extends HttpServerTestBase {
+
+    @BeforeAll
+    static void setup() throws Exception {
+        initWarehouse();
+        initClient();
+        initPort();
+        startServer();
+        installArrowExtension();
+        ConnectionPool.execute("CREATE TABLE jsonl_test(id INTEGER, name VARCHAR, score INTEGER)");
+        ConnectionPool.execute("INSERT INTO jsonl_test VALUES (1, 'Alice', 10), (2, 'Bob', 20), (3, 'Carol', 30)");
+    }
+
+    @AfterAll
+    static void cleanup() throws Exception {
+        ConnectionPool.execute("DROP TABLE IF EXISTS jsonl_test");
+        cleanupWarehouse();
+    }
+
+    // ==================== BASIC QUERY TESTS ====================
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testQueryJsonlWithGet() throws Exception {
+        var query = "SELECT * FROM jsonl_test ORDER BY id";
+        var request = authenticatedRequestBuilder(uriForQuery(query))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        List<JsonNode> rows = parseJsonl(response.body());
+        assertEquals(3, rows.size());
+        assertEquals(1, rows.get(0).get("id").asInt());
+        assertEquals("Alice", rows.get(0).get("name").asText());
+        assertEquals(10, rows.get(0).get("score").asInt());
+        assertEquals("Carol", rows.get(2).get("name").asText());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testQueryJsonlWithPost() throws Exception {
+        var query = "SELECT * FROM jsonl_test ORDER BY id";
+        var body = objectMapper.writeValueAsBytes(new QueryRequest(query));
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + "/v1/query"))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        List<JsonNode> rows = parseJsonl(response.body());
+        assertEquals(3, rows.size());
+        assertEquals("Bob", rows.get(1).get("name").asText());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testQueryJsonlResponseContentType() throws Exception {
+        var request = authenticatedRequestBuilder(uriForQuery("SELECT 1 AS id"))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        var contentType = response.headers().firstValue("Content-Type").orElse("");
+        assertTrue(contentType.contains("application/jsonl"),
+                "Expected JSONL Content-Type but got: " + contentType);
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testNdjsonAcceptAlias() throws Exception {
+        var request = authenticatedRequestBuilder(uriForQuery("SELECT 42 AS answer"))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_X_NDJSON)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        List<JsonNode> rows = parseJsonl(response.body());
+        assertEquals(1, rows.size());
+        assertEquals(42, rows.get(0).get("answer").asInt());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testEachLineIsValidStandaloneJson() throws Exception {
+        var query = "SELECT * FROM jsonl_test ORDER BY id";
+        var request = authenticatedRequestBuilder(uriForQuery(query))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        // Body must NOT be a JSON array — no enclosing brackets.
+        assertFalse(response.body().trim().startsWith("["), "JSONL must not be a JSON array");
+        for (String line : response.body().split("\n")) {
+            if (line.isBlank()) continue;
+            var node = objectMapper.readTree(line); // throws if not valid JSON
+            assertTrue(node.isObject(), "Each line must be a JSON object: " + line);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testEmptyResultProducesEmptyBody() throws Exception {
+        var request = authenticatedRequestBuilder(uriForQuery("SELECT * FROM jsonl_test WHERE id = -999"))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        assertEquals("", response.body().trim());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testQueryMillionRowsSingleColumn() throws Exception {
+        var query = "SELECT generate_series FROM generate_series(1, 1000000)";
+        var request = authenticatedRequestBuilder(uriForQuery(query))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        List<JsonNode> rows = parseJsonl(response.body());
+        assertEquals(1000000, rows.size());
+        assertEquals(1, rows.get(0).get("generate_series").asInt());
+        assertEquals(1000000, rows.get(999999).get("generate_series").asInt());
+    }
+
+    // ==================== TYPE FIDELITY TESTS ====================
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testNumericTypesAreJsonNumbers() throws Exception {
+        var sql = "SELECT " +
+                "CAST(1 AS TINYINT) AS ti, " +
+                "CAST(2 AS SMALLINT) AS si, " +
+                "CAST(3 AS INTEGER) AS i, " +
+                "CAST(4 AS BIGINT) AS bi, " +
+                "CAST(1.5 AS FLOAT) AS f, " +
+                "CAST(2.5 AS DOUBLE) AS d, " +
+                "true AS b";
+        var request = authenticatedRequestBuilder(uriForQuery(sql))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        JsonNode row = parseJsonl(response.body()).get(0);
+        assertTrue(row.get("ti").isNumber());
+        assertEquals(1, row.get("ti").asInt());
+        assertEquals(4, row.get("bi").asLong());
+        assertEquals(1.5, row.get("f").asDouble(), 1e-6);
+        assertEquals(2.5, row.get("d").asDouble(), 1e-9);
+        assertTrue(row.get("b").isBoolean());
+        assertTrue(row.get("b").asBoolean());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testNullValuesAreJsonNull() throws Exception {
+        var sql = "SELECT NULL::INTEGER AS i, NULL::VARCHAR AS s, NULL::DATE AS d";
+        var request = authenticatedRequestBuilder(uriForQuery(sql))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        JsonNode row = parseJsonl(response.body()).get(0);
+        assertTrue(row.get("i").isNull());
+        assertTrue(row.get("s").isNull());
+        assertTrue(row.get("d").isNull());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testTemporalTypesAreIsoStrings() throws Exception {
+        var sql = "SELECT CAST('2026-03-12' AS DATE) AS d, " +
+                "CAST('2026-03-12 10:30:00' AS TIMESTAMP) AS ts";
+        var request = authenticatedRequestBuilder(uriForQuery(sql))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        JsonNode row = parseJsonl(response.body()).get(0);
+        assertEquals("2026-03-12", row.get("d").asText());
+        assertTrue(row.get("ts").asText().startsWith("2026-03-12"), "TIMESTAMP: " + row.get("ts").asText());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testNestedTypesAreRealJson() throws Exception {
+        var sql = "SELECT [1, 2, 3] AS arr, {'name': 'Alice', 'age': 30} AS s";
+        var request = authenticatedRequestBuilder(uriForQuery(sql))
+                .GET()
+                .header(HeaderValues.ACCEPT_JSON.name(), ContentTypes.APPLICATION_JSONL)
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        JsonNode row = parseJsonl(response.body()).get(0);
+        assertTrue(row.get("arr").isArray(), "List should be a JSON array");
+        assertEquals(3, row.get("arr").size());
+        assertEquals(2, row.get("arr").get(1).asInt());
+        assertTrue(row.get("s").isObject(), "Struct should be a JSON object");
+        assertEquals("Alice", row.get("s").get("name").asText());
+        assertEquals(30, row.get("s").get("age").asInt());
+    }
+
+    // ==================== FORMAT FALLBACK ====================
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testNoAcceptHeaderStillReturnsArrow() throws Exception {
+        var request = authenticatedRequestBuilder(uriForQuery("SELECT 1 AS id"))
+                .GET()
+                .build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        assertFalse(response.headers().firstValue("Content-Type").orElse("").contains("application/jsonl"),
+                "No Accept header should not return JSONL Content-Type");
+    }
+
+    // ==================== HELPERS ====================
+
+    private List<JsonNode> parseJsonl(String body) throws Exception {
+        List<JsonNode> rows = new ArrayList<>();
+        for (String line : body.split("\n")) {
+            if (line.isBlank()) continue;
+            rows.add(objectMapper.readTree(line));
+        }
+        return rows;
+    }
+
+    private URI uriForQuery(String sql) {
+        return URI.create(baseUrl + "/v1/query?q=" + URLEncoder.encode(sql, StandardCharsets.UTF_8));
+    }
+}

--- a/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/NamedQueryServiceTest.java
+++ b/dazzleduck-sql-http/src/test/java/io/dazzleduck/sql/http/server/NamedQueryServiceTest.java
@@ -174,6 +174,33 @@ public class NamedQueryServiceTest extends HttpServerTestBase {
         assertEquals(4, lines.length - 1, "generate_series(3) produces 4 rows: 0..3 inclusive");
     }
 
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void testHappyPath_jsonlResponseBodyAndContentType() throws IOException, InterruptedException {
+        var namedQuery = NamedQueryRequest.execute("get_series", Map.of("limit", "3"));
+        var body = objectMapper.writeValueAsBytes(namedQuery);
+
+        var request = authenticatedRequestBuilder(URI.create(baseUrl + ENDPOINT))
+                .header("Accept", ContentTypes.APPLICATION_JSONL)
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        assertTrue(response.headers().firstValue("Content-Type")
+                        .orElse("").contains(ContentTypes.APPLICATION_JSONL),
+                "JSONL path must set Content-Type: application/jsonl");
+
+        // Body must be newline-delimited JSON objects, not a JSON array.
+        assertFalse(response.body().strip().startsWith("["), "JSONL must not be a JSON array");
+        String[] lines = response.body().strip().split("\n");
+        assertEquals(4, lines.length, "generate_series(3) produces 4 rows: 0..3 inclusive");
+        var first = objectMapper.readTree(lines[0]);
+        assertTrue(first.isObject(), "Each line must be a JSON object: " + lines[0]);
+        assertEquals(0, first.get("v").asInt(), "First data row should be 0 (generate_series is 0-based)");
+        assertEquals(3, objectMapper.readTree(lines[3]).get("v").asInt());
+    }
+
     // -------------------------------------------------------------------------
     // Error cases
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds **JSON Lines (JSONL / NDJSON)** as a third output format for query results, alongside the existing Arrow IPC (default) and TSV:

- `POST/GET /v1/query` and `POST /v1/named-query` now emit JSONL when the client sends `Accept: application/jsonl` (or the de-facto alias `application/x-ndjson`)
- One JSON object per row, per line, newline-terminated, **no enclosing array** — streamable and append-friendly, matching the row-by-row streaming model TSV already uses
- Arrow IPC remains the default; TSV behavior is unchanged

## Type fidelity

Unlike TSV (which stringifies everything), JSONL preserves JSON types:

| Arrow type | JSONL representation |
|---|---|
| numerics, booleans, null | native JSON number / boolean / null |
| DATE, TIME, TIMESTAMP(TZ) | ISO-8601 string |
| LIST / STRUCT / MAP | real nested JSON array / object |

## Implementation

- **`JsonOutputStreamListener`**: replaced the `includeArrayBrackets` boolean with a `Format` enum (`ARRAY`, `SINGLE_OBJECT`, `JSONL`); old constructors kept for backward compatibility, so existing array/single-object callers (named-query list/get) are untouched
- **Latent bug fix**: registered `JavaTimeModule` (ISO output) on the fallback `ObjectMapper` — previously a non-TZ `TIMESTAMP` (`LocalDateTime`) crashed the stream in *any* JSON mode
- **`HttpFlightAdaptor.streamJsonl`** / **`NamedQueryServiceAdaptor.streamJsonlNamedQuery`** mirror the existing TSV streaming entry points; JSONL goes through the same ticket-based `getStreamStatement` path, so authorization/RLS enforcement is identical to Arrow/TSV
- Empty result → committed 200 with empty body (consistent with TSV's header-only response)

## Usage

```bash
curl -H "Accept: application/jsonl" "http://localhost:8081/v1/query?q=select%20*%20from%20t"
```

## Testing

- New `HttpServerJsonlTest` (12 tests): content types, NDJSON alias, per-line JSON validity / no-array invariant, empty result, 1M-row streaming, numeric/null/temporal/nested type fidelity, Arrow fallback
- New JSONL test in `NamedQueryServiceTest`
- All existing TSV + named-query tests pass (52/52 across the three suites, JDK 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)