### PR TITLE
feat(ingestion): per-group MIN-timestamp watermark in the DuckLake post-ingestion transaction

### DIFF
--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
@@ -179,6 +179,13 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
     }
 
     @Override
+    public WatermarkSpec getWatermarkSpec(String queueId) {
+        QueueIdToTableMapping mapping = queueIdsToTableMappings.get(queueId);
+        if (mapping == null) mapping = queueIdsToTableMappings.get(extractSuffix(queueId));
+        return mapping == null ? null : WatermarkSpec.fromParameters(queueId, mapping.additionalParameters());
+    }
+
+    @Override
     public PostIngestionTask createPostIngestionTask(IngestionResult result) {
         QueueIdToTableMapping mapping = queueIdsToTableMappings.get(result.queueName());
         if (mapping == null) mapping = queueIdsToTableMappings.get(extractSuffix(result.queueName()));

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
@@ -7,31 +7,23 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Post-ingestion task that adds newly ingested files to a DuckLake table.
  * This task executes the ducklake_add_data_files procedure for each ingested file
  * within a transaction to ensure atomicity.
  *
- * <p>Optionally appends a watermark row set in the same transaction, configured through the
- * queue mapping's {@code additional_parameters}:
- * <ul>
- *   <li>{@code watermark_table} — unqualified table name (same catalog/schema as the target)
- *       receiving one row per group with the MIN of the timestamp column across the newly
- *       added files. Appended atomically with the file registration: a rollback undoes both.</li>
- *   <li>{@code watermark_timestamp_column} — timestamp column to MIN over; required when
- *       {@code watermark_table} is set. The result lands in a watermark-table column of the
- *       same name (matched BY NAME).</li>
- *   <li>{@code watermark_group_columns} — optional comma-separated grouping columns
- *       (e.g. {@code "county,state"}); each must exist in both the Parquet files and
- *       the watermark table. Empty/absent produces a single global-MIN row per batch.</li>
- * </ul>
- * The MIN is computed with a projected scan of only the newly written files
- * ({@code read_parquet}), never a rescan of the target table.
+ * <p>When the queue mapping configures a watermark (see {@link WatermarkSpec}), the rows
+ * precomputed at write time and carried on {@link IngestionResult#watermarkRows()} are appended
+ * to the watermark table via a plain {@code INSERT ... VALUES} in the SAME transaction, so file
+ * registration and watermark commit or roll back together. This task never re-reads the written
+ * files.
+ *
+ * <p>Limitation: queues registered through the dynamic SQLite registry
+ * ({@link DynamicQueueRepository}) do not carry {@code additional_parameters}, so watermarks are
+ * only available for statically configured queue mappings.
  */
 public class DuckLakePostIngestionTask implements PostIngestionTask {
 
@@ -39,17 +31,11 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
 
     private static final String ADD_FILE_QUERY = "CALL ducklake_add_data_files('%s', '%s', '%s', schema => '%s', ignore_extra_columns => true, allow_missing => true);";
 
-    public static final String WATERMARK_TABLE_KEY = "watermark_table";
-    public static final String WATERMARK_TIMESTAMP_COLUMN_KEY = "watermark_timestamp_column";
-    public static final String WATERMARK_GROUP_COLUMNS_KEY = "watermark_group_columns";
-
     private final IngestionResult ingestionResult;
     private final String catalogName;
     private final String tableName;
     private final String schemaName;
-    private final String watermarkTable;
-    private final String watermarkTimestampColumn;
-    private final List<String> watermarkGroupColumns;
+    private final WatermarkSpec watermarkSpec;
 
     public DuckLakePostIngestionTask(IngestionResult ingestionResult,
                                      String catalogName,
@@ -60,18 +46,7 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
         this.catalogName = catalogName;
         this.tableName = tableName;
         this.schemaName = schemaName;
-        Map<String, String> params = additionalParameters == null ? Map.of() : additionalParameters;
-        this.watermarkTable = params.get(WATERMARK_TABLE_KEY);
-        this.watermarkTimestampColumn = params.get(WATERMARK_TIMESTAMP_COLUMN_KEY);
-        this.watermarkGroupColumns = params.containsKey(WATERMARK_GROUP_COLUMNS_KEY)
-                ? Arrays.stream(params.get(WATERMARK_GROUP_COLUMNS_KEY).split(","))
-                        .map(String::trim).filter(s -> !s.isEmpty()).toList()
-                : List.of();
-        if (watermarkTable != null && watermarkTimestampColumn == null) {
-            throw new IllegalArgumentException(
-                    "Queue '%s': '%s' requires '%s'".formatted(
-                            ingestionResult.queueName(), WATERMARK_TABLE_KEY, WATERMARK_TIMESTAMP_COLUMN_KEY));
-        }
+        this.watermarkSpec = WatermarkSpec.fromParameters(ingestionResult.queueName(), additionalParameters);
     }
 
     @Override
@@ -94,36 +69,24 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
     /**
      * Adds files to DuckLake table within a transaction.
      * All files are added atomically - if any file fails, all changes are rolled back.
-     * When a watermark table is configured its INSERT joins the same transaction, so the
-     * registered files and their watermark rows commit or roll back together.
+     * Precomputed watermark rows join the same transaction, so the registered files and their
+     * watermark commit or roll back together.
      */
     private void addFilesInTransaction(List<String> files) throws SQLException {
         List<String> queries = new ArrayList<>(files.stream()
-                .map(file -> ADD_FILE_QUERY.formatted(catalogName, tableName, file, schemaName))
+                .map(file -> ADD_FILE_QUERY.formatted(
+                        escapeLiteral(catalogName), escapeLiteral(tableName), escapeLiteral(file), escapeLiteral(schemaName)))
                 .toList());
-        if (watermarkTable != null) {
-            queries.add(watermarkQuery(files));
+        List<List<String>> watermarkRows = ingestionResult.watermarkRows();
+        if (watermarkSpec != null && watermarkRows != null && !watermarkRows.isEmpty()) {
+            queries.add(watermarkSpec.insertSql(catalogName, schemaName, watermarkRows));
         }
         try (Connection conn = ConnectionPool.getConnection()) {
             ConnectionPool.executeBatchInTxn(conn, queries.toArray(String[]::new));
         }
     }
 
-    private String watermarkQuery(List<String> files) {
-        String fileList = files.stream()
-                .map(f -> "'" + f.replace("'", "''") + "'")
-                .collect(Collectors.joining(", ", "[", "]"));
-        String tsColumn = quoteIdentifier(watermarkTimestampColumn);
-        String groupColumns = watermarkGroupColumns.stream()
-                .map(DuckLakePostIngestionTask::quoteIdentifier)
-                .collect(Collectors.joining(", "));
-        String selectPrefix = groupColumns.isEmpty() ? "" : groupColumns + ", ";
-        String groupBy = groupColumns.isEmpty() ? "" : " GROUP BY " + groupColumns;
-        return "INSERT INTO %s.%s.%s BY NAME SELECT %sMIN(%s) AS %s FROM read_parquet(%s)%s".formatted(
-                catalogName, schemaName, watermarkTable, selectPrefix, tsColumn, tsColumn, fileList, groupBy);
-    }
-
-    private static String quoteIdentifier(String identifier) {
-        return '"' + identifier.replace("\"", "\"\"") + '"';
+    private static String escapeLiteral(String value) {
+        return value.replace("'", "''");
     }
 }

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
@@ -6,13 +6,32 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Post-ingestion task that adds newly ingested files to a DuckLake table.
  * This task executes the ducklake_add_data_files procedure for each ingested file
  * within a transaction to ensure atomicity.
+ *
+ * <p>Optionally appends a watermark row set in the same transaction, configured through the
+ * queue mapping's {@code additional_parameters}:
+ * <ul>
+ *   <li>{@code watermark_table} — unqualified table name (same catalog/schema as the target)
+ *       receiving one row per group with the MIN of the timestamp column across the newly
+ *       added files. Appended atomically with the file registration: a rollback undoes both.</li>
+ *   <li>{@code watermark_timestamp_column} — timestamp column to MIN over; required when
+ *       {@code watermark_table} is set. The result lands in a watermark-table column of the
+ *       same name (matched BY NAME).</li>
+ *   <li>{@code watermark_group_columns} — optional comma-separated grouping columns
+ *       (e.g. {@code "county,state"}); each must exist in both the Parquet files and
+ *       the watermark table. Empty/absent produces a single global-MIN row per batch.</li>
+ * </ul>
+ * The MIN is computed with a projected scan of only the newly written files
+ * ({@code read_parquet}), never a rescan of the target table.
  */
 public class DuckLakePostIngestionTask implements PostIngestionTask {
 
@@ -20,10 +39,17 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
 
     private static final String ADD_FILE_QUERY = "CALL ducklake_add_data_files('%s', '%s', '%s', schema => '%s', ignore_extra_columns => true, allow_missing => true);";
 
+    public static final String WATERMARK_TABLE_KEY = "watermark_table";
+    public static final String WATERMARK_TIMESTAMP_COLUMN_KEY = "watermark_timestamp_column";
+    public static final String WATERMARK_GROUP_COLUMNS_KEY = "watermark_group_columns";
+
     private final IngestionResult ingestionResult;
     private final String catalogName;
     private final String tableName;
     private final String schemaName;
+    private final String watermarkTable;
+    private final String watermarkTimestampColumn;
+    private final List<String> watermarkGroupColumns;
 
     public DuckLakePostIngestionTask(IngestionResult ingestionResult,
                                      String catalogName,
@@ -34,6 +60,18 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
         this.catalogName = catalogName;
         this.tableName = tableName;
         this.schemaName = schemaName;
+        Map<String, String> params = additionalParameters == null ? Map.of() : additionalParameters;
+        this.watermarkTable = params.get(WATERMARK_TABLE_KEY);
+        this.watermarkTimestampColumn = params.get(WATERMARK_TIMESTAMP_COLUMN_KEY);
+        this.watermarkGroupColumns = params.containsKey(WATERMARK_GROUP_COLUMNS_KEY)
+                ? Arrays.stream(params.get(WATERMARK_GROUP_COLUMNS_KEY).split(","))
+                        .map(String::trim).filter(s -> !s.isEmpty()).toList()
+                : List.of();
+        if (watermarkTable != null && watermarkTimestampColumn == null) {
+            throw new IllegalArgumentException(
+                    "Queue '%s': '%s' requires '%s'".formatted(
+                            ingestionResult.queueName(), WATERMARK_TABLE_KEY, WATERMARK_TIMESTAMP_COLUMN_KEY));
+        }
     }
 
     @Override
@@ -56,11 +94,36 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
     /**
      * Adds files to DuckLake table within a transaction.
      * All files are added atomically - if any file fails, all changes are rolled back.
+     * When a watermark table is configured its INSERT joins the same transaction, so the
+     * registered files and their watermark rows commit or roll back together.
      */
     private void addFilesInTransaction(List<String> files) throws SQLException {
-        try (Connection conn = ConnectionPool.getConnection()) {
-            String[] queries = files.stream().map(file -> ADD_FILE_QUERY.formatted(catalogName, tableName, file, schemaName)).toArray(String[]::new);
-            ConnectionPool.executeBatchInTxn(conn, queries);
+        List<String> queries = new ArrayList<>(files.stream()
+                .map(file -> ADD_FILE_QUERY.formatted(catalogName, tableName, file, schemaName))
+                .toList());
+        if (watermarkTable != null) {
+            queries.add(watermarkQuery(files));
         }
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.executeBatchInTxn(conn, queries.toArray(String[]::new));
+        }
+    }
+
+    private String watermarkQuery(List<String> files) {
+        String fileList = files.stream()
+                .map(f -> "'" + f.replace("'", "''") + "'")
+                .collect(Collectors.joining(", ", "[", "]"));
+        String tsColumn = quoteIdentifier(watermarkTimestampColumn);
+        String groupColumns = watermarkGroupColumns.stream()
+                .map(DuckLakePostIngestionTask::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        String selectPrefix = groupColumns.isEmpty() ? "" : groupColumns + ", ";
+        String groupBy = groupColumns.isEmpty() ? "" : " GROUP BY " + groupColumns;
+        return "INSERT INTO %s.%s.%s BY NAME SELECT %sMIN(%s) AS %s FROM read_parquet(%s)%s".formatted(
+                catalogName, schemaName, watermarkTable, selectPrefix, tsColumn, tsColumn, fileList, groupBy);
+    }
+
+    private static String quoteIdentifier(String identifier) {
+        return '"' + identifier.replace("\"", "\"\"") + '"';
     }
 }

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionHandler.java
@@ -17,6 +17,13 @@ public interface IngestionHandler {
      */
     default String[] getPartitionProjections(String queueId) { return new String[0]; }
 
+    /**
+     * Watermark configuration for the queue, or {@code null} when none is configured. When
+     * non-null, {@link ParquetIngestionQueue} computes the watermark rows at write time (from the
+     * same relation the output is written from) and carries them on the {@link IngestionResult}.
+     */
+    default WatermarkSpec getWatermarkSpec(String queueId) { return null; }
+
     default boolean supportPartitionByHeader() { return true; }
 
     // -----------------------------------------------------------------------

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionResult.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionResult.java
@@ -13,9 +13,17 @@ import java.util.Map;
  * @param applicationId Application which is responsible for Ingestion
  * @param maxProducerIds Id of the producer
  * @param filesCreated This will be populated when the  files are written in the s3
+ * @param watermarkRows Per-group MIN-timestamp rows precomputed at write time from the source
+ *                      relation (group values in {@link WatermarkSpec#groupColumns()} order,
+ *                      timestamp last, as DuckDB-rendered strings); null when the queue has no
+ *                      watermark configured
  */
-public record IngestionResult(String queueName, long ingestionBatchId, String applicationId, Map<String, Long> maxProducerIds, long rowCount, List<String> filesCreated, String query) {
+public record IngestionResult(String queueName, long ingestionBatchId, String applicationId, Map<String, Long> maxProducerIds, long rowCount, List<String> filesCreated, String query, List<List<String>> watermarkRows) {
     IngestionResult(String queueName, long ingestionBatchId, String applicationId, Map<String, Long> maxProducerIds, long rowCount, List<String> filesCreated) {
-        this(queueName, ingestionBatchId, applicationId, maxProducerIds, rowCount, filesCreated, null);
+        this(queueName, ingestionBatchId, applicationId, maxProducerIds, rowCount, filesCreated, null, null);
+    }
+
+    public IngestionResult(String queueName, long ingestionBatchId, String applicationId, Map<String, Long> maxProducerIds, long rowCount, List<String> filesCreated, String query) {
+        this(queueName, ingestionBatchId, applicationId, maxProducerIds, rowCount, filesCreated, query, null);
     }
 }

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/ParquetIngestionQueue.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/ParquetIngestionQueue.java
@@ -116,26 +116,19 @@ public class ParquetIngestionQueue extends BulkIngestQueue<String, IngestionResu
         }
     }
 
-    private String constructWriteQuery(WriteTask<String, IngestionResult> writeTask) {
+    /**
+     * The relation the output files are written from: the temp input files with the
+     * transformation and any partition projections applied. This is also the relation the
+     * watermark rows are computed over — same schema, same rows as the written output, read
+     * while the input files are still local.
+     */
+    private String constructSourceRelation(WriteTask<String, IngestionResult> writeTask) {
         var batches = writeTask.bucket().batches();
         // All Arrow files
         var arrowFiles = batches.stream().map(Batch::record).map("'%s'"::formatted).collect(Collectors.joining(","));
         String[] batchPartitionBy = batches.get(0).partitionBy();
         boolean hasBatchPartitionBy = batchPartitionBy != null && batchPartitionBy.length > 0;
-        String[] effectivePartitionBy = hasBatchPartitionBy
-                ? batchPartitionBy
-                : postIngestionHandler.getPartitionBy(queueId);
-        String partitionByClause = getClause(effectivePartitionBy, ", PARTITION_BY(%s)");
         String sortOrderClause = getClause(batches.get(0).sortOrder(), "ORDER BY %s ");
-        // Last format
-        var outputFormat = batches.isEmpty() ? "" : batches.get(batches.size() - 1).format();
-        String fullFilePath;
-        if (partitionByClause.isEmpty()) {
-            String uniqueFileName = "dd_" + UUID.randomUUID() + "." + outputFormat;
-            fullFilePath = this.outputPath + "/" + uniqueFileName;
-        } else {
-            fullFilePath = this.outputPath;
-        }
 
         // Inner SQL reads from the temp Arrow files
         var innerSql = "SELECT * FROM read_%s([%s]) %s".formatted(this.inputFormat, arrowFiles, sortOrderClause);
@@ -157,6 +150,28 @@ public class ParquetIngestionQueue extends BulkIngestQueue<String, IngestionResu
                         String.join(", ", partitionProjections), querySql);
             }
         }
+        return querySql;
+    }
+
+    private String constructWriteQuery(WriteTask<String, IngestionResult> writeTask) {
+        var batches = writeTask.bucket().batches();
+        String[] batchPartitionBy = batches.get(0).partitionBy();
+        boolean hasBatchPartitionBy = batchPartitionBy != null && batchPartitionBy.length > 0;
+        String[] effectivePartitionBy = hasBatchPartitionBy
+                ? batchPartitionBy
+                : postIngestionHandler.getPartitionBy(queueId);
+        String partitionByClause = getClause(effectivePartitionBy, ", PARTITION_BY(%s)");
+        // Last format
+        var outputFormat = batches.isEmpty() ? "" : batches.get(batches.size() - 1).format();
+        String fullFilePath;
+        if (partitionByClause.isEmpty()) {
+            String uniqueFileName = "dd_" + UUID.randomUUID() + "." + outputFormat;
+            fullFilePath = this.outputPath + "/" + uniqueFileName;
+        } else {
+            fullFilePath = this.outputPath;
+        }
+
+        var querySql = constructSourceRelation(writeTask);
 
         // Build SQL
         // https://duckdb.org/docs/stable/sql/statements/copy
@@ -174,8 +189,18 @@ public class ParquetIngestionQueue extends BulkIngestQueue<String, IngestionResu
         logger.debug("Executing COPY SQL: {}", sql);
         List<String> files = new ArrayList<>();
         long count = 0;
+        // Watermark rows are computed BEFORE the COPY, over the same source relation the output
+        // is written from: the data is still local, the transformation is already applied (so
+        // partition columns are real typed columns, not hive path fragments), and a misconfigured
+        // spec fails fast without leaving an unregistered output file behind.
+        WatermarkSpec watermarkSpec = postIngestionHandler.getWatermarkSpec(queueId);
+        List<List<String>> watermarkRows = null;
         try (var conn = ConnectionPool.getConnection();
              var stmt = conn.createStatement()) {
+
+            if (watermarkSpec != null) {
+                watermarkRows = watermarkSpec.computeRows(conn, constructSourceRelation(writeTask));
+            }
 
             // Set up cancellation hook
             var cancelHookSet = writeTask.setCancelHook(() -> {
@@ -210,6 +235,6 @@ public class ParquetIngestionQueue extends BulkIngestQueue<String, IngestionResu
         return new IngestionResult(this.queueId, writeTask.taskId(), this.applicationId,
                 writeTask.bucket().getProducerMaxBatchId(),
                 count,
-                files, sql);
+                files, sql, watermarkRows);
     }
 }

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/QueueIdToTableMapping.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/QueueIdToTableMapping.java
@@ -47,6 +47,9 @@ public record QueueIdToTableMapping(
                     "Queue '%s': 'transformation' and 'view'/'input_table' are mutually exclusive"
                             .formatted(ingestionQueue));
         }
+        // Fail at config load, not per batch: a malformed watermark spec (partial/blank/typo'd
+        // keys) would otherwise write each batch's output and then orphan it at post-ingestion.
+        WatermarkSpec.fromParameters(ingestionQueue, additionalParameters);
     }
 
     /** Backward-compatible constructor without outputPath/inputSchema (DuckLake-managed entries). */

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
@@ -1,0 +1,169 @@
+package io.dazzleduck.sql.commons.ingestion;
+
+import io.dazzleduck.sql.commons.util.HeaderUtils;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Per-queue watermark configuration, parsed from a queue mapping's {@code additional_parameters}:
+ * <ul>
+ *   <li>{@code watermark_table} — unqualified table (same catalog/schema as the target) receiving
+ *       one row per group with the MIN of the timestamp column across each ingested batch.</li>
+ *   <li>{@code watermark_timestamp_column} — column to MIN over; required when the table is set.
+ *       The value lands in a watermark-table column of the same name.</li>
+ *   <li>{@code watermark_group_columns} — optional grouping columns as a comma-separated string
+ *       (a HOCON list is tolerated: its flattened {@code [a, b]} form is unwrapped). Empty means
+ *       one global MIN row per batch.</li>
+ * </ul>
+ *
+ * <p>Watermark rows are computed at WRITE time by {@link ParquetIngestionQueue} — an aggregation
+ * over the same pre-COPY relation the output Parquet is written from (local data, transformation
+ * already applied) — and carried through {@link IngestionResult#watermarkRows()} to
+ * {@link DuckLakePostIngestionTask}, which appends them via a plain {@code INSERT ... VALUES} in
+ * the SAME transaction as the {@code ducklake_add_data_files} registration. The post-ingestion
+ * step therefore never re-reads the written files: no second download, no dependence on the
+ * written files' schema, and partition columns (present in the relation, hive-only in the files)
+ * group correctly. Rows whose MIN would be NULL (empty batch / all-NULL timestamps) are excluded.
+ *
+ * <p>Validation runs at config-load time via {@link QueueIdToTableMapping}, so a malformed spec
+ * fails startup rather than orphaning batches at flush time. Values are rejected when blank, and
+ * unknown {@code watermark_}-prefixed keys are rejected to surface typos.
+ */
+public record WatermarkSpec(String table, String timestampColumn, List<String> groupColumns) {
+
+    public static final String TABLE_KEY = "watermark_table";
+    public static final String TIMESTAMP_COLUMN_KEY = "watermark_timestamp_column";
+    public static final String GROUP_COLUMNS_KEY = "watermark_group_columns";
+
+    private static final List<String> KNOWN_KEYS = List.of(TABLE_KEY, TIMESTAMP_COLUMN_KEY, GROUP_COLUMNS_KEY);
+
+    public WatermarkSpec {
+        requireNonBlank(table, TABLE_KEY);
+        requireNonBlank(timestampColumn, TIMESTAMP_COLUMN_KEY);
+        groupColumns = groupColumns == null ? List.of() : List.copyOf(groupColumns);
+        groupColumns.forEach(c -> requireNonBlank(c, GROUP_COLUMNS_KEY));
+    }
+
+    /**
+     * Parses the watermark spec out of a queue mapping's {@code additional_parameters}.
+     * Returns {@code null} when no {@code watermark_} key is present.
+     *
+     * @throws IllegalArgumentException on a partial spec (table without timestamp column), blank
+     *         values, or an unknown {@code watermark_}-prefixed key (typo guard)
+     */
+    public static WatermarkSpec fromParameters(String queueName, Map<String, String> parameters) {
+        if (parameters == null || parameters.keySet().stream().noneMatch(k -> k.startsWith("watermark_"))) {
+            return null;
+        }
+        for (String key : parameters.keySet()) {
+            if (key.startsWith("watermark_") && !KNOWN_KEYS.contains(key)) {
+                throw new IllegalArgumentException(
+                        "Queue '%s': unknown watermark parameter '%s' (known: %s)".formatted(queueName, key, KNOWN_KEYS));
+            }
+        }
+        String table = parameters.get(TABLE_KEY);
+        String timestampColumn = parameters.get(TIMESTAMP_COLUMN_KEY);
+        if (isBlank(table) || isBlank(timestampColumn)) {
+            throw new IllegalArgumentException(
+                    "Queue '%s': watermark configuration requires non-blank '%s' and '%s'"
+                            .formatted(queueName, TABLE_KEY, TIMESTAMP_COLUMN_KEY));
+        }
+        try {
+            return new WatermarkSpec(table.trim(), timestampColumn.trim(), parseGroupColumns(parameters.get(GROUP_COLUMNS_KEY)));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Queue '%s': %s".formatted(queueName, e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Splits the comma-separated group-column value. A HOCON list flattened by
+     * {@code unwrapped().toString()} arrives as {@code "[a, b]"} — the surrounding brackets are
+     * stripped so both spellings configure the same columns.
+     */
+    private static List<String> parseGroupColumns(String value) {
+        if (value == null) return List.of();
+        String trimmed = value.trim();
+        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+            trimmed = trimmed.substring(1, trimmed.length() - 1);
+        }
+        if (trimmed.isBlank()) return List.of();
+        List<String> columns = Arrays.stream(trimmed.split(",")).map(String::trim).toList();
+        columns.forEach(c -> {
+            if (c.isBlank() || c.contains("[") || c.contains("]")) {
+                throw new IllegalArgumentException("malformed '%s' entry: '%s'".formatted(GROUP_COLUMNS_KEY, c));
+            }
+        });
+        return columns;
+    }
+
+    /**
+     * Aggregation over the write-time source relation: one row per group with the MIN timestamp.
+     * {@code HAVING MIN(..) IS NOT NULL} drops rows a NULL MIN would produce — the global row of
+     * an empty batch, or a group whose timestamps are all NULL.
+     */
+    public String aggregationSql(String relationSql) {
+        String tsColumn = HeaderUtils.quoteIdentifier(timestampColumn);
+        String groups = groupColumns.stream().map(HeaderUtils::quoteIdentifier).collect(Collectors.joining(", "));
+        String selectPrefix = groups.isEmpty() ? "" : groups + ", ";
+        String groupBy = groups.isEmpty() ? "" : " GROUP BY " + groups;
+        return "SELECT %sMIN(%s) AS %s FROM (%s)%s HAVING MIN(%s) IS NOT NULL"
+                .formatted(selectPrefix, tsColumn, tsColumn, relationSql, groupBy, tsColumn);
+    }
+
+    /**
+     * Executes {@link #aggregationSql} and returns the rows as DuckDB-rendered strings
+     * (group values in declared order, MIN timestamp last; NULL stays null). String values
+     * round-trip through DuckDB's implicit VARCHAR cast on INSERT.
+     */
+    public List<List<String>> computeRows(Connection connection, String relationSql) throws SQLException {
+        List<List<String>> rows = new ArrayList<>();
+        int columns = groupColumns.size() + 1;
+        try (var statement = connection.createStatement();
+             var resultSet = statement.executeQuery(aggregationSql(relationSql))) {
+            while (resultSet.next()) {
+                List<String> row = new ArrayList<>(columns);
+                for (int i = 1; i <= columns; i++) {
+                    row.add(resultSet.getString(i));
+                }
+                rows.add(row);
+            }
+        }
+        return rows;
+    }
+
+    /**
+     * Renders the INSERT appending precomputed watermark rows — explicit quoted column list
+     * (group columns then timestamp column), values as escaped string literals relying on
+     * DuckDB's implicit cast to the table's column types.
+     */
+    public String insertSql(String catalog, String schema, List<List<String>> rows) {
+        String columnList = groupColumns.stream().map(HeaderUtils::quoteIdentifier).collect(Collectors.joining(", "));
+        columnList = (columnList.isEmpty() ? "" : columnList + ", ") + HeaderUtils.quoteIdentifier(timestampColumn);
+        String values = rows.stream()
+                .map(row -> row.stream().map(WatermarkSpec::literal).collect(Collectors.joining(", ", "(", ")")))
+                .collect(Collectors.joining(", "));
+        return "INSERT INTO %s.%s.%s (%s) VALUES %s".formatted(
+                HeaderUtils.quoteIdentifier(catalog), HeaderUtils.quoteIdentifier(schema),
+                HeaderUtils.quoteIdentifier(table), columnList, values);
+    }
+
+    private static String literal(String value) {
+        return value == null ? "NULL" : "'" + value.replace("'", "''") + "'";
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static void requireNonBlank(String value, String key) {
+        if (isBlank(value)) {
+            throw new IllegalArgumentException("watermark configuration: '%s' must not be blank".formatted(key));
+        }
+    }
+}

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
@@ -16,11 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * DuckLakePostIngestionTask's optional watermark append: when the queue mapping's
- * {@code additional_parameters} configure a watermark table, timestamp column and group columns,
- * the task inserts one MIN-timestamp row per group — computed from only the newly registered
- * Parquet files — in the SAME transaction as {@code ducklake_add_data_files}, so file
- * registration and watermark rows commit or roll back together.
+ * DuckLakePostIngestionTask's watermark append: watermark rows are precomputed at write time
+ * (see {@link WatermarkSpec#computeRows}) and carried on {@link IngestionResult#watermarkRows()};
+ * the task appends them via INSERT ... VALUES in the SAME transaction as
+ * {@code ducklake_add_data_files}, so file registration and watermark rows commit or roll back
+ * together. The task itself never re-reads the written files.
  */
 class DuckLakeWatermarkPostIngestionTest {
 
@@ -63,25 +63,36 @@ class DuckLakeWatermarkPostIngestionTest {
         return List.of(f1, f2);
     }
 
-    private static IngestionResult result(List<String> files) {
-        return new IngestionResult("q1", 1, "test-app", Map.of(), 4, files, null);
+    private static final WatermarkSpec SPEC = new WatermarkSpec("ingest_watermark", "ts", List.of("county", "state"));
+
+    private static Map<String, String> watermarkParams(String table) {
+        return Map.of(
+                WatermarkSpec.TABLE_KEY, table,
+                WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts",
+                WatermarkSpec.GROUP_COLUMNS_KEY, "county, state");
     }
 
-    private static Map<String, String> watermarkParams() {
-        return Map.of(
-                DuckLakePostIngestionTask.WATERMARK_TABLE_KEY, "ingest_watermark",
-                DuckLakePostIngestionTask.WATERMARK_TIMESTAMP_COLUMN_KEY, "ts",
-                DuckLakePostIngestionTask.WATERMARK_GROUP_COLUMNS_KEY, "county, state");
+    /** Computes the rows the way ParquetIngestionQueue does at write time: over the source relation. */
+    private List<List<String>> computeRows(List<String> files) throws Exception {
+        String relation = "SELECT * FROM read_parquet(['%s', '%s'])".formatted(files.get(0), files.get(1));
+        try (Connection conn = ConnectionPool.getConnection()) {
+            return SPEC.computeRows(conn, relation);
+        }
+    }
+
+    private static IngestionResult result(List<String> files, List<List<String>> watermarkRows) {
+        return new IngestionResult("q1", 1, "test-app", Map.of(), 4, files, null, watermarkRows);
     }
 
     @Test
-    void appendsMinTimestampPerGroupInSameTransaction() throws Exception {
+    void appendsPrecomputedRowsInSameTransaction() throws Exception {
         List<String> files = writeBatchFiles();
-        new DuckLakePostIngestionTask(result(files), CATALOG, "facts", "main", watermarkParams()).execute();
+        List<List<String>> rows = computeRows(files);
+        new DuckLakePostIngestionTask(result(files, rows), CATALOG, "facts", "main",
+                watermarkParams("ingest_watermark")).execute();
 
         try (Connection conn = ConnectionPool.getConnection()) {
-            List<String> facts = collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.facts".formatted(CATALOG));
-            assertEquals(List.of("4"), facts);
+            assertEquals(List.of("4"), collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.facts".formatted(CATALOG)));
 
             List<String> watermarks = collect(conn,
                     ("SELECT county || '|' || state || '|' || strftime(ts, '%%Y-%%m-%%d %%H:%%M') AS r "
@@ -97,10 +108,9 @@ class DuckLakeWatermarkPostIngestionTest {
     @Test
     void watermarkFailureRollsBackFileRegistration() throws Exception {
         List<String> files = writeBatchFiles();
-        Map<String, String> params = Map.of(
-                DuckLakePostIngestionTask.WATERMARK_TABLE_KEY, "missing_watermark_table",
-                DuckLakePostIngestionTask.WATERMARK_TIMESTAMP_COLUMN_KEY, "ts");
-        var task = new DuckLakePostIngestionTask(result(files), CATALOG, "facts", "main", params);
+        List<List<String>> rows = computeRows(files);
+        var task = new DuckLakePostIngestionTask(result(files, rows), CATALOG, "facts", "main",
+                watermarkParams("missing_watermark_table"));
         assertThrows(RuntimeException.class, task::execute);
 
         try (Connection conn = ConnectionPool.getConnection()) {
@@ -110,9 +120,10 @@ class DuckLakeWatermarkPostIngestionTest {
     }
 
     @Test
-    void noWatermarkParametersRegistersFilesOnly() throws Exception {
+    void emptyWatermarkRowsSkipTheInsert() throws Exception {
         List<String> files = writeBatchFiles();
-        new DuckLakePostIngestionTask(result(files), CATALOG, "facts", "main", Map.of()).execute();
+        new DuckLakePostIngestionTask(result(files, List.of()), CATALOG, "facts", "main",
+                watermarkParams("ingest_watermark")).execute();
 
         try (Connection conn = ConnectionPool.getConnection()) {
             assertEquals(List.of("4"), collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.facts".formatted(CATALOG)));
@@ -121,11 +132,14 @@ class DuckLakeWatermarkPostIngestionTest {
     }
 
     @Test
-    void watermarkTableWithoutTimestampColumnIsRejected() throws Exception {
+    void noWatermarkParametersRegistersFilesOnly() throws Exception {
         List<String> files = writeBatchFiles();
-        Map<String, String> params = Map.of(DuckLakePostIngestionTask.WATERMARK_TABLE_KEY, "ingest_watermark");
-        assertThrows(IllegalArgumentException.class,
-                () -> new DuckLakePostIngestionTask(result(files), CATALOG, "facts", "main", params));
+        new DuckLakePostIngestionTask(result(files, null), CATALOG, "facts", "main", Map.of()).execute();
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            assertEquals(List.of("4"), collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.facts".formatted(CATALOG)));
+            assertEquals(List.of("0"), collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark".formatted(CATALOG)));
+        }
     }
 
     private static List<String> collect(Connection conn, String sql) throws Exception {

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
@@ -1,0 +1,136 @@
+package io.dazzleduck.sql.commons.ingestion;
+
+import io.dazzleduck.sql.commons.ConnectionPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * DuckLakePostIngestionTask's optional watermark append: when the queue mapping's
+ * {@code additional_parameters} configure a watermark table, timestamp column and group columns,
+ * the task inserts one MIN-timestamp row per group — computed from only the newly registered
+ * Parquet files — in the SAME transaction as {@code ducklake_add_data_files}, so file
+ * registration and watermark rows commit or roll back together.
+ */
+class DuckLakeWatermarkPostIngestionTest {
+
+    @TempDir Path tempDir;
+    static final String CATALOG = "watermark_lake";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.executeBatchInTxn(conn, new String[]{
+                    "ATTACH 'ducklake:%s' AS %s (DATA_PATH '%s')".formatted(
+                            tempDir.resolve("catalog"), CATALOG, tempDir.resolve("data")),
+                    "CREATE TABLE %s.main.facts (county VARCHAR, state VARCHAR, ts TIMESTAMP, v DOUBLE)".formatted(CATALOG),
+                    "CREATE TABLE %s.main.ingest_watermark (county VARCHAR, state VARCHAR, ts TIMESTAMP)".formatted(CATALOG)
+            });
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn, "DETACH " + CATALOG);
+        }
+    }
+
+    private List<String> writeBatchFiles() throws Exception {
+        String f1 = tempDir.resolve("b1.parquet").toString();
+        String f2 = tempDir.resolve("b2.parquet").toString();
+        try (Connection conn = ConnectionPool.getConnection()) {
+            // (king, wa) spans both files; its true min ts (01:00) is in the second file.
+            ConnectionPool.execute(conn, ("COPY (SELECT * FROM (VALUES "
+                    + "('king', 'wa', TIMESTAMP '2026-08-01 03:00', 1.0::DOUBLE), "
+                    + "('cook', 'il', TIMESTAMP '2026-08-02 05:00', 2.0::DOUBLE)"
+                    + ") AS t(county, state, ts, v)) TO '%s' (FORMAT parquet)").formatted(f1));
+            ConnectionPool.execute(conn, ("COPY (SELECT * FROM (VALUES "
+                    + "('king', 'wa', TIMESTAMP '2026-08-01 01:00', 3.0::DOUBLE), "
+                    + "('cook', 'in', TIMESTAMP '2026-08-03 09:00', 4.0::DOUBLE)"
+                    + ") AS t(county, state, ts, v)) TO '%s' (FORMAT parquet)").formatted(f2));
+        }
+        return List.of(f1, f2);
+    }
+
+    private static IngestionResult result(List<String> files) {
+        return new IngestionResult("q1", 1, "test-app", Map.of(), 4, files, null);
+    }
+
+    private static Map<String, String> watermarkParams() {
+        return Map.of(
+                DuckLakePostIngestionTask.WATERMARK_TABLE_KEY, "ingest_watermark",
+                DuckLakePostIngestionTask.WATERMARK_TIMESTAMP_COLUMN_KEY, "ts",
+                DuckLakePostIngestionTask.WATERMARK_GROUP_COLUMNS_KEY, "county, state");
+    }
+
+    @Test
+    void appendsMinTimestampPerGroupInSameTransaction() throws Exception {
+        List<String> files = writeBatchFiles();
+        new DuckLakePostIngestionTask(result(files), CATALOG, "facts", "main", watermarkParams()).execute();
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            List<String> facts = collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.facts".formatted(CATALOG));
+            assertEquals(List.of("4"), facts);
+
+            List<String> watermarks = collect(conn,
+                    ("SELECT county || '|' || state || '|' || strftime(ts, '%%Y-%%m-%%d %%H:%%M') AS r "
+                            + "FROM %s.main.ingest_watermark ORDER BY county, state").formatted(CATALOG));
+            assertEquals(List.of(
+                    "cook|il|2026-08-02 05:00",
+                    "cook|in|2026-08-03 09:00",
+                    "king|wa|2026-08-01 01:00"),  // min across BOTH files, not per file
+                    watermarks);
+        }
+    }
+
+    @Test
+    void watermarkFailureRollsBackFileRegistration() throws Exception {
+        List<String> files = writeBatchFiles();
+        Map<String, String> params = Map.of(
+                DuckLakePostIngestionTask.WATERMARK_TABLE_KEY, "missing_watermark_table",
+                DuckLakePostIngestionTask.WATERMARK_TIMESTAMP_COLUMN_KEY, "ts");
+        var task = new DuckLakePostIngestionTask(result(files), CATALOG, "facts", "main", params);
+        assertThrows(RuntimeException.class, task::execute);
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            // The add_data_files calls succeeded individually but the batch rolled back as one txn.
+            assertEquals(List.of("0"), collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.facts".formatted(CATALOG)));
+        }
+    }
+
+    @Test
+    void noWatermarkParametersRegistersFilesOnly() throws Exception {
+        List<String> files = writeBatchFiles();
+        new DuckLakePostIngestionTask(result(files), CATALOG, "facts", "main", Map.of()).execute();
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            assertEquals(List.of("4"), collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.facts".formatted(CATALOG)));
+            assertEquals(List.of("0"), collect(conn, "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark".formatted(CATALOG)));
+        }
+    }
+
+    @Test
+    void watermarkTableWithoutTimestampColumnIsRejected() throws Exception {
+        List<String> files = writeBatchFiles();
+        Map<String, String> params = Map.of(DuckLakePostIngestionTask.WATERMARK_TABLE_KEY, "ingest_watermark");
+        assertThrows(IllegalArgumentException.class,
+                () -> new DuckLakePostIngestionTask(result(files), CATALOG, "facts", "main", params));
+    }
+
+    private static List<String> collect(Connection conn, String sql) throws Exception {
+        List<String> rows = new ArrayList<>();
+        ConnectionPool.collectAll(conn, sql, rs -> rs.getString("r")).forEach(rows::add);
+        return rows;
+    }
+}

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpecTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpecTest.java
@@ -1,0 +1,132 @@
+package io.dazzleduck.sql.commons.ingestion;
+
+import io.dazzleduck.sql.commons.ConnectionPool;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WatermarkSpecTest {
+
+    @TempDir Path tempDir;
+
+    // ------------------------------------------------------------------ parsing
+
+    @Test
+    void absentKeysParseToNull() {
+        assertNull(WatermarkSpec.fromParameters("q", null));
+        assertNull(WatermarkSpec.fromParameters("q", Map.of()));
+        assertNull(WatermarkSpec.fromParameters("q", Map.of("unrelated_key", "x")));
+    }
+
+    @Test
+    void parsesFullSpecAndTrimsGroupColumns() {
+        WatermarkSpec spec = WatermarkSpec.fromParameters("q", Map.of(
+                WatermarkSpec.TABLE_KEY, "wm",
+                WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts",
+                WatermarkSpec.GROUP_COLUMNS_KEY, " county , state "));
+        assertEquals(new WatermarkSpec("wm", "ts", List.of("county", "state")), spec);
+    }
+
+    @Test
+    void toleratesFlattenedHoconListSyntax() {
+        // A HOCON list arrives via unwrapped().toString() as "[county, state]".
+        WatermarkSpec spec = WatermarkSpec.fromParameters("q", Map.of(
+                WatermarkSpec.TABLE_KEY, "wm",
+                WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts",
+                WatermarkSpec.GROUP_COLUMNS_KEY, "[county, state]"));
+        assertEquals(List.of("county", "state"), spec.groupColumns());
+    }
+
+    @Test
+    void rejectsPartialBlankAndTypodSpecs() {
+        // table without timestamp column
+        assertThrows(IllegalArgumentException.class, () -> WatermarkSpec.fromParameters("q",
+                Map.of(WatermarkSpec.TABLE_KEY, "wm")));
+        // blank values pass no-null checks but must still be rejected
+        assertThrows(IllegalArgumentException.class, () -> WatermarkSpec.fromParameters("q",
+                Map.of(WatermarkSpec.TABLE_KEY, "wm", WatermarkSpec.TIMESTAMP_COLUMN_KEY, " ")));
+        assertThrows(IllegalArgumentException.class, () -> WatermarkSpec.fromParameters("q",
+                Map.of(WatermarkSpec.TABLE_KEY, "", WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts")));
+        // typo'd watermark_ key must not silently disable the feature
+        assertThrows(IllegalArgumentException.class, () -> WatermarkSpec.fromParameters("q",
+                Map.of("watermark_tabel", "wm")));
+        // malformed group entry
+        assertThrows(IllegalArgumentException.class, () -> WatermarkSpec.fromParameters("q",
+                Map.of(WatermarkSpec.TABLE_KEY, "wm", WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts",
+                        WatermarkSpec.GROUP_COLUMNS_KEY, "county,,state")));
+    }
+
+    @Test
+    void queueMappingValidatesWatermarkAtConstruction() {
+        // The same validation runs from QueueIdToTableMapping so misconfig fails at config load.
+        assertThrows(IllegalArgumentException.class, () -> new QueueIdToTableMapping(
+                "q", "cat", "main", "t", Map.of(WatermarkSpec.TABLE_KEY, "wm"), null));
+    }
+
+    // ------------------------------------------------------------------ computation
+
+    private String relationOver(Connection conn, String values, String path) throws Exception {
+        ConnectionPool.execute(conn,
+                "COPY (SELECT * FROM (VALUES %s) AS t(county, state, ts)) TO '%s' (FORMAT parquet)"
+                        .formatted(values, path));
+        return "SELECT * FROM read_parquet('%s')".formatted(path);
+    }
+
+    @Test
+    void computesMinPerGroupExcludingNullTimestamps() throws Exception {
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county", "state"));
+        try (Connection conn = ConnectionPool.getConnection()) {
+            String relation = relationOver(conn,
+                    "('king','wa',TIMESTAMP '2026-08-01 03:00'),"
+                            + "('king','wa',TIMESTAMP '2026-08-01 01:00'),"
+                            + "('cook','il',TIMESTAMP '2026-08-02 05:00'),"
+                            + "('null','nv',NULL::TIMESTAMP)",   // all-NULL group must be dropped
+                    tempDir.resolve("grouped.parquet").toString());
+            List<List<String>> rows = spec.computeRows(conn, relation);
+            rows.sort(java.util.Comparator.comparing(r -> r.get(0)));
+            assertEquals(2, rows.size());
+            // JDBC renders TIMESTAMP via java.sql.Timestamp.toString (trailing ".0"); the string
+            // round-trips through DuckDB's implicit VARCHAR cast on INSERT.
+            assertEquals(List.of("cook", "il", "2026-08-02 05:00:00.0"), rows.get(0));
+            assertEquals(List.of("king", "wa", "2026-08-01 01:00:00.0"), rows.get(1));
+        }
+    }
+
+    @Test
+    void globalModeProducesNoRowForEmptyOrAllNullInput() throws Exception {
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of());
+        try (Connection conn = ConnectionPool.getConnection()) {
+            // zero-row relation: a global MIN would be a single NULL row — must be suppressed
+            String empty = relationOver(conn, "('x','y',TIMESTAMP '2026-01-01')",
+                    tempDir.resolve("empty.parquet").toString()) + " WHERE county = 'nope'";
+            assertTrue(spec.computeRows(conn, empty).isEmpty());
+
+            String allNull = relationOver(conn, "('x','y',NULL::TIMESTAMP)",
+                    tempDir.resolve("allnull.parquet").toString());
+            assertTrue(spec.computeRows(conn, allNull).isEmpty());
+
+            String real = relationOver(conn, "('x','y',TIMESTAMP '2026-01-01 08:00')",
+                    tempDir.resolve("real.parquet").toString());
+            assertEquals(List.of(List.of("2026-01-01 08:00:00.0")), spec.computeRows(conn, real));
+        }
+    }
+
+    // ------------------------------------------------------------------ rendering
+
+    @Test
+    void insertSqlQuotesIdentifiersAndEscapesValues() {
+        WatermarkSpec spec = new WatermarkSpec("ingest-watermark", "timestamp", List.of("county"));
+        String sql = spec.insertSql("cat", "main", List.of(List.of("o'brien", "2026-01-01 00:00:00")));
+        assertEquals("INSERT INTO \"cat\".\"main\".\"ingest-watermark\" (\"county\", \"timestamp\") "
+                + "VALUES ('o''brien', '2026-01-01 00:00:00')", sql);
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -73,6 +73,16 @@ otel_collector {
                 # catalog = "my_catalog"
                 # schema  = "main"
                 # table   = "logs"
+                # Optional watermark append — in the SAME transaction as the file
+                # registration, insert one MIN(<timestamp>) row per group computed from
+                # only the newly added Parquet files. The watermark table lives in the
+                # same catalog/schema and must have columns named exactly like the
+                # group columns plus the timestamp column (matched BY NAME).
+                # additional_parameters {
+                #     watermark_table            = "ingest_watermark"
+                #     watermark_timestamp_column = "timestamp"
+                #     watermark_group_columns    = "county,state"   # optional; empty = one global row per batch
+                # }
             }
             {
                 ingestion_queue = "traces"

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -73,11 +73,16 @@ otel_collector {
                 # catalog = "my_catalog"
                 # schema  = "main"
                 # table   = "logs"
-                # Optional watermark append — in the SAME transaction as the file
-                # registration, insert one MIN(<timestamp>) row per group computed from
-                # only the newly added Parquet files. The watermark table lives in the
-                # same catalog/schema and must have columns named exactly like the
-                # group columns plus the timestamp column (matched BY NAME).
+                # Optional watermark append — one MIN(<timestamp>) row per group is computed
+                # at WRITE time (from the same relation the output Parquet is written from)
+                # and inserted in the SAME transaction as the file registration, so files and
+                # watermark commit or roll back together. Rows whose MIN would be NULL (empty
+                # batch, all-NULL timestamps) are skipped. The watermark table lives in the
+                # same catalog/schema and needs columns named like the group columns plus the
+                # timestamp column. Malformed values (partial spec, blanks, typo'd watermark_*
+                # keys) fail at startup, not per batch. group_columns is a comma-separated
+                # string (a HOCON list is tolerated). NOT available for queues registered via
+                # the dynamic SQLite provider — its registry does not store additional_parameters.
                 # additional_parameters {
                 #     watermark_table            = "ingest_watermark"
                 #     watermark_timestamp_column = "timestamp"


### PR DESCRIPTION
## What

Adds an optional **watermark append** to the DuckLake post-ingestion path: for a configured queue, one `MIN(<timestamp>)` row per group is inserted into a watermark table **in the same transaction** as the `ducklake_add_data_files` registration. File registration and watermark rows commit or roll back together, so a consumer can never observe registered files without their watermark, or watermark rows for files that were rolled back.

## How

Configured per queue mapping through the existing `additional_parameters` map:

```hocon
additional_parameters {
    watermark_table            = "ingest_watermark"  # same catalog/schema as the target table
    watermark_timestamp_column = "timestamp"         # required when watermark_table is set
    watermark_group_columns    = "county,state"      # optional; empty = one global row per batch
}
```

**Watermark rows are computed at write time, not read back from the written files.** `ParquetIngestionQueue` aggregates the same pre-COPY relation the output Parquet is written from (local data, transformation applied), carries the rows on `IngestionResult.watermarkRows`, and `DuckLakePostIngestionTask` appends them as a plain `INSERT ... VALUES` alongside the registration calls. Consequences:

- no re-read of just-written files (no second S3 round-trip)
- no coupling to the written files' schema (heterogeneous batches register exactly as before)
- partition columns group as real typed columns (they are hive-path-only in the files)
- rows whose MIN would be NULL (empty batch, all-NULL timestamps) are excluded by construction

**Config is validated at load time** (`QueueIdToTableMapping` construction): partial specs, blank values, typo'd `watermark_*` keys, and malformed group lists fail startup with a message naming the key, instead of failing per batch after output is written. Flattened HOCON-list syntax for `watermark_group_columns` is tolerated. A new `WatermarkSpec` record owns parsing, validation, and both SQL shapes; identifiers are quoted via the existing `HeaderUtils.quoteIdentifier`, and string arguments to `ducklake_add_data_files` (including file paths) are escaped.

Known limitation (documented): queues registered via the dynamic SQLite provider don't carry `additional_parameters`, so watermarks require statically configured mappings.

Documented in the otel-collector `reference.conf` queue-mapping block.

## Testing

Full `dazzleduck-sql-commons` suite under JDK 21: **383 tests, 0 failures, 0 errors** — including the Arrow-based `ParquetIngestionQueueTest` / `DuckLakeIngestionIntegrationTest`, which exercise the refactored write path end to end.

New coverage:
- `WatermarkSpecTest` — parsing (absent/full/HOCON-list/partial/blank/typo'd), load-time validation via `QueueIdToTableMapping`, per-group MIN with NULL-timestamp exclusion, empty/all-NULL suppression in global mode, INSERT rendering (quoted identifiers, escaped values)
- `DuckLakeWatermarkPostIngestionTest` — precomputed rows appended in the same transaction (min-across-files case), **rollback atomicity** (failing watermark insert rolls back file registration), empty-rows and no-config paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)