### PR TITLE
refactor(config): finish the StartupScriptProvider migration to common

### DIFF
--- a/dazzleduck-sql-ducklake-compactor/pom.xml
+++ b/dazzleduck-sql-ducklake-compactor/pom.xml
@@ -22,14 +22,17 @@
     </properties>
 
     <dependencies>
+        <!-- ConnectionPool + CommandLineConfigUtil; brings dazzleduck-sql-common transitively. -->
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- StartupScriptProvider. Declared even though commons pulls it in, because this module
+             imports it directly and a transitive path is not a contract. -->
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
-            <artifactId>dazzleduck-sql-flight</artifactId>
+            <artifactId>dazzleduck-sql-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/dazzleduck-sql-ducklake-compactor/src/main/java/io/dazzleduck/sql/compaction/Main.java
+++ b/dazzleduck-sql-ducklake-compactor/src/main/java/io/dazzleduck/sql/compaction/Main.java
@@ -2,7 +2,7 @@ package io.dazzleduck.sql.compaction;
 
 import com.typesafe.config.Config;
 import io.dazzleduck.sql.commons.ConnectionPool;
-import io.dazzleduck.sql.flight.StartupScriptProvider;
+import io.dazzleduck.sql.common.StartupScriptProvider;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
 import org.slf4j.Logger;

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/StartupScriptProvider.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/StartupScriptProvider.java
@@ -1,70 +1,33 @@
 package io.dazzleduck.sql.flight;
 
 import com.typesafe.config.Config;
-import io.dazzleduck.sql.commons.config.ConfigBasedProvider;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+/**
+ * @deprecated Use {@link io.dazzleduck.sql.common.StartupScriptProvider}.
+ *             <p>This interface duplicated the one in {@code dazzleduck-sql-common}, which is the
+ *             layer a startup script belongs in: reading SQL to run at connection setup has nothing
+ *             to do with Arrow Flight, and a service that needs only that had to depend on the
+ *             whole Flight module to get it. It is retained so that any implementation declaring
+ *             {@code implements io.dazzleduck.sql.flight.StartupScriptProvider} still compiles and
+ *             still loads.
+ *             <p>The companion {@link ConfigBasedStartupScriptProvider} shim is the one that
+ *             matters at runtime, since HOCON can name that class by string.
+ */
+@Deprecated(forRemoval = true)
+public interface StartupScriptProvider extends io.dazzleduck.sql.common.StartupScriptProvider {
 
-public interface StartupScriptProvider extends ConfigBasedProvider {
+    String STARTUP_SCRIPT_CONFIG_PREFIX =
+            io.dazzleduck.sql.common.StartupScriptProvider.STARTUP_SCRIPT_CONFIG_PREFIX;
 
-    String STARTUP_SCRIPT_CONFIG_PREFIX = "startup_script_provider";
-    Pattern ENV_VAR_PATTERN = Pattern.compile("\\$\\{([A-Za-z_][A-Za-z0-9_]*)\\}");
-
-    void setConfig(Config config);
-
-    String getStartupScript()  throws IOException;
-
-    static StartupScriptProvider load(Config config) throws Exception {
-        return ConfigBasedProvider.load(config, STARTUP_SCRIPT_CONFIG_PREFIX,
-                new ConfigBasedStartupScriptProvider());
+    /** @deprecated Use {@link io.dazzleduck.sql.common.StartupScriptProvider#load(Config)}. */
+    @Deprecated(forRemoval = true)
+    static io.dazzleduck.sql.common.StartupScriptProvider load(Config config) throws Exception {
+        return io.dazzleduck.sql.common.StartupScriptProvider.load(config);
     }
 
-    /**
-     * Replaces all environment variable references in the given content with their actual values
-     * from the process environment ({@link System#getenv}).
-     *
-     * <p>Supported syntax: {@code ${VAR_NAME}} where {@code VAR_NAME} must start with a letter or
-     * underscore and contain only letters, digits, or underscores (i.e. matches
-     * {@code [A-Za-z_][A-Za-z0-9_]*}).
-     *
-     * <p>All referenced variables must be present in the environment. If any are missing, an
-     * {@link IllegalArgumentException} is thrown listing every unresolved variable so the caller
-     * can fix the misconfiguration before the script reaches DuckDB.
-     *
-     * <p>Example:
-     * <pre>{@code
-     * // Given: ENV WAREHOUSE=/data
-     * String script = "ATTACH '${WAREHOUSE}/db.duckdb' AS db;";
-     * String result = StartupScriptProvider.replaceEnvVariable(script);
-     * // result => "ATTACH '/data/db.duckdb' AS db;"
-     * }</pre>
-     *
-     * @param content the script or configuration text containing {@code ${VAR_NAME}} references
-     * @return the content with all environment variable references substituted
-     * @throws IllegalArgumentException if one or more referenced environment variables are not set
-     */
+    /** @deprecated Use {@link io.dazzleduck.sql.common.StartupScriptProvider#replaceEnvVariable}. */
+    @Deprecated(forRemoval = true)
     static String replaceEnvVariable(String content) {
-        Matcher matcher = ENV_VAR_PATTERN.matcher(content);
-        StringBuilder result = new StringBuilder();
-        List<String> missing = new ArrayList<>();
-        while (matcher.find()) {
-            String varName = matcher.group(1);
-            String value = System.getenv(varName);
-            if (value == null) {
-                missing.add(varName);
-            } else {
-                matcher.appendReplacement(result, Matcher.quoteReplacement(value));
-            }
-        }
-        if (!missing.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Startup script references undefined environment variable(s): " + missing);
-        }
-        matcher.appendTail(result);
-        return result.toString();
+        return io.dazzleduck.sql.common.StartupScriptProvider.replaceEnvVariable(content);
     }
 }

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/Main.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/Main.java
@@ -2,9 +2,7 @@ package io.dazzleduck.sql.flight.server;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import io.dazzleduck.sql.commons.config.ConfigBasedProvider;
-import io.dazzleduck.sql.flight.ConfigBasedStartupScriptProvider;
-import io.dazzleduck.sql.flight.StartupScriptProvider;
+import io.dazzleduck.sql.common.StartupScriptProvider;
 import io.dazzleduck.sql.common.ConfigConstants;
 import io.dazzleduck.sql.commons.util.CommandLineConfigUtil;
 import io.dazzleduck.sql.commons.ConnectionPool;
@@ -66,9 +64,9 @@ public class Main {
     }
     public static FlightServer createServer(Config config) throws Exception {
         // Execute startup script if provided
-        StartupScriptProvider startupScriptProvider = ConfigBasedProvider.load(config,
-                StartupScriptProvider.STARTUP_SCRIPT_CONFIG_PREFIX,
-                new ConfigBasedStartupScriptProvider());
+        // StartupScriptProvider.load does exactly this — same prefix, same default — so call it
+        // rather than re-deriving the arguments at the call site.
+        StartupScriptProvider startupScriptProvider = StartupScriptProvider.load(config);
         if (startupScriptProvider.getStartupScript() != null) {
             ConnectionPool.executeOnSingleton(startupScriptProvider.getStartupScript());
         }

--- a/dazzleduck-sql-runtime/src/main/java/io/dazzleduck/sql/runtime/Runtime.java
+++ b/dazzleduck-sql-runtime/src/main/java/io/dazzleduck/sql/runtime/Runtime.java
@@ -4,10 +4,8 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import static io.dazzleduck.sql.common.ConfigConstants.CONFIG_PATH;
-import io.dazzleduck.sql.commons.config.ConfigBasedProvider;
 import io.dazzleduck.sql.commons.util.CommandLineConfigUtil;
-import io.dazzleduck.sql.flight.ConfigBasedStartupScriptProvider;
-import io.dazzleduck.sql.flight.StartupScriptProvider;
+import io.dazzleduck.sql.common.StartupScriptProvider;
 import io.dazzleduck.sql.common.ConfigConstants;
 import io.dazzleduck.sql.commons.ConnectionPool;
 import io.dazzleduck.sql.flight.server.DuckDBFlightSqlProducer;
@@ -107,9 +105,8 @@ public class Runtime implements Closeable {
     }
 
     private static void executeStartupScript(Config config) throws Exception {
-        StartupScriptProvider startupScriptProvider = ConfigBasedProvider.load(config,
-                StartupScriptProvider.STARTUP_SCRIPT_CONFIG_PREFIX,
-                new ConfigBasedStartupScriptProvider());
+        // StartupScriptProvider.load does exactly this — same prefix, same default.
+        StartupScriptProvider startupScriptProvider = StartupScriptProvider.load(config);
         String startupScript = startupScriptProvider.getStartupScript();
         if (startupScript != null && !startupScript.isBlank()) {
             logger.info("Executing startup script on singleton connection");


### PR DESCRIPTION
`StartupScriptProvider` exists **twice** — in `dazzleduck-sql-common` and `dazzleduck-sql-flight` — and the migration between them was half done. The flight `ConfigBasedStartupScriptProvider` is already `@Deprecated` pointing at common's, but the **interface** was not, and 3 of the 4 call sites still imported flight's.

This finishes it in the direction that note set: **`common` survives, `flight` becomes a shim.**

Reading SQL to run at connection setup has nothing to do with Arrow Flight, and a service needing only that had to depend on the whole Flight module to get it.

## What changed

`flight.StartupScriptProvider` → `@Deprecated(forRemoval)` shim extending common's, keeping its constant and static helpers as delegates, so both compatibility paths still work:

- an existing `implements io.dazzleduck.sql.flight.StartupScriptProvider` still compiles
- `class = "io.dazzleduck.sql.flight.ConfigBasedStartupScriptProvider"` in HOCON still loads

Call sites in the compactor, flight server and runtime now import `common`'s.

**Two call sites were bypassing the interface's own `load()`:**

```java
// before — re-deriving at the call site exactly what load() already supplies
StartupScriptProvider p = ConfigBasedProvider.load(config,
        StartupScriptProvider.STARTUP_SCRIPT_CONFIG_PREFIX,
        new ConfigBasedStartupScriptProvider());
// after
StartupScriptProvider p = StartupScriptProvider.load(config);
```

That also removes the last thing tying them to `ConfigBasedProvider` — which `common` **cannot** extend anyway, since `common` sits *below* `commons`. The duplicated reflection in common is structural, not an oversight, and is the one real cost of choosing common as the home.

## The payoff

**The compactor's only use of Flight was this interface**, so it no longer depends on `dazzleduck-sql-flight` at all. A compaction daemon no longer drags in an Arrow Flight server.

It now declares `dazzleduck-sql-common` explicitly alongside `commons`, since it imports from both directly (`ConnectionPool`, `CommandLineConfigUtil` from commons; `StartupScriptProvider` from common) and a transitive path is not a contract.

## Testing

Run under **Java 21**. The four touched modules — common, commons, flight, compactor — have **0 failures**.

Two unrelated suites fail identically on a clean `upstream/main` in full-reactor scope and are untouched here: `LogForwardingIntegrationTest` (logback module) and a temp-dir cleanup flake in commons. `dazzleduck-sql-runtime`'s `DuckLakePostgresLoadTest` needs Docker, unavailable locally.

## Follow-up

`flight.ConfigBasedStartupScriptProvider` and this shim can both be deleted once no configuration names the flight class paths — worth a note in the next release's upgrade notes rather than a silent removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)