### PR TITLE
feat(commons): prune unused complex select-list expressions; fold identifier case

### DIFF
--- a/LEFT_JOIN_PRUNING_SPEC.md
+++ b/LEFT_JOIN_PRUNING_SPEC.md
@@ -202,11 +202,41 @@ Additional conservative rules:
 - **Projection pushdown is skipped** (join elimination still applies) when the
   view body has `DISTINCT`, `GROUP BY` / grouping sets, or any other modifier —
   under `DISTINCT` the select list *is* the dedup key, and positional references
-  (`GROUP BY 1`, `ORDER BY 1`) would silently re-point if entries were dropped.
+  (`GROUP BY 1`, `ORDER BY 1`) would silently re-point if entries were dropped —
+  and likewise when it has `GROUP BY ALL` (the grouping key is *derived from* the
+  select list, and it serializes with EMPTY `group_expressions`;
+  `aggregate_handling = FORCE_AGGREGATES` is the only marker), a `QUALIFY`
+  (its own field, not a modifier; may reference a select-list alias), or a
+  `HAVING` (alias references, and without GROUP BY it forces implicit
+  aggregation).
+- **Any nameable entry is droppable, not only `COLUMN_REF`s** — an aliased
+  `CASE`/`CAST`/`FUNCTION`/`SUBQUERY` whose alias the outer query never uses is
+  dropped too, so unused expressions stop being computed and stop contributing
+  references to (b)'s counts (an unused lambda parameter, which reads as an
+  unqualified column, no longer disables elimination for the whole view).
+  `STAR` entries and unaliased expressions are always kept. One deliberate
+  consequence: a correlated scalar subquery that would error at runtime (more
+  than one row) no longer errors for callers who never projected its column —
+  an error becomes a result, never a result a different result.
+- **Implicit aggregation guard.** `SELECT 42 AS c, sum(x) AS s FROM t` is one
+  row and serializes with NO marker at all (STANDARD_HANDLING, empty groups, no
+  HAVING); dropping `s` would make it N rows. Aggregate-ness is a binder fact —
+  at parse level `sum` and `+` are both just `FUNCTION` nodes — so the guard is
+  structural: if nothing kept references a column (SUBQUERY subtrees excluded,
+  their refs bind in their own scope), every kept entry may be a plain constant
+  and nothing is dropped. A kept column reference proves a valid aggregated body
+  stays aggregated, and a non-aggregated body's row count is
+  projection-independent anyway.
 - **Multi-part column references** (`s.field`) are ambiguous at parse time
   between `table.column` and `struct_column.field`; *every* part is recorded as
   a potentially-used column name so a struct column projected by the view is
   never pruned away (keeps too much, never too little).
+- **Identifier comparisons fold case**, matching DuckDB's case-insensitive
+  resolution (quoted identifiers included): used-column matching, join-qualifier
+  counting, the CTE-shadow bail, and view-name location. Exact matching read a
+  differently-cased-but-binding reference as unused — pruning the entry (a bind
+  failure after inlining) or the join (eliminated out from under a still-bound
+  qualified reference).
 
 ---
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ExpressionConstants.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ExpressionConstants.java
@@ -109,6 +109,10 @@ public class ExpressionConstants {
     public static final String FIELD_SAMPLE = "sample";
     public static final String FIELD_GROUP_EXPRESSIONS = "group_expressions";
     public static final String FIELD_GROUP_SETS = "group_sets";
+    public static final String FIELD_QUALIFY = "qualify";
+    public static final String FIELD_HAVING = "having";
+    public static final String FIELD_AGGREGATE_HANDLING = "aggregate_handling";
+    public static final String AGGREGATE_HANDLING_STANDARD = "STANDARD_HANDLING";
 
     // Type ID constants for data types
     public static final String TYPE_VARCHAR = "VARCHAR";

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -960,7 +960,9 @@ public class Transformations {
         if (map == null || !map.isArray()) return false;
         for (JsonNode entry : map) {
             JsonNode key = entry.get("key");
-            if (key != null && name.equals(key.asText())) return true;
+            // Case-insensitive: a CTE named FV shadows view fv in DuckDB, so an exact match here
+            // would miss the shadow and inline the view over a reference that resolves to the CTE.
+            if (key != null && name.equalsIgnoreCase(key.asText())) return true;
         }
         return false;
     }
@@ -1157,17 +1159,17 @@ public class Transformations {
         if (fromRef == null
                 || view.table == null
                 || !NODE_TYPE_BASE_TABLE.equals(asText(fromRef, FIELD_TYPE))
-                || !view.table.equals(asText(fromRef, FIELD_TABLE_NAME))) return false;
+                || !view.table.equalsIgnoreCase(asText(fromRef, FIELD_TABLE_NAME))) return false;
         return qualifierMatches(view.schema, asText(fromRef, FIELD_SCHEMA_NAME))
                 && qualifierMatches(view.catalog, asText(fromRef, FIELD_CATALOG_NAME));
     }
 
-    /** Both absent, or both present and equal. */
+    /** Both absent, or both present and equal — case-insensitively, matching DuckDB resolution. */
     private static boolean qualifierMatches(String expected, String actual) {
         boolean expectedEmpty = expected == null || expected.isEmpty();
         boolean actualEmpty = actual == null || actual.isEmpty();
         if (expectedEmpty != actualEmpty) return false;
-        return expectedEmpty || expected.equals(actual);
+        return expectedEmpty || expected.equalsIgnoreCase(actual);
     }
 
     /**
@@ -1216,12 +1218,23 @@ public class Transformations {
 
     /** Column usage collected from the outer query: referenced name parts and STAR presence. */
     private static final class UsedColumns {
-        final Set<String> columnNames = new HashSet<>(); // every part of every COLUMN_REF (see collectUsage)
+        final Set<String> columnNames = new HashSet<>(); // every part of every COLUMN_REF, case-folded (see collectUsage)
         boolean hasStar = false;          // a bare (unqualified) STAR
         boolean hasQualifiedStar = false; // a table-qualified STAR, e.g. fv.*
     }
 
-    /** Deep-walk the outer query collecting COLUMN_REF name parts and STAR presence. */
+    /**
+     * DuckDB resolves identifiers case-insensitively — quoted ones included — so every identifier
+     * comparison in the prune must fold case, or a consumer spelling {@code "total tokens"} against a
+     * view column {@code "Total Tokens"} binds at execution but reads as unused here, and the pruned
+     * body then fails to bind. Folding also only errs conservative on the join side: a fold collision
+     * over-counts a qualifier, which keeps a join, never drops one.
+     */
+    private static String foldCase(String identifier) {
+        return identifier == null ? null : identifier.toLowerCase(java.util.Locale.ROOT);
+    }
+
+    /** Deep-walk the outer query collecting COLUMN_REF name parts (case-folded) and STAR presence. */
     private static void collectUsage(JsonNode node, UsedColumns out) {
         if (node == null || node.isNull()) return;
         if (node.isObject()) {
@@ -1231,7 +1244,7 @@ public class Transformations {
                 // cannot distinguish. Record every part as a potentially-used column name so a
                 // struct column projected by the view is never pruned away (conservative: keeps
                 // too much, never too little).
-                for (String part : getReferenceName(node)) out.columnNames.add(part);
+                for (String part : getReferenceName(node)) out.columnNames.add(foldCase(part));
                 return; // a COLUMN_REF has no nested COLUMN_REF/STAR children
             }
             if (STAR_CLASS.equals(clazz)) {
@@ -1246,13 +1259,18 @@ public class Transformations {
         }
     }
 
-    /** Reference counts over a view-body fragment, used to decide join eliminability. */
+    /** Reference counts over a view-body fragment, used to decide join eliminability.
+     *  Qualifiers are case-folded on both insert and lookup: a body referencing {@code TN.name}
+     *  against a join aliased {@code tn} binds in DuckDB, so an exact-match count would read the
+     *  join as unused and wrongly eliminate it. */
     private static final class UsageCounts {
-        final Map<String, Integer> qualifierCounts = new HashMap<>(); // table/alias -> #references
+        final Map<String, Integer> qualifierCounts = new HashMap<>(); // folded table/alias -> #references
         int unqualified = 0;  // single-part COLUMN_REFs
         int bareStars = 0;    // unqualified STARs
 
-        int count(String qualifier) { return qualifierCounts.getOrDefault(qualifier, 0); }
+        int count(String qualifier) { return qualifierCounts.getOrDefault(foldCase(qualifier), 0); }
+
+        void record(String qualifier) { qualifierCounts.merge(foldCase(qualifier), 1, Integer::sum); }
     }
 
     /** Deep-walk a body fragment counting per-qualifier references, unqualified refs, and bare stars. */
@@ -1262,13 +1280,13 @@ public class Transformations {
             String clazz = asText(node, FIELD_CLASS);
             if (COLUMN_REF_CLASS.equals(clazz)) {
                 String[] parts = getReferenceName(node);
-                if (parts.length >= 2) out.qualifierCounts.merge(parts[0], 1, Integer::sum);
+                if (parts.length >= 2) out.record(parts[0]);
                 else out.unqualified++;
                 return;
             }
             if (STAR_CLASS.equals(clazz)) {
                 String relation = asText(node, FIELD_RELATION_NAME);
-                if (relation != null && !relation.isEmpty()) out.qualifierCounts.merge(relation, 1, Integer::sum);
+                if (relation != null && !relation.isEmpty()) out.record(relation);
                 else out.bareStars++;
                 return;
             }
@@ -1279,22 +1297,59 @@ public class Transformations {
     }
 
     /**
-     * Projection pushdown is only safe when dropping a select-list entry cannot change row count
-     * or shift positional references: under DISTINCT the select list <em>is</em> the dedup key,
-     * and GROUP BY / ORDER BY may reference entries by position ({@code GROUP BY 1}). Join
-     * elimination remains applicable either way.
+     * Projection pushdown is only safe when dropping a select-list entry cannot change row count,
+     * shift positional references, or unbind a body-internal alias reference:
+     * <ul>
+     *   <li>under DISTINCT the select list <em>is</em> the dedup key (DISTINCT is a modifier);</li>
+     *   <li>GROUP BY / ORDER BY may reference entries by position ({@code GROUP BY 1});</li>
+     *   <li>under {@code GROUP BY ALL} the grouping key is <b>derived from</b> the select list —
+     *       it serializes with EMPTY group_expressions and {@code aggregate_handling =
+     *       FORCE_AGGREGATES}, so the group checks below never see it, and dropping an entry
+     *       would silently change the grouping;</li>
+     *   <li>a {@code QUALIFY} clause (its own field, not a modifier) may reference a select-list
+     *       alias ({@code QUALIFY rn = 1}), so dropping the aliased entry unbinds it;</li>
+     *   <li>{@code HAVING} likewise, and a HAVING without GROUP BY also forces implicit
+     *       aggregation.</li>
+     * </ul>
+     * Join elimination remains applicable in every one of these cases.
+     *
+     * <p>Implicit aggregation with no marker at all ({@code SELECT 42 AS c, sum(x) AS s FROM t}
+     * serializes with STANDARD_HANDLING, empty groups, no HAVING) is handled inside
+     * {@link #pruneSelectList} instead — aggregate-ness is a binder fact invisible at parse level,
+     * so it is guarded structurally there rather than detected here.
      */
     private static boolean projectionPruningIsSafe(JsonNode body) {
         JsonNode modifiers = body.get(FIELD_MODIFIERS);
         if (modifiers != null && modifiers.isArray() && !modifiers.isEmpty()) return false;
         JsonNode groups = body.get(FIELD_GROUP_EXPRESSIONS);
         if (groups != null && groups.isArray() && !groups.isEmpty()) return false;
+        JsonNode qualify = body.get(FIELD_QUALIFY);
+        if (qualify != null && !qualify.isNull()) return false;
+        JsonNode having = body.get(FIELD_HAVING);
+        if (having != null && !having.isNull()) return false;
+        String aggregateHandling = asText(body, FIELD_AGGREGATE_HANDLING);
+        if (aggregateHandling != null && !AGGREGATE_HANDLING_STANDARD.equals(aggregateHandling)) return false;
         JsonNode groupSets = body.get(FIELD_GROUP_SETS);
         return groupSets == null || !groupSets.isArray() || groupSets.isEmpty();
     }
 
     /**
-     * (a) Keep every STAR and non-column expression; keep a COLUMN_REF only if its output name is used.
+     * (a) An entry is droppable when we can name it and the outer query never uses that name: a
+     * COLUMN_REF under its alias or column name, any other expression under its alias. A STAR is
+     * always kept (it expands to an unknown column set), as is an unaliased expression — its output
+     * name is whatever DuckDB derives from the expression text, which we do not model.
+     *
+     * <p>Dropping expressions, not just columns, matters twice over. The expression stops being
+     * computed — on a view carrying correlated scalar subqueries that is the dominant cost of every
+     * projection that doesn't reference them, since the engine plans them as delim joins at bind
+     * time regardless of projection. And it stops contributing references: join elimination (b)
+     * counts over the pruned body, so an unused expression whose lambda parameter reads as an
+     * unqualified column no longer disables elimination for the whole view.
+     *
+     * <p>One observable consequence, accepted deliberately: a correlated scalar subquery that would
+     * error at runtime (more than one row) no longer errors when its column is not projected. That
+     * direction only — an error becomes a result, never a result a different result.
+     *
      * @return true if any entry was dropped
      */
     private static boolean pruneSelectList(ObjectNode body, Set<String> usedViewCols) {
@@ -1302,17 +1357,54 @@ public class Transformations {
         if (!(selectList instanceof ArrayNode list)) return false;
         ArrayNode kept = objectMapper.createArrayNode();
         for (JsonNode entry : list) {
-            String clazz = asText(entry, FIELD_CLASS);
-            if (COLUMN_REF_CLASS.equals(clazz)) {
-                if (usedViewCols.contains(selectOutputName(entry))) kept.add(entry);
-                // else: dropped (outer query never references this column)
-            } else {
-                kept.add(entry); // STAR or complex expression — keep conservatively
+            if (STAR_CLASS.equals(asText(entry, FIELD_CLASS))) {
+                kept.add(entry); // expands to an unknown column set — never droppable
+                continue;
             }
+            String name = selectOutputName(entry);
+            if (name.isEmpty() || usedViewCols.contains(foldCase(name))) {
+                kept.add(entry); // unnameable, or actually referenced (usedViewCols is case-folded)
+            }
+            // else: dropped — the outer query cannot see this entry under any name
         }
         if (kept.isEmpty() || kept.size() == list.size()) return false; // nothing droppable (never emit an empty list)
+        // Implicit-aggregation guard: `SELECT 42 AS c, sum(x) AS s FROM t` is one row, and dropping
+        // s makes it N — but aggregate-ness is a binder fact, invisible at parse level (sum is just a
+        // function name, and operators like + are FUNCTION nodes too), so it cannot be detected, only
+        // excluded structurally. In a VALID implicitly-aggregated query, every entry that references
+        // a column does so through an aggregate; so a kept column reference proves the pruned body is
+        // still aggregated, and in a non-aggregated body row count is projection-independent anyway.
+        // If nothing kept references a column, every kept entry may be a plain constant — drop
+        // nothing. (SUBQUERY subtrees are skipped by referencesAColumn: their refs are their own
+        // scope, and an uncorrelated scalar subquery is exactly the constant-like case this guards.)
+        boolean keptReferencesAColumn = false;
+        for (JsonNode entry : kept) {
+            if (referencesAColumn(entry)) {
+                keptReferencesAColumn = true;
+                break;
+            }
+        }
+        if (!keptReferencesAColumn) return false;
         body.set(FIELD_SELECT_LIST, kept);
         return true;
+    }
+
+    /** Any COLUMN_REF or STAR in this expression's own scope — SUBQUERY subtrees excluded. */
+    private static boolean referencesAColumn(JsonNode node) {
+        if (node == null || node.isNull()) return false;
+        if (node.isObject()) {
+            String clazz = asText(node, FIELD_CLASS);
+            if (SUBQUERY_CLASS.equals(clazz)) return false; // its refs bind in the subquery's scope
+            if (COLUMN_REF_CLASS.equals(clazz) || STAR_CLASS.equals(clazz)) return true;
+            for (JsonNode child : node) {
+                if (referencesAColumn(child)) return true;
+            }
+        } else if (node.isArray()) {
+            for (JsonNode child : node) {
+                if (referencesAColumn(child)) return true;
+            }
+        }
+        return false;
     }
 
     /** Output name of a select-list entry: its alias, else the last part of a COLUMN_REF's names. */

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/PruneUnusedLeftJoinsTest.java
@@ -664,4 +664,354 @@ public class PruneUnusedLeftJoinsTest {
             conn.createStatement().execute("DROP SCHEMA IF EXISTS s3");
         }
     }
+
+    // ---- complex select-list entries: droppable when aliased and unused ----
+    //
+    // An entry is droppable when we can name it and the outer query never uses that name — which
+    // now includes aliased CASE/CAST/FUNCTION/SUBQUERY entries, not only COLUMN_REFs. Two payoffs:
+    // the expression stops being computed, and it stops contributing references, so an expression
+    // whose lambda parameter reads as an unqualified column no longer disables join elimination
+    // for the whole view. STARs and unaliased expressions are still kept unconditionally.
+
+    /** Body with an aliased plain expression and both dimension joins. */
+    private static final String EXPR_VIEW_BODY =
+            "SELECT f.f_id, f.f_col, a.a_name, b.b_name, f.f_col + f.a_id AS total " +
+            "FROM f " +
+            "LEFT JOIN a ON f.a_id = a.a_id " +
+            "LEFT JOIN b ON f.b_id = b.b_id";
+
+    /** Body with a lambda: the parameter `r` is a single-part COLUMN_REF to the reference
+     *  counter, so while this entry survives, no join in the body is eliminable. */
+    private static final String LAMBDA_VIEW_BODY =
+            "SELECT f.f_id, f.f_col, a.a_name, b.b_name, " +
+            "list_filter([f.a_id], r -> r > 0) AS flt " +
+            "FROM f " +
+            "LEFT JOIN a ON f.a_id = a.a_id " +
+            "LEFT JOIN b ON f.b_id = b.b_id";
+
+    @Test
+    void unusedAliasedExpression_isDropped() throws Exception {
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fve AS " + EXPR_VIEW_BODY);
+        try {
+            String outer = "SELECT f_col FROM fve WHERE f_col > 10";
+            JsonNode pruned = prune(outer, EXPR_VIEW_BODY);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertFalse(sql.contains("total"), "the unused aliased expression must be dropped: " + sql);
+            assertEquals(0, countJoins(pruned), "no dimension column is used");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fve");
+        }
+    }
+
+    @Test
+    void usedAliasedExpression_isKept() throws Exception {
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fve AS " + EXPR_VIEW_BODY);
+        try {
+            String outer = "SELECT f_col, total FROM fve";
+            JsonNode pruned = prune(outer, EXPR_VIEW_BODY);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("total"), "the referenced expression must survive: " + sql);
+            assertEquals(0, countJoins(pruned),
+                    "the expression references only f, so both joins still go");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fve");
+        }
+    }
+
+    @Test
+    void unaliasedExpression_isKept() throws Exception {
+        // No alias → its output name is whatever DuckDB derives from the expression text, which
+        // the prune does not model. Kept regardless of projection; the unused join still goes.
+        String body =
+                "SELECT f.f_id, f.f_col, a.a_name, f.f_col + f.a_id " +
+                "FROM f " +
+                "LEFT JOIN a ON f.a_id = a.a_id " +
+                "LEFT JOIN b ON f.b_id = b.b_id";
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvu AS " + body);
+        try {
+            String outer = "SELECT f_col FROM fvu";
+            JsonNode pruned = prune(outer, body);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("f_col + "),
+                    "an unaliased expression is unnameable and must be kept: " + sql);
+            assertEquals(0, countJoins(pruned),
+                    "the kept expression references only f, and the unused a_name column is "
+                    + "pruned as usual — so both joins still go");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvu");
+        }
+    }
+
+    /** The §7.0 regression case (analytics-schema): dropping the unused lambda entry removes its
+     *  unqualified `r` before join elimination counts references, so elimination works again. */
+    @Test
+    void unusedLambdaExpression_droppedAndJoinsEliminated() throws Exception {
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvl AS " + LAMBDA_VIEW_BODY);
+        try {
+            String outer = "SELECT f_col FROM fvl WHERE f_col > 10";
+            JsonNode pruned = prune(outer, LAMBDA_VIEW_BODY);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertFalse(sql.contains("list_filter"), "the unused lambda entry must be dropped: " + sql);
+            assertEquals(0, countJoins(pruned),
+                    "with the lambda gone, its parameter no longer reads as an unqualified column, "
+                    + "so both joins are eliminable");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvl");
+        }
+    }
+
+    /** The complement: a lambda the caller DID ask for still blocks elimination — that limitation
+     *  is unchanged, this feature only removes entries nobody uses. */
+    @Test
+    void usedLambdaExpression_keptAndJoinsRetained() throws Exception {
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvl AS " + LAMBDA_VIEW_BODY);
+        try {
+            String outer = "SELECT f_col, flt FROM fvl";
+            JsonNode pruned = prune(outer, LAMBDA_VIEW_BODY);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("list_filter"), "the referenced lambda entry must survive: " + sql);
+            assertEquals(2, countJoins(pruned),
+                    "the surviving lambda parameter still blocks elimination of every join");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvl");
+        }
+    }
+
+    @Test
+    void allEntriesUnused_selectListIsNeverEmptied() throws Exception {
+        // The outer query references no view column at all, so every (droppable) entry is unused.
+        // The kept-list-empty guard must leave the select list alone rather than emit `SELECT FROM`;
+        // join elimination still fires independently.
+        String body =
+                "SELECT f.f_col + f.a_id AS total " +
+                "FROM f " +
+                "LEFT JOIN a ON f.a_id = a.a_id";
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvx AS " + body);
+        try {
+            String outer = "SELECT 42 AS c FROM fvx";
+            JsonNode pruned = prune(outer, body);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("total"),
+                    "the last entry must be kept — a select list can never be emptied: " + sql);
+            assertEquals(0, countJoins(pruned), "the unused join is still eliminated");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvx");
+        }
+    }
+
+    // ---- shapes where the select list is semantically load-bearing: pruning must not run ----
+
+    /** GROUP BY ALL derives the grouping key FROM the select list, and serializes with EMPTY
+     *  group_expressions (aggregate_handling=FORCE_AGGREGATES is the only marker) — so without its
+     *  own gate, dropping an entry silently changes the grouping. Join elimination still applies. */
+    @Test
+    void groupByAllBody_selectListNotPruned_unusedJoinStillDropped() throws Exception {
+        String body =
+                "SELECT f.a_id, a.a_name, sum(f.f_col) AS s " +
+                "FROM f " +
+                "LEFT JOIN a ON f.a_id = a.a_id " +
+                "LEFT JOIN b ON f.b_id = b.b_id " +
+                "GROUP BY ALL";
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvall AS " + body);
+        try {
+            String outer = "SELECT a_id, s FROM fvall";
+            JsonNode pruned = prune(outer, body);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("a_name"),
+                    "under GROUP BY ALL the select list IS the grouping key — a_name must stay: " + sql);
+            assertEquals(1, countJoins(pruned), "b is unused and still eliminable under GROUP BY ALL");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvall");
+        }
+    }
+
+    /** QUALIFY is its own field (not a modifier) and may reference a select-list alias — dropping
+     *  the aliased window function would unbind a valid query. With an inline window in the
+     *  QUALIFY (every reference qualified), the gate is what keeps the rn entry; join elimination
+     *  still applies. */
+    @Test
+    void qualifyBody_selectListNotPruned_unusedJoinStillDropped() throws Exception {
+        String body =
+                "SELECT f.f_id, f.f_col, " +
+                "row_number() OVER (PARTITION BY f.a_id ORDER BY f.f_id) AS rn " +
+                "FROM f " +
+                "LEFT JOIN b ON f.b_id = b.b_id " +
+                "QUALIFY row_number() OVER (PARTITION BY f.a_id ORDER BY f.f_id) = 1";
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvq AS " + body);
+        try {
+            String outer = "SELECT f_col FROM fvq";
+            JsonNode pruned = prune(outer, body);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("rn"),
+                    "the QUALIFY gate must keep the whole select list, rn included: " + sql);
+            assertEquals(0, countJoins(pruned), "b is unused and still eliminable under QUALIFY");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvq");
+        }
+    }
+
+    /** The common QUALIFY spelling references the alias unqualified ({@code QUALIFY rn = 1}), which
+     *  ALSO reads as an unqualified column to the join-elimination counter — so the entire prune
+     *  no-ops for that shape: select list gated, joins retained, input returned as-is. */
+    @Test
+    void qualifyReferencingAnAlias_wholePruneBailsOut() throws Exception {
+        String body =
+                "SELECT f.f_id, f.f_col, " +
+                "row_number() OVER (PARTITION BY f.a_id ORDER BY f.f_id) AS rn " +
+                "FROM f " +
+                "LEFT JOIN b ON f.b_id = b.b_id " +
+                "QUALIFY rn = 1";
+        assertBailsOut("SELECT f_col FROM fvq2", body);
+    }
+
+    /** HAVING may reference a select alias, and HAVING without GROUP BY also forces implicit
+     *  aggregation — either way the select list must be left alone. */
+    @Test
+    void havingBody_selectListNotPruned() throws Exception {
+        String body =
+                "SELECT sum(f.f_col) AS s, 42 AS tag " +
+                "FROM f " +
+                "LEFT JOIN a ON f.a_id = a.a_id " +
+                "HAVING sum(f.f_col) > 0";
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvh AS " + body);
+        try {
+            String outer = "SELECT tag FROM fvh";
+            JsonNode pruned = prune(outer, body);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("sum("), "HAVING forces aggregation — s must stay: " + sql);
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvh");
+        }
+    }
+
+    /** Implicit aggregation has NO parse-level marker (STANDARD_HANDLING, empty groups, no HAVING):
+     *  `SELECT 42 AS tag, sum(x) AS s` is one row, and dropping s would make it N. Aggregate-ness is
+     *  a binder fact, so the guard is structural: when nothing kept references a column, every kept
+     *  entry may be a plain constant, and nothing is dropped. Join elimination is unaffected. */
+    @Test
+    void implicitAggregationBody_aggregateNotDroppedForAConstantProjection() throws Exception {
+        String body =
+                "SELECT 42 AS tag, sum(f.f_col) AS s " +
+                "FROM f " +
+                "LEFT JOIN a ON f.a_id = a.a_id";
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvagg AS " + body);
+        try {
+            String outer = "SELECT tag FROM fvagg";
+            JsonNode pruned = prune(outer, body);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("sum("),
+                    "dropping the only aggregate would turn 1 row into N — s must stay: " + sql);
+            assertEquals(0, countJoins(pruned), "a is unused and still eliminable");
+            assertEquals(1, exec(Transformations.parseToSql(conn, pruned)).size(),
+                    "the pruned body must still aggregate to one row");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvagg");
+        }
+    }
+
+    // ---- case-insensitive identifier matching (DuckDB resolves identifiers case-insensitively) ----
+
+    /** A consumer spelling a column in a different case binds in DuckDB, so the prune must read it
+     *  as used — exact matching dropped the entry and the pruned body then failed to bind. */
+    @Test
+    void differentlyCasedReference_stillCountsAsUsed() throws Exception {
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fve AS " + EXPR_VIEW_BODY);
+        try {
+            String outer = "SELECT F_COL, TOTAL FROM fve";
+            JsonNode pruned = prune(outer, EXPR_VIEW_BODY);
+
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertTrue(sql.contains("total"), "TOTAL must match the total alias case-insensitively: " + sql);
+            assertTrue(sql.contains("f_col"), "F_COL must match the f_col column case-insensitively: " + sql);
+            assertEquals(0, countJoins(pruned), "no dimension column is used under any casing");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fve");
+        }
+    }
+
+    /** A body referencing {@code A.a_name} against a join on table {@code a} binds in DuckDB, so the
+     *  qualifier count must fold case — exact matching read the join as unused and eliminated it
+     *  out from under a still-projected column. */
+    @Test
+    void differentlyCasedQualifierInBody_keepsItsJoin() throws Exception {
+        String body =
+                "SELECT f.f_id, f.f_col, A.a_name, b.b_name " +
+                "FROM f " +
+                "LEFT JOIN a ON f.a_id = a.a_id " +
+                "LEFT JOIN b ON f.b_id = b.b_id";
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fvc AS " + body);
+        try {
+            String outer = "SELECT f_col, a_name FROM fvc";
+            JsonNode pruned = prune(outer, body);
+
+            assertEquals(1, countJoins(pruned),
+                    "the a join is used through the differently-cased A.a_name and must survive; "
+                    + "only b is eliminable");
+            assertEquivalentToView(pruned, outer);
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fvc");
+        }
+    }
+
+    /** A CTE named {@code FV} shadows view {@code fv} in DuckDB, so the shadow bail must also
+     *  match case-insensitively — an exact match would inline the view over a reference that
+     *  actually resolves to the CTE. */
+    @Test
+    void differentlyCasedCteShadow_stillBailsOut() throws Exception {
+        assertBailsOut("WITH FV AS (SELECT 1 AS f_col) SELECT f_col FROM fv", "fv", VIEW_BODY);
+    }
+
+    /**
+     * The one observable behaviour change, pinned as a decision: a correlated scalar subquery that
+     * returns more than one row errors at runtime — and DuckDB plans it as a delim join regardless
+     * of projection, so the view errors even for callers who never projected the column. Dropping
+     * the unused entry makes those callers succeed. One direction only: an error becomes a result,
+     * never a result a different result.
+     */
+    @Test
+    void multiRowScalarSubquery_errorSuppressedWhenColumnUnused() throws Exception {
+        conn.createStatement().execute("CREATE TABLE dup (d_id INT, d_name VARCHAR)");
+        conn.createStatement().execute("INSERT INTO dup VALUES (10,'x'),(10,'y')");
+        String body =
+                "SELECT f.f_id, f.f_col, " +
+                "(SELECT dup.d_name FROM dup WHERE dup.d_id = f.a_id) AS one_name " +
+                "FROM f " +
+                "LEFT JOIN a ON f.a_id = a.a_id";
+        conn.createStatement().execute("CREATE OR REPLACE VIEW fverr AS " + body);
+        try {
+            String outer = "SELECT f_col FROM fverr";
+            org.junit.jupiter.api.Assertions.assertThrows(SQLException.class, () -> exec(outer),
+                    "precondition: the un-pruned view must error even though one_name is not projected");
+
+            JsonNode pruned = prune(outer, body);
+            String sql = Transformations.parseToSql(conn, pruned).toLowerCase();
+            assertFalse(sql.contains("one_name"), "the unused subquery entry must be dropped: " + sql);
+            assertEquals(3, exec(Transformations.parseToSql(conn, pruned)).size(),
+                    "with the subquery dropped, the same projection succeeds");
+        } finally {
+            conn.createStatement().execute("DROP VIEW IF EXISTS fverr");
+            conn.createStatement().execute("DROP TABLE IF EXISTS dup");
+        }
+    }
 }


### PR DESCRIPTION
## What

`Transformations.pruneSelectList` kept every non-`COLUMN_REF` entry unconditionally. Now an entry is droppable when it can be **named** and the outer query never **uses** that name — aliased `CASE`/`CAST`/`FUNCTION`/`SUBQUERY` entries included. `STAR`s and unaliased expressions are still kept unconditionally.

Two payoffs:

1. **Unused expressions stop being computed.** A correlated scalar subquery in a view's select list plans as a delim join regardless of projection, so it is a flat tax on every query against the view. Measured on a 500k-row consumer view carrying four such subqueries: 0.815 s → ~0.055 s for a projection referencing none of them, `count(*)` included.
2. **Unused expressions stop contributing references.** Join elimination counts references over the already-pruned body, so an unused lambda whose parameter reads as an unqualified column (the AST has no node type for a lambda parameter) no longer disables elimination for the *whole* view.

## New projection-pruning gates

Implementing this surfaced three select-list shapes that passed `projectionPruningIsSafe` unguarded — one of them a **pre-existing silent-wrong-results hole** for plain columns, widened by this change:

| shape | why it was invisible | consequence unguarded |
|---|---|---|
| `GROUP BY ALL` | serializes with **empty** `group_expressions`; `aggregate_handling = FORCE_AGGREGATES` is the only marker | dropping an entry silently changes the grouping key |
| `QUALIFY` | own AST field, not a modifier | dropping the aliased window function it references unbinds a valid query |
| `HAVING` (no GROUP BY) | own AST field | alias unbind + forces implicit aggregation |
| implicit aggregation (`SELECT 42 AS c, sum(x) AS s`) | **no parse-level marker at all** | dropping `s` turns 1 row into N |

The first three are gated in `projectionPruningIsSafe`. The fourth cannot be detected at parse level — aggregate-ness is a binder fact; `sum` and `+` are both just `FUNCTION` nodes — so the guard is structural: **when anything is dropped, at least one kept entry must reference a column outside `SUBQUERY` subtrees**. In a valid implicitly-aggregated query, every column-referencing entry does so through an aggregate, so a kept column reference proves the pruned body stays aggregated; in a non-aggregated body row count is projection-independent anyway. (`SUBQUERY` subtrees are excluded because their refs bind in their own scope — an uncorrelated scalar subquery is exactly the constant-like case this guards.)

## One deliberate behaviour change

A multi-row correlated scalar subquery errors at runtime — and DuckDB plans it regardless of projection, so the view errored even for callers who never projected the column. With the entry dropped, those callers now succeed. One direction only: an error becomes a result, never a result a different result. Pinned by `multiRowScalarSubquery_errorSuppressedWhenColumnUnused`.

## Identifier comparisons now fold case

DuckDB resolves identifiers case-insensitively (quoted ones included); the prune matched exactly. Folding fixes one widened exposure and two latent soundness bugs:

- **used-column matching** — a consumer spelling `"TOTAL"` no longer gets the `total` entry pruned out from under it (previously a bind failure after inlining)
- **join-qualifier counting** — a body referencing `A.a_name` against a join on `a` no longer reads the join as unused and wrongly eliminates it
- **CTE shadow bail** — a CTE named `FV` now shadows view `fv`, as it does in DuckDB (exact matching missed the shadow and inlined the view over a reference that resolves to the CTE)
- **view-name location** — `isViewRef`/`qualifierMatches` match case-insensitively

Fold-collision errs conservative on every path: keeps an entry, keeps a join, or bails — never drops.

## Tests

`PruneUnusedLeftJoinsTest`: 36 → 54 cases. New coverage: dropped/kept/unaliased expression; unused lambda → joins eliminable again (and the complement: a *used* lambda still blocks, unchanged); never-empty select list; the four gate shapes above (incl. the alias-referencing `QUALIFY rn = 1` spelling, where the whole prune correctly no-ops); case-folded matching (used-column, join-qualifier, CTE shadow); suppressed-error decision. Every elimination case asserts result-set equivalence against the un-pruned view.

Full `dazzleduck-sql-commons` suite: **400 tests, 0 failures** under JDK 21 (8 pre-existing ingestion skips; JDK 25 breaks Arrow's `RootAllocator`).

`LEFT_JOIN_PRUNING_SPEC.md` updated: the droppable-entry rule, the new gates, the implicit-aggregation guard, and case folding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)