### PR TITLE
release: set version 0.2.13-SNAPSHOT → 0.2.13

### DIFF
--- a/dazzleduck-sql-client-grpc/pom.xml
+++ b/dazzleduck-sql-client-grpc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
 
     <artifactId>dazzleduck-sql-client-grpc</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
@@ -48,13 +48,13 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-client/pom.xml
+++ b/dazzleduck-sql-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
 
     <artifactId>dazzleduck-sql-client</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
@@ -38,13 +38,13 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-common/pom.xml
+++ b/dazzleduck-sql-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
     <artifactId>dazzleduck-sql-common</artifactId>
     <name>DazzleDuck Project Common</name>

--- a/dazzleduck-sql-commons/pom.xml
+++ b/dazzleduck-sql-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
     <artifactId>dazzleduck-sql-commons</artifactId>
     <name>DazzleDuck Project Commons</name>
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <!-- Test only: ResultStreamsTest exercises ZSTD Arrow round-trip via CommonsCompressionFactory
              (brings zstd-jni transitively). commons main code stays compression-impl-free. -->

--- a/dazzleduck-sql-ducklake-compactor/pom.xml
+++ b/dazzleduck-sql-ducklake-compactor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
 
     <artifactId>dazzleduck-sql-ducklake-compactor</artifactId>

--- a/dazzleduck-sql-examples/pom.xml
+++ b/dazzleduck-sql-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
 
     <artifactId>dazzleduck-sql-examples</artifactId>

--- a/dazzleduck-sql-flight/pom.xml
+++ b/dazzleduck-sql-flight/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
 
     <artifactId>dazzleduck-sql-flight</artifactId>
@@ -43,19 +43,19 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId> <!-- ✅ fixed -->
             <artifactId>dazzleduck-sql-login</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>

--- a/dazzleduck-sql-http/pom.xml
+++ b/dazzleduck-sql-http/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
     <artifactId>dazzleduck-sql-http</artifactId>
     <name>DazzleDuck Project Http Sql</name>
@@ -19,17 +19,17 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-login</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-flight</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/dazzleduck-sql-logback/pom.xml
+++ b/dazzleduck-sql-logback/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
     <artifactId>dazzleduck-sql-logback</artifactId>
     <name>DazzleDuck Project Logback</name>

--- a/dazzleduck-sql-login/pom.xml
+++ b/dazzleduck-sql-login/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
     <artifactId>dazzleduck-sql-login</artifactId>
     <name>DazzleDuck Project Login</name>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/dazzleduck-sql-micrometer/pom.xml
+++ b/dazzleduck-sql-micrometer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
 
     <artifactId>dazzleduck-sql-micrometer</artifactId>
@@ -62,18 +62,18 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-otel-collector/pom.xml
+++ b/dazzleduck-sql-otel-collector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
 
     <artifactId>dazzleduck-sql-otel-collector</artifactId>
@@ -86,12 +86,12 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
 
         <!-- Logging -->

--- a/dazzleduck-sql-runtime/pom.xml
+++ b/dazzleduck-sql-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
     <name>DazzleDuck Project Runtime</name>
     <artifactId>dazzleduck-sql-runtime</artifactId>

--- a/dazzleduck-sql-scrapper/pom.xml
+++ b/dazzleduck-sql-scrapper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
 
     <artifactId>dazzleduck-sql-scrapper</artifactId>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
     </dependencies>
 

--- a/dazzleduck-sql-search/pom.xml
+++ b/dazzleduck-sql-search/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.13-SNAPSHOT</version>
+        <version>0.2.13</version>
     </parent>
     <name>DazzleDuck Project Search</name>
     <artifactId>dazzleduck-sql-search</artifactId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.13-SNAPSHOT</version>
+            <version>0.2.13</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.dazzleduck.sql</groupId>
     <artifactId>dazzleduck-parent</artifactId>
-    <version>0.2.13-SNAPSHOT</version>
+    <version>0.2.13</version>
     <packaging>pom</packaging>
     <name>DazzleDuck Project Parent POM</name>
     <url>https://github.com/dazzleduck-web/dazzleduck-sql-server</url>


### PR DESCRIPTION
## Summary

Bumps the project version from `0.2.13-SNAPSHOT` to the release version `0.2.13` across the parent POM and all 15 child modules.

Mechanical change only (via `mvn versions:set`); no code changes.

Cut after the RLS view LEFT JOIN pruning work (#365/#370) landed on main, following the 0.2.12 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)