### PR TITLE
feat(commons): prune view LEFT JOINs when the view is referenced inside a CTE

### DIFF
--- a/LEFT_JOIN_PRUNING_SPEC.md
+++ b/LEFT_JOIN_PRUNING_SPEC.md
@@ -166,6 +166,27 @@ no-op by reference identity. Explicit bail-outs:
   reference is the CTE, not the view; inlining the view body there would change
   results.
 
+### Scope-aware variant — view referenced inside a CTE
+
+`pruneUnusedLeftJoins(outerSqlAst, viewName, viewBodyAst)` extends the above to the
+case where the view is referenced inside a **CTE body** rather than at the outer
+top-level `FROM`, e.g. `WITH a AS (SELECT a_name FROM fv) SELECT * FROM a`. Passing
+`viewName` lets a reference be located by name. Two shapes are handled; everything
+else is the same-instance no-op:
+
+- **Top-level** — outer `FROM` is the view: delegates to the two-arg method, behaviour
+  unchanged.
+- **CTE-nested** — the view is in the `FROM` of exactly one CTE body. Column usage and
+  the STAR bail are evaluated **within that CTE body scope**, so an outer `SELECT *`
+  *over the CTE* (which expands to CTE columns, not view columns) does not block the
+  optimization. The pruned view body is inlined in place of the reference inside the CTE
+  body; the CTE's own `SELECT` list is untouched.
+
+Additional bail-outs for this variant: the view name is rebound by a CTE anywhere in the
+outer `WITH` (sibling/outer shadow); a bare/qualified STAR **within the CTE body** over
+the view; the view referenced by **more than one** CTE body (single reference only in
+this increment).
+
 Additional conservative rules:
 
 - **Projection pushdown is skipped** (join elimination still applies) when the

--- a/LEFT_JOIN_PRUNING_SPEC.md
+++ b/LEFT_JOIN_PRUNING_SPEC.md
@@ -182,11 +182,17 @@ else is the same-instance no-op:
   optimization. The pruned view body is inlined in place of the reference inside the CTE
   body; the CTE's own `SELECT` list is untouched.
 
-Additional bail-outs for this variant: the view name is rebound by a CTE anywhere in the
-outer `WITH` (sibling/outer shadow); a bare/qualified STAR **within the CTE body** over
-the view; the view referenced by **more than one** CTE body (single reference only in
-this increment); a **schema- or catalog-qualified** reference (`s2.fv`) — `viewName` is
-unqualified, and a qualified reference may be a *different*, same-named view.
+`viewName` may be **qualified** (`s2.fv`, `cat.s2.fv`); qualification must match the
+reference at the same level. An unqualified name matches only unqualified references —
+a qualified reference (`s2.fv`) may be a *different*, same-named view. A qualified name
+matches only identically-qualified references — an unqualified reference resolves via
+the search path, which is invisible at the AST level. Qualified references can never
+resolve to a CTE, so qualified names skip the CTE-shadow bail below.
+
+Additional bail-outs for this variant: an **unqualified** view name rebound by a CTE
+anywhere in the outer `WITH` (sibling/outer shadow); a bare/qualified STAR **within the
+CTE body** over the view; the view referenced by **more than one** CTE body (single
+reference only in this increment).
 
 Additional conservative rules:
 

--- a/LEFT_JOIN_PRUNING_SPEC.md
+++ b/LEFT_JOIN_PRUNING_SPEC.md
@@ -185,7 +185,8 @@ else is the same-instance no-op:
 Additional bail-outs for this variant: the view name is rebound by a CTE anywhere in the
 outer `WITH` (sibling/outer shadow); a bare/qualified STAR **within the CTE body** over
 the view; the view referenced by **more than one** CTE body (single reference only in
-this increment).
+this increment); a **schema- or catalog-qualified** reference (`s2.fv`) — `viewName` is
+unqualified, and a qualified reference may be a *different*, same-named view.
 
 Additional conservative rules:
 

--- a/LEFT_JOIN_PRUNING_SPEC.md
+++ b/LEFT_JOIN_PRUNING_SPEC.md
@@ -169,18 +169,23 @@ no-op by reference identity. Explicit bail-outs:
 ### Scope-aware variant — view referenced inside a CTE
 
 `pruneUnusedLeftJoins(outerSqlAst, viewName, viewBodyAst)` extends the above to the
-case where the view is referenced inside a **CTE body** rather than at the outer
-top-level `FROM`, e.g. `WITH a AS (SELECT a_name FROM fv) SELECT * FROM a`. Passing
-`viewName` lets a reference be located by name. Two shapes are handled; everything
-else is the same-instance no-op:
+case where the view is referenced inside **CTE bodies** and/or at the outer top-level
+`FROM`, e.g. `WITH a AS (SELECT a_name FROM fv) SELECT * FROM a`. Passing `viewName`
+lets references be located by name. Every eligible reference is pruned
+**independently within its own scope** — inlining is local and semantics-preserving,
+so any subset of references may be optimized:
 
-- **Top-level** — outer `FROM` is the view: delegates to the two-arg method, behaviour
-  unchanged.
-- **CTE-nested** — the view is in the `FROM` of exactly one CTE body. Column usage and
-  the STAR bail are evaluated **within that CTE body scope**, so an outer `SELECT *`
-  *over the CTE* (which expands to CTE columns, not view columns) does not block the
-  optimization. The pruned view body is inlined in place of the reference inside the CTE
-  body; the CTE's own `SELECT` list is untouched.
+- **Top-level** — outer `FROM` is the view. Usage is collected from the outer SELECT
+  scope **excluding CTE bodies** (a CTE cannot reference the outer `FROM`'s columns),
+  so sibling CTE usage does not pollute top-level pruning.
+- **CTE-nested** — the view is in the `FROM` of one or more CTE bodies. Column usage
+  and the STAR check are evaluated **within each CTE body scope**, so an outer
+  `SELECT *` *over the CTE* (which expands to CTE columns, not view columns) does not
+  block the optimization. The pruned view body is inlined in place of the reference
+  inside each CTE body; the CTE's own `SELECT` list is untouched.
+
+A scope whose view columns cannot be enumerated (a bare or qualified STAR **in that
+scope**) is skipped individually; other references are still pruned.
 
 `viewName` may be **qualified** (`s2.fv`, `cat.s2.fv`); qualification must match the
 reference at the same level. An unqualified name matches only unqualified references —
@@ -189,10 +194,8 @@ matches only identically-qualified references — an unqualified reference resol
 the search path, which is invisible at the AST level. Qualified references can never
 resolve to a CTE, so qualified names skip the CTE-shadow bail below.
 
-Additional bail-outs for this variant: an **unqualified** view name rebound by a CTE
-anywhere in the outer `WITH` (sibling/outer shadow); a bare/qualified STAR **within the
-CTE body** over the view; the view referenced by **more than one** CTE body (single
-reference only in this increment).
+Additional bail-out for this variant: an **unqualified** view name rebound by a CTE
+anywhere in the outer `WITH` (sibling/outer shadow) is a full no-op.
 
 Additional conservative rules:
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -976,31 +976,42 @@ public class Transformations {
      *       reference inside the CTE body; the CTE's own SELECT list is untouched.</li>
      * </ul>
      *
-     * <p>Bails when the view name is bound by a CTE anywhere in the outer WITH clause (a local CTE
-     * shadows the catalog view), when the view is referenced by more than one CTE body (single
-     * reference only in this increment), or on any structural surprise.
+     * <p>{@code viewName} may be qualified ({@code s2.fv}, {@code cat.s2.fv}); qualification must
+     * match the reference at the same level. An unqualified name matches only unqualified
+     * references (a qualified reference may be a different, same-named view); a qualified name
+     * matches only identically-qualified references (an unqualified reference resolves via the
+     * search path, invisible at the AST level).
+     *
+     * <p>Bails when an unqualified view name is bound by a CTE anywhere in the outer WITH clause
+     * (a local CTE shadows the catalog view — a qualified reference can never resolve to a CTE, so
+     * qualified names skip this bail), when the view is referenced by more than one CTE body
+     * (single reference only in this increment), or on any structural surprise.
      *
      * @param outerSqlAst parsed outer query (statement wrapper from {@code parseToTree})
-     * @param viewName    name of the catalog view to locate in {@code outerSqlAst}
+     * @param viewName    name of the catalog view to locate in {@code outerSqlAst}; may be
+     *                    schema/catalog-qualified
      * @param viewBodyAst parsed view body (the F/A/B join SELECT)
      * @return rewritten outer AST with the view inlined as a pruned subquery, or {@code outerSqlAst} unchanged
      */
     public static JsonNode pruneUnusedLeftJoins(JsonNode outerSqlAst, String viewName, JsonNode viewBodyAst) {
         try {
             if (viewName == null || viewName.isEmpty()) return pruneUnusedLeftJoins(outerSqlAst, viewBodyAst);
+            QualifiedName view = QualifiedName.parse(viewName);
             JsonNode outerNode = getFirstStatementNode(outerSqlAst);
             if (!NODE_TYPE_SELECT_NODE.equals(asText(outerNode, FIELD_TYPE))) return outerSqlAst;
 
-            // The view name is rebound by a CTE in this query's WITH clause → any reference to it
-            // resolves to that CTE, not the view. Too risky to inline anywhere here.
-            if (declaresCte(outerNode, viewName)) return outerSqlAst;
+            // An unqualified view name rebound by a CTE in this query's WITH clause → any
+            // unqualified reference to it resolves to that CTE, not the view. Too risky to inline
+            // anywhere here. (A qualified reference like s2.fv can never resolve to a CTE, so
+            // qualified view names skip this bail.)
+            if (!view.isQualified() && declaresCte(outerNode, view.table)) return outerSqlAst;
 
             // Top-level FROM is the view: the v1 path already handles this exactly.
             JsonNode topFrom = outerNode.get(FIELD_FROM_TABLE);
-            if (isViewRef(topFrom, viewName)) return pruneUnusedLeftJoins(outerSqlAst, viewBodyAst);
+            if (isViewRef(topFrom, view)) return pruneUnusedLeftJoins(outerSqlAst, viewBodyAst);
 
             // Otherwise, look for the view in the FROM of exactly one CTE body.
-            int cteIndex = findSoleCteReferencingView(outerNode, viewName);
+            int cteIndex = findSoleCteReferencingView(outerNode, view);
             if (cteIndex < 0) return outerSqlAst;
 
             ObjectNode rootCopy = (ObjectNode) outerSqlAst.deepCopy();
@@ -1021,26 +1032,61 @@ public class Transformations {
     }
 
     /**
-     * True if {@code fromRef} is a single BASE_TABLE whose name is {@code viewName}.
-     * {@code viewName} is unqualified in this increment, so a schema- or catalog-qualified
-     * reference ({@code s2.fv}) never matches — it may be a different, same-named view, and
-     * inlining {@code viewBodyAst} in its place would silently swap the view.
+     * A view name split into its optional catalog / optional schema / table parts.
+     * {@code fv} → table only; {@code s2.fv} → schema+table; {@code cat.s2.fv} → all three.
+     * Dotted parts inside quoted identifiers are not supported — a name with more than three
+     * parts is treated as never matching (the transform then degrades to its no-op).
      */
-    private static boolean isViewRef(JsonNode fromRef, String viewName) {
+    private record QualifiedName(String catalog, String schema, String table) {
+        static QualifiedName parse(String name) {
+            String[] parts = name.split("\\.");
+            return switch (parts.length) {
+                case 1 -> new QualifiedName(null, null, parts[0]);
+                case 2 -> new QualifiedName(null, parts[0], parts[1]);
+                case 3 -> new QualifiedName(parts[0], parts[1], parts[2]);
+                default -> new QualifiedName(null, null, null); // unmatchable
+            };
+        }
+
+        boolean isQualified() { return schema != null || catalog != null; }
+    }
+
+    /**
+     * True if {@code fromRef} is a single BASE_TABLE reference to {@code view}, with qualification
+     * matched at the same level:
+     * <ul>
+     *   <li>an <b>unqualified</b> view name matches only an unqualified reference — a qualified
+     *       reference ({@code s2.fv}) may be a different, same-named view;</li>
+     *   <li>a <b>qualified</b> view name matches only a reference qualified identically — an
+     *       unqualified reference resolves via the search path, which is invisible at the AST
+     *       level, so it never matches.</li>
+     * </ul>
+     */
+    private static boolean isViewRef(JsonNode fromRef, QualifiedName view) {
         if (fromRef == null
+                || view.table == null
                 || !NODE_TYPE_BASE_TABLE.equals(asText(fromRef, FIELD_TYPE))
-                || !viewName.equals(asText(fromRef, FIELD_TABLE_NAME))) return false;
-        String schema = asText(fromRef, FIELD_SCHEMA_NAME);
-        String catalog = asText(fromRef, FIELD_CATALOG_NAME);
-        return (schema == null || schema.isEmpty()) && (catalog == null || catalog.isEmpty());
+                || !view.table.equals(asText(fromRef, FIELD_TABLE_NAME))) return false;
+        return qualifierMatches(view.schema, asText(fromRef, FIELD_SCHEMA_NAME))
+                && qualifierMatches(view.catalog, asText(fromRef, FIELD_CATALOG_NAME));
+    }
+
+    /** Both absent, or both present and equal. */
+    private static boolean qualifierMatches(String expected, String actual) {
+        boolean expectedEmpty = expected == null || expected.isEmpty();
+        boolean actualEmpty = actual == null || actual.isEmpty();
+        if (expectedEmpty != actualEmpty) return false;
+        return expectedEmpty || expected.equals(actual);
     }
 
     /**
      * Index in the outer WITH map of the sole CTE whose body's FROM is a reference to {@code
-     * viewName} (not shadowed by that CTE body's own nested WITH); {@code -1} if none or more than
-     * one. Sibling/outer shadowing of the name is handled by the caller's {@link #declaresCte} bail.
+     * view} (not shadowed by that CTE body's own nested WITH — applicable to unqualified names
+     * only, since a qualified reference can never resolve to a CTE); {@code -1} if none or more
+     * than one. Sibling/outer shadowing of an unqualified name is handled by the caller's
+     * {@link #declaresCte} bail.
      */
-    private static int findSoleCteReferencingView(JsonNode outerNode, String viewName) {
+    private static int findSoleCteReferencingView(JsonNode outerNode, QualifiedName view) {
         JsonNode cteMap = outerNode.get(FIELD_CTE_MAP);
         if (cteMap == null) return -1;
         JsonNode map = cteMap.get(FIELD_MAP);
@@ -1050,7 +1096,8 @@ public class Transformations {
             JsonNode body = map.get(i).path("value").path("query").path("node");
             if (!NODE_TYPE_SELECT_NODE.equals(asText(body, FIELD_TYPE))) continue;
             JsonNode from = body.get(FIELD_FROM_TABLE);
-            if (isViewRef(from, viewName) && !referencesOuterCte(body, from)) {
+            if (isViewRef(from, view)
+                    && (view.isQualified() || !referencesOuterCte(body, from))) {
                 if (found >= 0) return -1;   // more than one reference — single-reference only
                 found = i;
             }

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -939,8 +939,15 @@ public class Transformations {
         }
     }
 
-    /** True if {@code fromRef}'s table name matches a CTE declared in {@code selectNode}'s WITH clause. */
+    /**
+     * True if {@code fromRef} can resolve to a CTE declared in {@code selectNode}'s WITH clause.
+     * A schema- or catalog-qualified reference ({@code s3.fv}) always resolves to the catalog and
+     * can never hit a CTE, so it returns false regardless of CTE names.
+     */
     private static boolean referencesOuterCte(JsonNode selectNode, JsonNode fromRef) {
+        String schema = asText(fromRef, FIELD_SCHEMA_NAME);
+        String catalog = asText(fromRef, FIELD_CATALOG_NAME);
+        if ((schema != null && !schema.isEmpty()) || (catalog != null && !catalog.isEmpty())) return false;
         return declaresCte(selectNode, asText(fromRef, FIELD_TABLE_NAME));
     }
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -1020,11 +1020,19 @@ public class Transformations {
         }
     }
 
-    /** True if {@code fromRef} is a single BASE_TABLE whose name is {@code viewName}. */
+    /**
+     * True if {@code fromRef} is a single BASE_TABLE whose name is {@code viewName}.
+     * {@code viewName} is unqualified in this increment, so a schema- or catalog-qualified
+     * reference ({@code s2.fv}) never matches — it may be a different, same-named view, and
+     * inlining {@code viewBodyAst} in its place would silently swap the view.
+     */
     private static boolean isViewRef(JsonNode fromRef, String viewName) {
-        return fromRef != null
-                && NODE_TYPE_BASE_TABLE.equals(asText(fromRef, FIELD_TYPE))
-                && viewName.equals(asText(fromRef, FIELD_TABLE_NAME));
+        if (fromRef == null
+                || !NODE_TYPE_BASE_TABLE.equals(asText(fromRef, FIELD_TYPE))
+                || !viewName.equals(asText(fromRef, FIELD_TABLE_NAME))) return false;
+        String schema = asText(fromRef, FIELD_SCHEMA_NAME);
+        String catalog = asText(fromRef, FIELD_CATALOG_NAME);
+        return (schema == null || schema.isEmpty()) && (catalog == null || catalog.isEmpty());
     }
 
     /**

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -971,17 +971,21 @@ public class Transformations {
      * the outer top-level FROM. {@code viewName} names the catalog view whose body is {@code
      * viewBodyAst}, so a reference to it can be located by name.
      *
-     * <p>Handles two shapes; anything else degrades to the same-instance no-op:
+     * <p>Every eligible reference is pruned <b>independently within its own scope</b> — inlining
+     * is local and semantics-preserving, so any subset of references may be optimized:
      * <ul>
-     *   <li><b>Top-level</b> — the outer FROM is the view: delegates to the v1 two-arg method,
-     *       behaviour unchanged.</li>
-     *   <li><b>CTE-nested</b> — the view is referenced in the FROM of exactly one CTE body
-     *       (e.g. {@code WITH a AS (SELECT a_name FROM fv) SELECT * FROM a}). Pruning is scoped to
-     *       that CTE body: column usage and the STAR bail are evaluated there, so an outer
+     *   <li><b>Top-level</b> — the outer FROM is the view. Usage is collected from the outer
+     *       SELECT scope <em>excluding</em> CTE bodies (a CTE cannot reference the outer FROM's
+     *       columns), so sibling CTE usage does not pollute top-level pruning.</li>
+     *   <li><b>CTE-nested</b> — the view is referenced in the FROM of one or more CTE bodies
+     *       (e.g. {@code WITH a AS (SELECT a_name FROM fv) SELECT * FROM a}). Each CTE body is its
+     *       own scope: column usage and the STAR check are evaluated there, so an outer
      *       {@code SELECT *} over the CTE — which expands to CTE columns, not view columns — does
      *       not block the optimization. The view body is inlined as a subquery in place of the
      *       reference inside the CTE body; the CTE's own SELECT list is untouched.</li>
      * </ul>
+     * A scope whose view columns cannot be enumerated (a bare or qualified STAR in that scope) is
+     * skipped individually; other references are still pruned.
      *
      * <p>{@code viewName} may be qualified ({@code s2.fv}, {@code cat.s2.fv}); qualification must
      * match the reference at the same level. An unqualified name matches only unqualified
@@ -989,16 +993,16 @@ public class Transformations {
      * matches only identically-qualified references (an unqualified reference resolves via the
      * search path, invisible at the AST level).
      *
-     * <p>Bails when an unqualified view name is bound by a CTE anywhere in the outer WITH clause
-     * (a local CTE shadows the catalog view — a qualified reference can never resolve to a CTE, so
-     * qualified names skip this bail), when the view is referenced by more than one CTE body
-     * (single reference only in this increment), or on any structural surprise.
+     * <p>Bails entirely when an unqualified view name is bound by a CTE anywhere in the outer WITH
+     * clause (a local CTE shadows the catalog view — a qualified reference can never resolve to a
+     * CTE, so qualified names skip this bail), or on any structural surprise.
      *
      * @param outerSqlAst parsed outer query (statement wrapper from {@code parseToTree})
      * @param viewName    name of the catalog view to locate in {@code outerSqlAst}; may be
      *                    schema/catalog-qualified
      * @param viewBodyAst parsed view body (the F/A/B join SELECT)
-     * @return rewritten outer AST with the view inlined as a pruned subquery, or {@code outerSqlAst} unchanged
+     * @return rewritten outer AST with each eligible view reference inlined as a pruned subquery,
+     *         or {@code outerSqlAst} unchanged
      */
     public static JsonNode pruneUnusedLeftJoins(JsonNode outerSqlAst, String viewName, JsonNode viewBodyAst) {
         try {
@@ -1013,29 +1017,53 @@ public class Transformations {
             // qualified view names skip this bail.)
             if (!view.isQualified() && declaresCte(outerNode, view.table)) return outerSqlAst;
 
-            // Top-level FROM is the view: the v1 path already handles this exactly.
-            JsonNode topFrom = outerNode.get(FIELD_FROM_TABLE);
-            if (isViewRef(topFrom, view)) return pruneUnusedLeftJoins(outerSqlAst, viewBodyAst);
-
-            // Otherwise, look for the view in the FROM of exactly one CTE body.
-            int cteIndex = findSoleCteReferencingView(outerNode, view);
-            if (cteIndex < 0) return outerSqlAst;
+            // Locate every eligible reference: the top-level FROM and/or any CTE bodies.
+            boolean topLevel = isViewRef(outerNode.get(FIELD_FROM_TABLE), view);
+            List<Integer> cteRefs = findCtesReferencingView(outerNode, view);
+            if (!topLevel && cteRefs.isEmpty()) return outerSqlAst;
 
             ObjectNode rootCopy = (ObjectNode) outerSqlAst.deepCopy();
             ObjectNode outerCopy = (ObjectNode) getFirstStatementNode(rootCopy);
-            ObjectNode cteBody = (ObjectNode) outerCopy.get(FIELD_CTE_MAP).get(FIELD_MAP)
-                    .get(cteIndex).get("value").get("query").get("node");
-            JsonNode viewRef = cteBody.get(FIELD_FROM_TABLE);
-
-            // Usage and STAR bail are scoped to the CTE body — the only place the view is visible.
-            UsedColumns use = new UsedColumns();
-            collectUsage(cteBody, use);
-            if (use.hasStar || use.hasQualifiedStar) return outerSqlAst;
-
-            return pruneViewBodyInto(cteBody, viewRef, viewBodyAst, use.columnNames) ? rootCopy : outerSqlAst;
+            boolean changed = false;
+            for (int idx : cteRefs) {
+                ObjectNode cteBody = (ObjectNode) outerCopy.get(FIELD_CTE_MAP).get(FIELD_MAP)
+                        .get(idx).get("value").get("query").get("node");
+                changed |= pruneScope(cteBody, viewBodyAst, collectScopedUsage(cteBody, false));
+            }
+            if (topLevel) {
+                // The top-level scope excludes CTE bodies: a CTE cannot see the outer FROM's
+                // columns, so its usage is irrelevant to this reference.
+                changed |= pruneScope(outerCopy, viewBodyAst, collectScopedUsage(outerCopy, true));
+            }
+            return changed ? rootCopy : outerSqlAst;
         } catch (RuntimeException e) {
             return outerSqlAst;
         }
+    }
+
+    /** Collect column usage for one SELECT scope, optionally skipping its {@code cte_map} subtree. */
+    private static UsedColumns collectScopedUsage(ObjectNode scopeNode, boolean excludeCteMap) {
+        UsedColumns use = new UsedColumns();
+        if (!excludeCteMap) {
+            collectUsage(scopeNode, use);
+            return use;
+        }
+        var fields = scopeNode.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            if (!FIELD_CTE_MAP.equals(entry.getKey())) collectUsage(entry.getValue(), use);
+        }
+        return use;
+    }
+
+    /**
+     * Prune the view body against one scope's usage and inline it in place of that scope's FROM.
+     * A scope containing a STAR cannot enumerate its view columns and is skipped (returns false);
+     * other references remain eligible.
+     */
+    private static boolean pruneScope(ObjectNode scopeNode, JsonNode viewBodyAst, UsedColumns use) {
+        if (use.hasStar || use.hasQualifiedStar) return false;
+        return pruneViewBodyInto(scopeNode, scopeNode.get(FIELD_FROM_TABLE), viewBodyAst, use.columnNames);
     }
 
     /**
@@ -1087,26 +1115,24 @@ public class Transformations {
     }
 
     /**
-     * Index in the outer WITH map of the sole CTE whose body's FROM is a reference to {@code
-     * view} (not shadowed by that CTE body's own nested WITH — applicable to unqualified names
-     * only, since a qualified reference can never resolve to a CTE); {@code -1} if none or more
-     * than one. Sibling/outer shadowing of an unqualified name is handled by the caller's
-     * {@link #declaresCte} bail.
+     * Indexes in the outer WITH map of every CTE whose body's FROM is a reference to {@code view}
+     * (not shadowed by that CTE body's own nested WITH — applicable to unqualified names only,
+     * since a qualified reference can never resolve to a CTE). Sibling/outer shadowing of an
+     * unqualified name is handled by the caller's {@link #declaresCte} bail.
      */
-    private static int findSoleCteReferencingView(JsonNode outerNode, QualifiedName view) {
+    private static List<Integer> findCtesReferencingView(JsonNode outerNode, QualifiedName view) {
         JsonNode cteMap = outerNode.get(FIELD_CTE_MAP);
-        if (cteMap == null) return -1;
+        if (cteMap == null) return List.of();
         JsonNode map = cteMap.get(FIELD_MAP);
-        if (map == null || !map.isArray()) return -1;
-        int found = -1;
+        if (map == null || !map.isArray()) return List.of();
+        List<Integer> found = new ArrayList<>();
         for (int i = 0; i < map.size(); i++) {
             JsonNode body = map.get(i).path("value").path("query").path("node");
             if (!NODE_TYPE_SELECT_NODE.equals(asText(body, FIELD_TYPE))) continue;
             JsonNode from = body.get(FIELD_FROM_TABLE);
             if (isViewRef(from, view)
                     && (view.isQualified() || !referencesOuterCte(body, from))) {
-                if (found >= 0) return -1;   // more than one reference — single-reference only
-                found = i;
+                found.add(i);
             }
         }
         return found;

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -941,7 +941,11 @@ public class Transformations {
 
     /** True if {@code fromRef}'s table name matches a CTE declared in {@code selectNode}'s WITH clause. */
     private static boolean referencesOuterCte(JsonNode selectNode, JsonNode fromRef) {
-        String name = asText(fromRef, FIELD_TABLE_NAME);
+        return declaresCte(selectNode, asText(fromRef, FIELD_TABLE_NAME));
+    }
+
+    /** True if {@code selectNode}'s WITH clause declares a CTE named {@code name}. */
+    private static boolean declaresCte(JsonNode selectNode, String name) {
         if (name == null || name.isEmpty()) return false;
         JsonNode cteMap = selectNode.get(FIELD_CTE_MAP);
         if (cteMap == null) return false;
@@ -952,6 +956,118 @@ public class Transformations {
             if (key != null && name.equals(key.asText())) return true;
         }
         return false;
+    }
+
+    /**
+     * Scope-aware variant of {@link #pruneUnusedLeftJoins(JsonNode, JsonNode)}: prune the view's
+     * unused LEFT JOINs even when the view is referenced <em>inside a CTE body</em> rather than at
+     * the outer top-level FROM. {@code viewName} names the catalog view whose body is {@code
+     * viewBodyAst}, so a reference to it can be located by name.
+     *
+     * <p>Handles two shapes; anything else degrades to the same-instance no-op:
+     * <ul>
+     *   <li><b>Top-level</b> — the outer FROM is the view: delegates to the v1 two-arg method,
+     *       behaviour unchanged.</li>
+     *   <li><b>CTE-nested</b> — the view is referenced in the FROM of exactly one CTE body
+     *       (e.g. {@code WITH a AS (SELECT a_name FROM fv) SELECT * FROM a}). Pruning is scoped to
+     *       that CTE body: column usage and the STAR bail are evaluated there, so an outer
+     *       {@code SELECT *} over the CTE — which expands to CTE columns, not view columns — does
+     *       not block the optimization. The view body is inlined as a subquery in place of the
+     *       reference inside the CTE body; the CTE's own SELECT list is untouched.</li>
+     * </ul>
+     *
+     * <p>Bails when the view name is bound by a CTE anywhere in the outer WITH clause (a local CTE
+     * shadows the catalog view), when the view is referenced by more than one CTE body (single
+     * reference only in this increment), or on any structural surprise.
+     *
+     * @param outerSqlAst parsed outer query (statement wrapper from {@code parseToTree})
+     * @param viewName    name of the catalog view to locate in {@code outerSqlAst}
+     * @param viewBodyAst parsed view body (the F/A/B join SELECT)
+     * @return rewritten outer AST with the view inlined as a pruned subquery, or {@code outerSqlAst} unchanged
+     */
+    public static JsonNode pruneUnusedLeftJoins(JsonNode outerSqlAst, String viewName, JsonNode viewBodyAst) {
+        try {
+            if (viewName == null || viewName.isEmpty()) return pruneUnusedLeftJoins(outerSqlAst, viewBodyAst);
+            JsonNode outerNode = getFirstStatementNode(outerSqlAst);
+            if (!NODE_TYPE_SELECT_NODE.equals(asText(outerNode, FIELD_TYPE))) return outerSqlAst;
+
+            // The view name is rebound by a CTE in this query's WITH clause → any reference to it
+            // resolves to that CTE, not the view. Too risky to inline anywhere here.
+            if (declaresCte(outerNode, viewName)) return outerSqlAst;
+
+            // Top-level FROM is the view: the v1 path already handles this exactly.
+            JsonNode topFrom = outerNode.get(FIELD_FROM_TABLE);
+            if (isViewRef(topFrom, viewName)) return pruneUnusedLeftJoins(outerSqlAst, viewBodyAst);
+
+            // Otherwise, look for the view in the FROM of exactly one CTE body.
+            int cteIndex = findSoleCteReferencingView(outerNode, viewName);
+            if (cteIndex < 0) return outerSqlAst;
+
+            ObjectNode rootCopy = (ObjectNode) outerSqlAst.deepCopy();
+            ObjectNode outerCopy = (ObjectNode) getFirstStatementNode(rootCopy);
+            ObjectNode cteBody = (ObjectNode) outerCopy.get(FIELD_CTE_MAP).get(FIELD_MAP)
+                    .get(cteIndex).get("value").get("query").get("node");
+            JsonNode viewRef = cteBody.get(FIELD_FROM_TABLE);
+
+            // Usage and STAR bail are scoped to the CTE body — the only place the view is visible.
+            UsedColumns use = new UsedColumns();
+            collectUsage(cteBody, use);
+            if (use.hasStar || use.hasQualifiedStar) return outerSqlAst;
+
+            return pruneViewBodyInto(cteBody, viewRef, viewBodyAst, use.columnNames) ? rootCopy : outerSqlAst;
+        } catch (RuntimeException e) {
+            return outerSqlAst;
+        }
+    }
+
+    /** True if {@code fromRef} is a single BASE_TABLE whose name is {@code viewName}. */
+    private static boolean isViewRef(JsonNode fromRef, String viewName) {
+        return fromRef != null
+                && NODE_TYPE_BASE_TABLE.equals(asText(fromRef, FIELD_TYPE))
+                && viewName.equals(asText(fromRef, FIELD_TABLE_NAME));
+    }
+
+    /**
+     * Index in the outer WITH map of the sole CTE whose body's FROM is a reference to {@code
+     * viewName} (not shadowed by that CTE body's own nested WITH); {@code -1} if none or more than
+     * one. Sibling/outer shadowing of the name is handled by the caller's {@link #declaresCte} bail.
+     */
+    private static int findSoleCteReferencingView(JsonNode outerNode, String viewName) {
+        JsonNode cteMap = outerNode.get(FIELD_CTE_MAP);
+        if (cteMap == null) return -1;
+        JsonNode map = cteMap.get(FIELD_MAP);
+        if (map == null || !map.isArray()) return -1;
+        int found = -1;
+        for (int i = 0; i < map.size(); i++) {
+            JsonNode body = map.get(i).path("value").path("query").path("node");
+            if (!NODE_TYPE_SELECT_NODE.equals(asText(body, FIELD_TYPE))) continue;
+            JsonNode from = body.get(FIELD_FROM_TABLE);
+            if (isViewRef(from, viewName) && !referencesOuterCte(body, from)) {
+                if (found >= 0) return -1;   // more than one reference — single-reference only
+                found = i;
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Shared core: prune {@code viewBodyAst} to {@code usedViewCols}, eliminate the now-unused LEFT
+     * JOINs, and inline the result as a subquery in place of {@code scopeNode}'s FROM. Mutates the
+     * (already-copied) {@code scopeNode}. Returns whether anything changed.
+     */
+    private static boolean pruneViewBodyInto(ObjectNode scopeNode, JsonNode viewRef,
+                                             JsonNode viewBodyAst, Set<String> usedViewCols) {
+        JsonNode bodyNode = getFirstStatementNode(viewBodyAst);
+        if (!NODE_TYPE_SELECT_NODE.equals(asText(bodyNode, FIELD_TYPE))) return false;
+        if (hasUnsupportedJoin(bodyNode.get(FIELD_FROM_TABLE))) return false;
+
+        ObjectNode body = (ObjectNode) bodyNode.deepCopy();
+        boolean changed = projectionPruningIsSafe(body) && pruneSelectList(body, usedViewCols);
+        changed |= eliminateUnusedLeftJoins(body);
+        if (!changed) return false;
+
+        scopeNode.set(FIELD_FROM_TABLE, wrapAsSubquery(body, effectiveId(viewRef), viewRef));
+        return true;
     }
 
     /** Column usage collected from the outer query: referenced name parts and STAR presence. */

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
@@ -108,6 +108,21 @@ public class PruneUnusedLeftJoinsTest {
         return Transformations.pruneUnusedLeftJoins(outer, body);
     }
 
+    /** Scope-aware (three-arg) prune, locating the view by name. */
+    private JsonNode prune(String outerSql, String viewName, String viewBody) throws Exception {
+        JsonNode outer = Transformations.parseToTree(conn, outerSql);
+        JsonNode body = Transformations.parseToTree(conn, viewBody);
+        return Transformations.pruneUnusedLeftJoins(outer, viewName, body);
+    }
+
+    /** Assert the three-arg (scope-aware) method bailed out: the exact input instance comes back. */
+    private void assertBailsOut(String outerSql, String viewName, String viewBody) throws Exception {
+        JsonNode outer = Transformations.parseToTree(conn, outerSql);
+        JsonNode body = Transformations.parseToTree(conn, viewBody);
+        JsonNode pruned = Transformations.pruneUnusedLeftJoins(outer, viewName, body);
+        assertSame(outer, pruned, "expected a no-op (same instance returned) for: " + outerSql);
+    }
+
     /** Assert the method bailed out: the exact input instance comes back. */
     private void assertBailsOut(String outerSql, String viewBody) throws Exception {
         JsonNode outer = Transformations.parseToTree(conn, outerSql);
@@ -378,5 +393,78 @@ public class PruneUnusedLeftJoinsTest {
                 "WITH fv AS (SELECT 42 AS f_col, 'zz' AS a_name, 'yy' AS b_name) " +
                 "SELECT f_col FROM fv";
         assertBailsOut(outer, VIEW_BODY);
+    }
+
+    // ---- scope-aware (three-arg) prune: view referenced inside a CTE body ----
+
+    @Test
+    void cteWrappingView_prunedWithinCteBody() throws Exception {
+        // The view is referenced inside the CTE `a`, which projects only a_name; the outer
+        // SELECT * is over the CTE (expands to a_name), NOT the view. b is used nowhere in the
+        // view's scope, so its join must be eliminated inside the CTE body.
+        String outer = "WITH a AS (SELECT a_name FROM fv) SELECT * FROM a";
+        JsonNode pruned = prune(outer, "fv", VIEW_BODY);
+
+        assertEquals(1, countJoins(pruned), "b join must be eliminated inside the CTE body; a kept");
+        String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertFalse(sql.contains("b_name"), "b_name projection should be gone");
+        assertEquivalentToView(pruned, outer);
+        assertEquals(3, exec(Transformations.parseToSql(conn, pruned)).size(),
+                "all fact rows (incl. the b-unmatched one) must survive");
+    }
+
+    @Test
+    void cteWrappingView_dimColumnUsedInCteBody_joinKept() throws Exception {
+        // b_name IS referenced in the CTE body (WHERE), so the b join must be kept; a_name unused
+        // in the view's scope, so the a join is eliminated.
+        String outer = "WITH a AS (SELECT f_col FROM fv WHERE b_name = 'b100') SELECT * FROM a";
+        JsonNode pruned = prune(outer, "fv", VIEW_BODY);
+
+        String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertTrue(sql.contains("b_name"), "b_name is used in the CTE body, so the b join must be kept");
+        assertFalse(sql.contains("a_name"), "a_name is unused, so the a join must be dropped");
+        assertEquals(1, countJoins(pruned));
+        assertEquivalentToView(pruned, outer);
+    }
+
+    @Test
+    void threeArg_topLevelViewFrom_delegatesToV1() throws Exception {
+        // When the outer FROM is the view itself, the scope-aware entry point matches the v1 path.
+        String outer = "SELECT f_col, a_name FROM fv WHERE f_col > 10";
+        JsonNode pruned = prune(outer, "fv", VIEW_BODY);
+
+        assertEquals(1, countJoins(pruned), "b eliminated, a kept");
+        assertEquivalentToView(pruned, outer);
+    }
+
+    @Test
+    void cteWrappingView_bothDimsUsedInCteBody_returnedUnchanged() throws Exception {
+        // Both dimension columns flow through the CTE body → nothing to prune or eliminate → no-op.
+        assertBailsOut("WITH a AS (SELECT a_name, b_name FROM fv) SELECT * FROM a", "fv", VIEW_BODY);
+    }
+
+    @Test
+    void starOverViewInsideCteBody_returnedUnchanged() throws Exception {
+        // The CTE body does SELECT * over the view — its columns cannot be enumerated, so the STAR
+        // bail applies within the view's scope even though the reference is nested.
+        assertBailsOut("WITH a AS (SELECT * FROM fv) SELECT a_name FROM a", "fv", VIEW_BODY);
+    }
+
+    @Test
+    void viewNameReboundBySiblingCte_returnedUnchanged() throws Exception {
+        // `fv` is declared as a CTE in the same WITH, so the reference inside CTE `a` resolves to
+        // that CTE, not the catalog view. Must bail.
+        String outer =
+                "WITH fv AS (SELECT 1 AS a_name), a AS (SELECT a_name FROM fv) SELECT * FROM a";
+        assertBailsOut(outer, "fv", VIEW_BODY);
+    }
+
+    @Test
+    void viewReferencedByTwoCteBodies_returnedUnchanged() throws Exception {
+        // More than one CTE references the view — single-reference only in this increment → no-op.
+        String outer =
+                "WITH a AS (SELECT a_name FROM fv), b AS (SELECT f_col FROM fv) " +
+                "SELECT * FROM a, b";
+        assertBailsOut(outer, "fv", VIEW_BODY);
     }
 }

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
@@ -147,6 +147,13 @@ public class PruneUnusedLeftJoinsTest {
         return c;
     }
 
+    /** Count non-overlapping occurrences of {@code needle} in {@code haystack}. */
+    private int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) count++;
+        return count;
+    }
+
     private List<List<Object>> exec(String sql) throws SQLException {
         Statement s = conn.createStatement();
         ResultSet rs = s.executeQuery(sql);
@@ -461,12 +468,52 @@ public class PruneUnusedLeftJoinsTest {
     }
 
     @Test
-    void viewReferencedByTwoCteBodies_returnedUnchanged() throws Exception {
-        // More than one CTE references the view — single-reference only in this increment → no-op.
+    void viewReferencedByTwoCteBodies_eachPrunedInItsOwnScope() throws Exception {
+        // Both CTEs reference the view; each is pruned against its own usage:
+        // CTE a uses a_name → keeps join a, drops join b. CTE b uses f_col only → drops both.
         String outer =
                 "WITH a AS (SELECT a_name FROM fv), b AS (SELECT f_col FROM fv) " +
                 "SELECT * FROM a, b";
-        assertBailsOut(outer, "fv", VIEW_BODY);
+        JsonNode pruned = prune(outer, "fv", VIEW_BODY);
+
+        String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertEquals(1, countOccurrences(sql, "left join"),
+                "one LEFT JOIN total: a's inline keeps join a; b's inline drops both");
+        assertFalse(sql.contains("b_name"), "b_name is unused in every scope");
+        assertEquivalentToView(pruned, outer);
+    }
+
+    @Test
+    void viewReferencedTopLevelAndInCte_bothPrunedIndependently() throws Exception {
+        // Top-level scope uses f_col + b_name (drops join a); CTE scope uses a_name (drops join b).
+        // Each reference is pruned against its own scope's usage.
+        String outer =
+                "WITH c AS (SELECT a_name FROM fv) " +
+                "SELECT f_col, b_name FROM fv WHERE f_col > (SELECT count(*) FROM c)";
+        JsonNode pruned = prune(outer, "fv", VIEW_BODY);
+
+        assertEquals(2, countJoins(pruned),
+                "top-level inline keeps join b, CTE inline keeps join a — one join each");
+        String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertTrue(sql.contains("a_name"), "CTE scope needs a_name");
+        assertTrue(sql.contains("b_name"), "top-level scope needs b_name");
+        assertEquivalentToView(pruned, outer);
+    }
+
+    @Test
+    void starScopeSkipped_otherReferenceStillPruned() throws Exception {
+        // CTE a does SELECT * over the view (columns not enumerable → skipped, stays a raw view
+        // reference); CTE b is still pruned to zero joins.
+        String outer =
+                "WITH a AS (SELECT * FROM fv), b AS (SELECT f_col FROM fv) " +
+                "SELECT a.a_name, b.f_col FROM a, b";
+        JsonNode pruned = prune(outer, "fv", VIEW_BODY);
+
+        String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertEquals(0, countOccurrences(sql, "left join"),
+                "b's inline drops both joins; a's star scope is skipped, not inlined");
+        assertTrue(sql.contains("fv"), "the star CTE must still reference the view by name");
+        assertEquivalentToView(pruned, outer);
     }
 
     // ---- review probes: edge cases ----

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
@@ -573,6 +573,31 @@ public class PruneUnusedLeftJoinsTest {
     }
 
     @Test
+    void qualifiedRefAtTopLevel_notShadowedByCteOfSameBareName_stillPruned() throws Exception {
+        // Top-level variant of the shadow case: a CTE named `fv` exists, but the top-level FROM is
+        // the qualified s3.fv, which always resolves to the catalog. The v1 delegation path must
+        // not let the bare-name CTE block pruning.
+        conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS s3");
+        conn.createStatement().execute("CREATE OR REPLACE VIEW s3.fv AS " + VIEW_BODY);
+        try {
+            String outer =
+                    "WITH fv AS (SELECT 1 AS t) " +
+                    "SELECT f_col, a_name FROM s3.fv WHERE f_col > (SELECT t FROM fv)";
+            JsonNode outerAst = Transformations.parseToTree(conn, outer);
+            JsonNode pruned = Transformations.pruneUnusedLeftJoins(
+                    outerAst, "s3.fv", Transformations.parseToTree(conn, VIEW_BODY));
+
+            assertNotSame(outerAst, pruned,
+                    "the bare-name CTE must not block pruning of the qualified s3.fv reference");
+            assertEquals(1, countJoins(pruned), "b eliminated, a kept — view inlined at top level");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS s3.fv");
+            conn.createStatement().execute("DROP SCHEMA IF EXISTS s3");
+        }
+    }
+
+    @Test
     void qualifiedRef_notShadowedByCteOfSameBareName_stillPruned() throws Exception {
         // A CTE named `fv` shadows only unqualified references; s3.fv always resolves to the
         // catalog. With a qualified viewName the shadow bail must not block pruning.

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -466,5 +467,62 @@ public class PruneUnusedLeftJoinsTest {
                 "WITH a AS (SELECT a_name FROM fv), b AS (SELECT f_col FROM fv) " +
                 "SELECT * FROM a, b";
         assertBailsOut(outer, "fv", VIEW_BODY);
+    }
+
+    // ---- review probes: edge cases ----
+
+    @Test
+    void nestedWithInsideCteBodyShadowsView_returnedUnchanged() throws Exception {
+        // The CTE body carries its own WITH that rebinds `fv`; the inner FROM fv resolves to that
+        // nested CTE, not the catalog view. Inlining the view body there would replace 'inner'
+        // with real fact data. Must bail.
+        String outer =
+                "WITH a AS (WITH fv AS (SELECT 'inner' AS a_name) SELECT a_name FROM fv) " +
+                "SELECT * FROM a";
+        assertBailsOut(outer, "fv", VIEW_BODY);
+    }
+
+    @Test
+    void viewInCteAndOuterFromJoin_cteBodyPruned_outerRefUntouched() throws Exception {
+        // The view appears both inside CTE `a` and in the outer FROM join. Only the CTE body is
+        // eligible (outer FROM is not a single base table); the outer fv reference must keep
+        // pointing at the real view and results must be equivalent.
+        String outer =
+                "WITH a AS (SELECT a_name FROM fv) " +
+                "SELECT a.a_name, fv.b_name FROM a, fv";
+        JsonNode outerAst = Transformations.parseToTree(conn, outer);
+        JsonNode pruned = Transformations.pruneUnusedLeftJoins(
+                outerAst, "fv", Transformations.parseToTree(conn, VIEW_BODY));
+
+        assertNotSame(outerAst, pruned, "the CTE body is eligible, so a rewrite must occur");
+        String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertTrue(sql.contains("fv"), "the outer FROM must still reference the view by name");
+        assertEquivalentToView(pruned, outer);
+    }
+
+    @Test
+    void schemaQualifiedSameNamedView_returnedUnchanged() throws Exception {
+        // s2.fv is a DIFFERENT view that happens to share the name. viewName "fv" is unqualified,
+        // so a schema-qualified reference must not match — inlining the default-schema body in its
+        // place would silently swap the view. Must bail.
+        conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS s2");
+        conn.createStatement().execute(
+                "CREATE OR REPLACE VIEW s2.fv AS SELECT 'other' AS a_name, 'x' AS b_name, 0 AS f_col");
+        try {
+            assertBailsOut("WITH a AS (SELECT a_name FROM s2.fv) SELECT * FROM a", "fv", VIEW_BODY);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS s2.fv");
+            conn.createStatement().execute("DROP SCHEMA IF EXISTS s2");
+        }
+    }
+
+    @Test
+    void aliasedViewRefInCteBody_pruned() throws Exception {
+        // The view is referenced with an alias inside the CTE body; qualification uses the alias.
+        String outer = "WITH a AS (SELECT x.a_name FROM fv x) SELECT * FROM a";
+        JsonNode pruned = prune(outer, "fv", VIEW_BODY);
+
+        assertEquals(1, countJoins(pruned), "b join eliminated; a kept");
+        assertEquivalentToView(pruned, outer);
     }
 }

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
@@ -525,4 +525,71 @@ public class PruneUnusedLeftJoinsTest {
         assertEquals(1, countJoins(pruned), "b join eliminated; a kept");
         assertEquivalentToView(pruned, outer);
     }
+
+    // ---- qualified viewName matching ----
+
+    @Test
+    void qualifiedViewName_matchesQualifiedRefInCteBody() throws Exception {
+        // viewName "s3.fv" must match FROM s3.fv inside the CTE body and prune there.
+        conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS s3");
+        conn.createStatement().execute("CREATE OR REPLACE VIEW s3.fv AS " + VIEW_BODY);
+        try {
+            String outer = "WITH a AS (SELECT a_name FROM s3.fv) SELECT * FROM a";
+            JsonNode pruned = prune(outer, "s3.fv", VIEW_BODY);
+
+            assertEquals(1, countJoins(pruned), "b join eliminated inside the CTE body; a kept");
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertFalse(sql.contains("b_name"), "b_name projection should be gone");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS s3.fv");
+            conn.createStatement().execute("DROP SCHEMA IF EXISTS s3");
+        }
+    }
+
+    @Test
+    void qualifiedViewName_matchesQualifiedRefAtTopLevel() throws Exception {
+        // Top-level FROM s3.fv with viewName "s3.fv" delegates to the v1 path.
+        conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS s3");
+        conn.createStatement().execute("CREATE OR REPLACE VIEW s3.fv AS " + VIEW_BODY);
+        try {
+            String outer = "SELECT f_col, a_name FROM s3.fv WHERE f_col > 10";
+            JsonNode pruned = prune(outer, "s3.fv", VIEW_BODY);
+
+            assertEquals(1, countJoins(pruned), "b eliminated, a kept");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS s3.fv");
+            conn.createStatement().execute("DROP SCHEMA IF EXISTS s3");
+        }
+    }
+
+    @Test
+    void qualifiedViewName_doesNotMatchUnqualifiedRef() throws Exception {
+        // An unqualified FROM fv resolves via the search path — invisible at the AST level — so a
+        // qualified viewName must not match it. No-op.
+        assertBailsOut("WITH a AS (SELECT a_name FROM fv) SELECT * FROM a", "s3.fv", VIEW_BODY);
+        assertBailsOut("SELECT f_col, a_name FROM fv", "s3.fv", VIEW_BODY);
+    }
+
+    @Test
+    void qualifiedRef_notShadowedByCteOfSameBareName_stillPruned() throws Exception {
+        // A CTE named `fv` shadows only unqualified references; s3.fv always resolves to the
+        // catalog. With a qualified viewName the shadow bail must not block pruning.
+        conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS s3");
+        conn.createStatement().execute("CREATE OR REPLACE VIEW s3.fv AS " + VIEW_BODY);
+        try {
+            String outer =
+                    "WITH fv AS (SELECT 'cte' AS tag), a AS (SELECT a_name FROM s3.fv) " +
+                    "SELECT a.a_name, fv.tag FROM a, fv";
+            JsonNode pruned = prune(outer, "s3.fv", VIEW_BODY);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertFalse(sql.contains("b_name"), "b join must be pruned despite the fv-named CTE");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS s3.fv");
+            conn.createStatement().execute("DROP SCHEMA IF EXISTS s3");
+        }
+    }
 }


### PR DESCRIPTION
## What

Follow-up to #362. Adds a scope-aware overload:

```
pruneUnusedLeftJoins(outerSqlAst, viewName, viewBodyAst)
```

that prunes a fact/dimension view's unused `LEFT JOIN`s wherever the view is referenced — at the outer top-level `FROM` **and/or inside any number of CTE bodies** — locating references by (optionally qualified) name.

### Example (previously a no-op, now optimized)

```sql
-- view fv: SELECT f.*, a.a_name, b.b_name
--          FROM f LEFT JOIN a ON f.a_id=a.a_id LEFT JOIN b ON f.b_id=b.b_id
WITH a AS (SELECT a_name FROM fv) SELECT * FROM a;
-- becomes (LEFT JOIN b eliminated, b_name dropped):
WITH a AS (SELECT a_name FROM (SELECT f.*, a.a_name FROM f LEFT JOIN a ON f.a_id=a.a_id) AS fv)
SELECT * FROM a;
```

## Design

The v1 transform was hardwired to one scope — "the top-level SELECT whose FROM is the view." This makes it scope-aware. **Every eligible reference is pruned independently within its own scope** — inlining is local and semantics-preserving, so any subset of references may be optimized:

- **Top-level** — usage collected from the outer SELECT scope *excluding* CTE bodies (a CTE cannot reference the outer FROM's columns), so sibling CTE usage doesn't pollute top-level pruning.
- **CTE-nested** — each CTE body is its own scope: usage and the STAR check are evaluated there, so an outer `SELECT *` *over the CTE* (which expands to CTE columns, not view columns) doesn't block the optimization.
- A scope containing a STAR (view columns not enumerable) is **skipped individually**; other references still prune.

**Qualified names**: `viewName` may be `fv`, `s2.fv`, or `cat.s2.fv`. Matching is level-exact in both directions — an unqualified name never matches a qualified reference (may be a different, same-named view), and a qualified name never matches an unqualified reference (search-path resolution is invisible at the AST level). Qualified references can never resolve to a CTE, so they are immune to CTE shadowing.

## Correctness / bail-outs (same-instance no-op)

Everything the v1 method guarded, plus:
- **Unqualified** view name rebound by a CTE anywhere in the outer `WITH` (sibling or outer shadow, incl. nested WITH inside a CTE body) — the reference resolves to the CTE, not the view.
- Qualification mismatch in either direction (see above).

Still pure AST-in/AST-out; any structural surprise degrades to the no-op.

## Review findings fixed during the PR (see comments)

- `isViewRef` originally matched by bare `table_name` — a CTE body referencing a same-named view in another schema (`s2.fv`) got the *wrong* view body inlined. Fixed with level-exact qualification matching.
- `referencesOuterCte` matched CTEs by bare name even for qualified refs, blocking legitimate top-level pruning of `s3.fv` when a CTE named `fv` existed. Qualified refs now never match CTEs.

## Scope (intentional limits)

Not yet: a CTE body doing `SELECT *` from the view while the outer selects a subset (needs projection-through-a-star across scopes — that scope is skipped, others still prune); view references nested deeper than a scope's direct FROM (inside joins/subqueries); quoted identifiers containing dots.

## Tests

`PruneUnusedLeftJoinsTest` grew 17 → 35, covering: the CTE-wrapping example (elimination + row preservation + equivalence vs the real view), per-scope pruning of two CTE references, top-level + CTE pruned independently (a different join survives in each scope), star-scope skipped while siblings prune, dim column used only in the CTE body, nested/sibling CTE shadowing, schema-qualified same-named view regression, qualified-name matching (CTE-nested, top-level, vs-unqualified no-op, immune to bare-name CTE shadow), aliased refs, and dual reference (CTE + outer join). All 35 + 3 DuckLake tests pass (JDK 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)