### PR TITLE
feat(commons): prune view LEFT JOINs through the RLS row-filter CTE

### DIFF
--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -1028,7 +1028,14 @@ public class Transformations {
             for (int idx : cteRefs) {
                 ObjectNode cteBody = (ObjectNode) outerCopy.get(FIELD_CTE_MAP).get(FIELD_MAP)
                         .get(idx).get("value").get("query").get("node");
-                changed |= pruneScope(cteBody, viewBodyAst, collectScopedUsage(cteBody, false));
+                if (isStarFilterCteBody(cteBody)) {
+                    // Row-filter wrapper `SELECT * FROM <view> WHERE <filter>` (the RLS authorizer's
+                    // output): its own STAR hides the real column usage, which lives in the CTE's
+                    // consumers. Recover it from there rather than bailing on the STAR.
+                    changed |= pruneStarFilterCte(outerCopy, cteBody, viewBodyAst);
+                } else {
+                    changed |= pruneScope(cteBody, viewBodyAst, collectScopedUsage(cteBody, false));
+                }
             }
             if (topLevel) {
                 // The top-level scope excludes CTE bodies: a CTE cannot see the outer FROM's
@@ -1064,6 +1071,55 @@ public class Transformations {
     private static boolean pruneScope(ObjectNode scopeNode, JsonNode viewBodyAst, UsedColumns use) {
         if (use.hasStar || use.hasQualifiedStar) return false;
         return pruneViewBodyInto(scopeNode, scopeNode.get(FIELD_FROM_TABLE), viewBodyAst, use.columnNames);
+    }
+
+    /**
+     * The signature of a row-filter wrapper CTE body: exactly a single bare {@code SELECT *} over
+     * (already matched as) the view, plus a WHERE clause. This is precisely what the
+     * RESTRICT_READ_ONLY authorizer emits (`SELECT * FROM <view> WHERE <rls-filter>`), and it is the
+     * only STAR-over-view shape {@link #pruneStarFilterCte} handles — a plain {@code SELECT * FROM
+     * view} (no filter) keeps the conservative STAR bail.
+     */
+    private static boolean isStarFilterCteBody(ObjectNode cteBody) {
+        JsonNode where = cteBody.get(FIELD_WHERE_CLAUSE);
+        if (where == null || where.isNull()) return false;
+        JsonNode selectList = cteBody.get(FIELD_SELECT_LIST);
+        if (!(selectList instanceof ArrayNode list) || list.size() != 1) return false;
+        return STAR_CLASS.equals(asText(list.get(0), FIELD_CLASS));
+    }
+
+    /**
+     * Prune a view referenced inside a CTE body whose own SELECT list is a STAR — most importantly
+     * the RESTRICT_READ_ONLY authorizer's row-filter wrapper
+     * {@code ___t AS (SELECT * FROM <view> WHERE <rls-filter>)}. The STAR forwards every column to
+     * the CTE's consumers, so {@link #pruneScope} (which bails on any STAR) cannot drive elimination
+     * here. The columns actually needed are recovered from the union of:
+     * <ul>
+     *   <li>the enclosing scope's references to the CTE — its <b>consumers</b>
+     *       ({@code consumerScope} minus its own CTE bodies), and</li>
+     *   <li>the CTE body's own <b>WHERE</b> — the filter's columns: the wrapper still applies the
+     *       filter over the inlined subquery, so those columns must survive pruning or the wrapper
+     *       fails to bind.</li>
+     * </ul>
+     * The view body is then inlined and its now-unused LEFT JOINs eliminated, leaving the wrapper's
+     * {@code SELECT *} and {@code WHERE} intact over the pruned subquery.
+     *
+     * <p>No-op (returns false) when the consumer scope itself contains a STAR over the CTE — the
+     * view's columns can't be enumerated there, so no narrowing is safe. Consumer usage is read from
+     * {@code consumerScope} excluding its CTE bodies, matching the authorizer's output shape (the
+     * filter-CTE is consumed at the top level). Over-collection from sibling references is harmless
+     * (keeps extra columns → fewer joins dropped, never a wrong result), and the projection-only
+     * change is fail-safe: a missed column yields a bind error, never an unfiltered row.
+     */
+    private static boolean pruneStarFilterCte(ObjectNode consumerScope, ObjectNode cteBody,
+                                              JsonNode viewBodyAst) {
+        UsedColumns consumer = collectScopedUsage(consumerScope, true);
+        if (consumer.hasStar || consumer.hasQualifiedStar) return false;
+        Set<String> usedViewCols = new HashSet<>(consumer.columnNames);
+        UsedColumns filterUse = new UsedColumns();
+        collectUsage(cteBody.get(FIELD_WHERE_CLAUSE), filterUse);
+        usedViewCols.addAll(filterUse.columnNames);
+        return pruneViewBodyInto(cteBody, cteBody.get(FIELD_FROM_TABLE), viewBodyAst, usedViewCols);
     }
 
     /**

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ducklake/PruneUnusedLeftJoinsFilterCteDuckLakeTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ducklake/PruneUnusedLeftJoinsFilterCteDuckLakeTest.java
@@ -1,0 +1,237 @@
+package io.dazzleduck.sql.commons.ducklake;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.dazzleduck.sql.commons.ConnectionPool;
+import io.dazzleduck.sql.commons.Transformations;
+import io.dazzleduck.sql.commons.authorization.SqlAuthorizer;
+import org.duckdb.DuckDBConnection;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Approach-A prototype coverage: join elimination through the RLS authorizer's row-filter CTE.
+ *
+ * <p>The RESTRICT_READ_ONLY authorizer rewrites {@code SELECT <cols> FROM <view> WHERE <rw>} into
+ * <pre>WITH ___view AS (SELECT * FROM view WHERE &lt;rls-filter&gt;) SELECT &lt;cols&gt; FROM ___view WHERE &lt;rw&gt;</pre>
+ * The scope-aware {@link Transformations#pruneUnusedLeftJoins(JsonNode, String, JsonNode)} must see
+ * <em>through</em> that injected {@code SELECT *} — recovering used columns from the CTE's consumers
+ * plus the filter's own WHERE — and still eliminate the view's unused LEFT JOINs, for every role,
+ * with an identical result set. This is what {@code classic-search-v2-join-pruning.md} (Approach A)
+ * specifies for classic-search v2, where the view stays the authorization target.
+ */
+public class PruneUnusedLeftJoinsFilterCteDuckLakeTest {
+
+    @TempDir
+    static Path WORKSPACE;
+
+    private static final String CATALOG = "dl_fc";
+    private static DuckDBConnection conn;
+
+    // Fact (DuckLake, hidden rowid projected as `rid`) LEFT JOIN two dimensions for their names.
+    private static final String VIEW_BODY =
+            "SELECT f.rowid AS rid, f.f_id, f.f_col, a.a_name, b.b_name " +
+            "FROM " + CATALOG + ".fact f " +
+            "LEFT JOIN " + CATALOG + ".dim_a a ON f.a_id = a.a_id " +
+            "LEFT JOIN " + CATALOG + ".dim_b b ON f.b_id = b.b_id";
+
+    // Snapshot-aware variant (classic-search v2's AT-view): the AT lives on the retained fact ref.
+    private static final String VIEW_BODY_AT =
+            "SELECT f.rowid AS rid, f.f_id, f.f_col, a.a_name, b.b_name " +
+            "FROM " + CATALOG + ".fact f " +
+            "AT (TIMESTAMP => COALESCE(TRY_CAST(getvariable('cs2_as_of') AS TIMESTAMPTZ), now())) " +
+            "LEFT JOIN " + CATALOG + ".dim_a a ON f.a_id = a.a_id " +
+            "LEFT JOIN " + CATALOG + ".dim_b b ON f.b_id = b.b_id";
+
+    @BeforeAll
+    static void setup() throws SQLException {
+        String ws = WORKSPACE.toString();
+        conn = ConnectionPool.getConnection();
+        exec("INSTALL ducklake");
+        exec("LOAD ducklake");
+        exec("ATTACH 'ducklake:" + ws + "/metadata' AS " + CATALOG + " (DATA_PATH '" + ws + "/data')");
+        exec("CREATE TABLE " + CATALOG + ".fact(f_id INT, a_id INT, b_id INT, f_col INT)");
+        // rowid 0,1,2; row (2,10,999,15) has a b_id with no match in dim_b (LEFT-JOIN unmatched).
+        exec("INSERT INTO " + CATALOG + ".fact VALUES (1,10,100,5),(2,10,999,15),(3,20,100,25)");
+        exec("CREATE TABLE " + CATALOG + ".dim_a(a_id INT, a_name VARCHAR)");
+        exec("INSERT INTO " + CATALOG + ".dim_a VALUES (10,'a10'),(20,'a20')");
+        exec("CREATE TABLE " + CATALOG + ".dim_b(b_id INT, b_name VARCHAR)");
+        exec("INSERT INTO " + CATALOG + ".dim_b VALUES (100,'b100')");
+        exec("CREATE VIEW fv AS " + VIEW_BODY);
+        exec("CREATE VIEW fv_at AS " + VIEW_BODY_AT);
+    }
+
+    @AfterAll
+    static void tearDown() throws SQLException {
+        exec("DROP VIEW IF EXISTS fv");
+        exec("DROP VIEW IF EXISTS fv_at");
+        exec("DETACH " + CATALOG);
+        conn.close();
+    }
+
+    private static void exec(String sql) throws SQLException {
+        try (Statement s = conn.createStatement()) {
+            s.execute(sql);
+        }
+    }
+
+    // ---- helpers ----
+
+    /** Emulate the authorizer: wrap {@code viewName} in a `SELECT * FROM view WHERE <filter>` CTE. */
+    private JsonNode authorize(String outerSql, String filter) throws Exception {
+        JsonNode query = Transformations.parseToTree(conn, outerSql);
+        JsonNode filterNode = SqlAuthorizer.compileFilterString(filter);
+        return Transformations.injectFilterCtes(query, filterNode);
+    }
+
+    private JsonNode pruneThroughFilterCte(String outerSql, String filter, String viewName,
+                                           String viewBody) throws Exception {
+        JsonNode authorized = authorize(outerSql, filter);
+        JsonNode body = Transformations.parseToTree(conn, viewBody);
+        return Transformations.pruneUnusedLeftJoins(authorized, viewName, body);
+    }
+
+    private int countJoins(JsonNode node) {
+        if (node == null) return 0;
+        int c = 0;
+        if (node.isObject()) {
+            JsonNode type = node.get("type");
+            if (type != null && "JOIN".equals(type.asText())) c++;
+            var it = node.fields();
+            while (it.hasNext()) c += countJoins(it.next().getValue());
+        } else if (node.isArray()) {
+            for (JsonNode child : node) c += countJoins(child);
+        }
+        return c;
+    }
+
+    private List<List<Object>> execRows(String sql) throws SQLException {
+        try (Statement s = conn.createStatement(); ResultSet rs = s.executeQuery(sql)) {
+            int cols = rs.getMetaData().getColumnCount();
+            List<List<Object>> rows = new ArrayList<>();
+            while (rs.next()) {
+                List<Object> row = new ArrayList<>();
+                for (int i = 1; i <= cols; i++) row.add(rs.getObject(i));
+                rows.add(row);
+            }
+            return rows;
+        }
+    }
+
+    /** The pruned query and the un-pruned authorized query must return the same rows. Compared as a
+     *  multiset (sorted): neither query has an ORDER BY, so row order is not guaranteed and differs
+     *  once the join is eliminated — only the set of rows (and its cardinality) is contractual. */
+    private void assertRowsEqualAuthorized(JsonNode pruned, String outerSql, String filter)
+            throws Exception {
+        String prunedSql = Transformations.parseToSql(conn, pruned);
+        String authorizedSql = Transformations.parseToSql(conn, authorize(outerSql, filter));
+        assertEquals(sortedRepr(execRows(authorizedSql)), sortedRepr(execRows(prunedSql)),
+                "pruned result set must equal the un-pruned authorized result set");
+    }
+
+    private List<String> sortedRepr(List<List<Object>> rows) {
+        List<String> repr = new ArrayList<>();
+        for (List<Object> row : rows) repr.add(String.valueOf(row));
+        repr.sort(null);
+        return repr;
+    }
+
+    // ---- tests ----
+
+    @Test
+    void throughFilterCte_onlyDimAUsed_dropsJoinB() throws Exception {
+        String outer = "SELECT rid, a_name FROM fv";
+        JsonNode pruned = pruneThroughFilterCte(outer, "f_col > 0", "fv", VIEW_BODY);
+
+        assertEquals(1, countJoins(pruned),
+                "unused dim_b join must be eliminated through the filter-CTE; dim_a kept");
+        String prunedSql = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertFalse(prunedSql.contains("b_name"), "dim_b projection should be gone: " + prunedSql);
+        assertTrue(prunedSql.contains("f_col"), "filter column f_col must survive in the pruned body");
+        assertRowsEqualAuthorized(pruned, outer, "f_col > 0");
+    }
+
+    @Test
+    void throughFilterCte_neitherDimUsed_dropsBothJoins() throws Exception {
+        // Projection + filter reference only fact columns → both dimension joins eliminable.
+        String outer = "SELECT rid, f_col FROM fv";
+        JsonNode pruned = pruneThroughFilterCte(outer, "f_id > 0", "fv", VIEW_BODY);
+
+        assertEquals(0, countJoins(pruned), "both dimension joins must be eliminated");
+        assertRowsEqualAuthorized(pruned, outer, "f_id > 0");
+    }
+
+    @Test
+    void filterColumnNotInProjection_survivesPruning() throws Exception {
+        // The reconciliation case: f_id is referenced ONLY by the RLS filter, never projected.
+        // The pruned body must still project it (from the CTE WHERE), or the wrapper won't bind.
+        String outer = "SELECT rid, a_name FROM fv";
+        JsonNode pruned = pruneThroughFilterCte(outer, "f_id = 2", "fv", VIEW_BODY);
+
+        assertEquals(1, countJoins(pruned));
+        String prunedSql = Transformations.parseToSql(conn, pruned);
+        // Binds + executes: only rowid 1 (f_id=2) matches.
+        List<List<Object>> rows = execRows(prunedSql);
+        assertEquals(1, rows.size(), "filter f_id=2 selects exactly one row");
+        assertRowsEqualAuthorized(pruned, outer, "f_id = 2");
+    }
+
+    @Test
+    void unmatchedLeftJoinRow_retainedAfterElimination() throws Exception {
+        // rowid 1 (b_id=999) has no dim_b match; eliminating the LEFT JOIN must not drop it.
+        String outer = "SELECT rid, a_name FROM fv";
+        JsonNode pruned = pruneThroughFilterCte(outer, "f_col > 0", "fv", VIEW_BODY);
+
+        assertEquals(1, countJoins(pruned));
+        List<List<Object>> rows = execRows(Transformations.parseToSql(conn, pruned));
+        assertEquals(3, rows.size(), "all three fact rows (incl. the dim_b-unmatched one) must remain");
+    }
+
+    @Test
+    void atTimeTravel_preservedThroughFilterCte() throws Exception {
+        String outer = "SELECT rid, a_name FROM fv_at";
+        JsonNode pruned = pruneThroughFilterCte(outer, "f_col > 0", "fv_at", VIEW_BODY_AT);
+
+        assertEquals(1, countJoins(pruned), "dim_b join eliminated even with an AT clause on the fact");
+        String lower = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertFalse(lower.contains("b_name"), "dim_b projection should be gone");
+        assertTrue(lower.contains("getvariable"),
+                "AT(TIMESTAMP => …) must be preserved through the filter-CTE: " + lower);
+        assertEquals(3, execRows(Transformations.parseToSql(conn, pruned)).size());
+    }
+
+    @Test
+    void outerStarOverCte_noOp_viewNotInlined() throws Exception {
+        // `SELECT *` over the CTE needs every view column → cannot enumerate → must NOT prune.
+        String outer = "SELECT * FROM fv";
+        JsonNode pruned = pruneThroughFilterCte(outer, "f_col > 0", "fv", VIEW_BODY);
+
+        String prunedSql = Transformations.parseToSql(conn, pruned).toLowerCase();
+        assertFalse(prunedSql.contains(CATALOG + ".fact"),
+                "the view body must NOT be inlined on a star projection: " + prunedSql);
+        assertTrue(prunedSql.contains("fv"), "the view reference should remain: " + prunedSql);
+    }
+
+    @Test
+    void rlsFilter_stillApplied_afterPruning() throws Exception {
+        // The whole point of keeping the wrapper: the row filter must still bind + restrict.
+        String outer = "SELECT rid, a_name FROM fv";
+        JsonNode pruned = pruneThroughFilterCte(outer, "f_id >= 2", "fv", VIEW_BODY);
+
+        List<List<Object>> rows = execRows(Transformations.parseToSql(conn, pruned));
+        assertEquals(2, rows.size(), "filter f_id>=2 keeps rowids 1,2 only");
+        assertRowsEqualAuthorized(pruned, outer, "f_id >= 2");
+    }
+}


### PR DESCRIPTION
## What

Extends the scope-aware `Transformations.pruneUnusedLeftJoins` so a view's unused `LEFT JOIN`s are eliminated **even when the view is referenced only through a row-filter CTE** of the shape `WITH ___v AS (SELECT * FROM v WHERE <filter>) …` — for example the output of `RESTRICT_READ_ONLY`'s row-level-security rewrite.

Previously the prune bailed on that injected `SELECT *` (a STAR scope can't be enumerated), so a view behind such a wrapper never got pruned.

## How

- **`isStarFilterCteBody`** — recognizes the wrapper's exact shape: a single bare `SELECT *` select list **plus** a WHERE. Only this shape is routed to the new path; a plain `SELECT * FROM view` (no filter) keeps the existing conservative STAR bail, so existing behavior/tests are unchanged.
- **`pruneStarFilterCte`** — recovers the columns actually needed from **the CTE's consumers** (enclosing scope minus its CTE bodies) **∪ the CTE body's own WHERE** (the filter's columns, which must survive or the wrapper won't bind), then reuses `pruneViewBodyInto` to inline the view body and eliminate now-unused joins. The wrapper's `SELECT *` and `WHERE` stay intact over the pruned subquery.

## Safety

- **Projection-only change** — the filter is untouched, so a wrong/missed column can only cause a bind error, never an unfiltered row.
- **No-op** when the consumer scope itself has a STAR over the CTE (columns not enumerable).
- **Over-collection is safe** — sibling references only keep extra columns → fewer joins dropped, never a wrong result.
- Correctness rests on the transform's existing join-key-uniqueness assumption; the new test verifies it empirically on DuckLake data.

## Tests

New `PruneUnusedLeftJoinsFilterCteDuckLakeTest` (7 cases) drives the prune through a real `injectFilterCtes` wrapper on DuckLake tables:
- unused dimension joins eliminated through the filter-CTE; result set / row count identical to the un-pruned query;
- a column referenced **only by the filter** survives pruning and binds;
- unmatched LEFT-JOIN rows retained; an `AT (TIMESTAMP => …)` time-travel clause preserved; the filter still restricts; an outer `SELECT *` correctly no-ops.

Full `dazzleduck-sql-commons` suite passes locally under JDK 21.