### PR TITLE
ci: add GitHub Actions build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A newer push to the same branch makes the in-flight run obsolete.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test (JDK 21)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      # Runs the full reactor: compile, tests, plus the source/javadoc jars that
+      # the verify phase binds, so a release cannot be blocked by a javadoc break.
+      # Arrow's --add-opens flags come from the surefire argLine in the root pom.
+      # Tests tagged docker-compose are excluded by default; the testcontainers
+      # suites (MinIO, Postgres) run against the runner's Docker daemon.
+      - name: Build and test
+        run: ./mvnw -B -ntp clean verify
+
+      - name: Upload surefire reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: '**/target/surefire-reports/**'
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` — the repository's first CI. Until now there were no
workflows at all, so PRs merged with an empty status check rollup.

## What it does

Runs `./mvnw -B -ntp clean verify` on JDK 21 (Temurin) for every pull request and every
push to `main`.

- **`verify`, not `test`** — the root pom binds the source and javadoc jars to the `verify`
  phase, so this also catches a javadoc break before it can block a release.
- **No `MAVEN_OPTS` needed** — Arrow's `--add-opens` already comes from the surefire
  `argLine` in the root pom. The `MAVEN_OPTS` in the README applies to `exec:java` and
  local runs, not the test JVM.
- **Testcontainers suites run** against the runner's Docker daemon (MinIO, Postgres).
  Tests tagged `docker-compose` stay excluded by the existing default in
  `dazzleduck-sql-examples/pom.xml`.
- Maven dependency cache via `actions/setup-java`, in-progress runs cancelled when a PR is
  pushed again, and surefire reports uploaded as an artifact on failure.

## Verification

`./mvnw -B -ntp clean verify` — the exact command the workflow runs — passes locally on
JDK 21: **894 tests, 0 failures, 0 errors**, BUILD SUCCESS in 2m18s warm. The 45 minute
job timeout leaves ample room for a cold cache and container pulls.

## Follow-ups (deliberately not in this PR)

- A `release.yml` to automate what the 0.2.14 release did by hand (tag, Jib push, GitHub
  release, Maven Central deploy — the `central-publishing-maven-plugin` and GPG signing
  profile are already configured but never automated).
- Making Jib push a real multi-arch manifest in one run, rather than six per-arch builds
  plus `docker manifest create`.
- Once this is green, add `build` as a required status check on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)