### PR TITLE
fix(otel-collector): publish image as dazzleduck-otel-collector

### DIFF
--- a/dazzleduck-sql-otel-collector/pom.xml
+++ b/dazzleduck-sql-otel-collector/pom.xml
@@ -179,7 +179,7 @@
                         </platforms>
                     </from>
                     <to>
-                        <image>dazzleduck/dazzleduck-sql-otel-collector:${project.version}-${jib.architecture}</image>
+                        <image>dazzleduck/dazzleduck-otel-collector:${project.version}-${jib.architecture}</image>
                         <tags>
                             <tag>latest-${jib.architecture}</tag>
                         </tags>

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -49,7 +49,7 @@ MVN="$ROOT/mvnw"
 MODULES=(
   "runtime|dazzleduck-sql-runtime|dazzleduck/dazzleduck|multi"
   "compactor|dazzleduck-sql-ducklake-compactor|dazzleduck/ducklake-compactor|multi"
-  "otel-collector|dazzleduck-sql-otel-collector|dazzleduck/dazzleduck-sql-otel-collector|multi"
+  "otel-collector|dazzleduck-sql-otel-collector|dazzleduck/dazzleduck-otel-collector|multi"
   "scrapper|dazzleduck-sql-scrapper|dazzleduck/dazzleduck-sql-scrapper|single"
 )
 


### PR DESCRIPTION
The OTel collector's Jib target defaulted to `dazzleduck/dazzleduck-sql-otel-collector`,
which is not the repo the collector is actually released to. A plain
`mvn jib:build -pl dazzleduck-sql-otel-collector` therefore published to the wrong place.

## Why the short name is the right one

Both repos exist on Docker Hub, so this needed checking rather than assuming:

| Repo | `0.2.12` | `0.2.13` | `0.2.14` | `latest` |
|------|----------|----------|----------|----------|
| `dazzleduck/dazzleduck-otel-collector` | yes | yes | yes | matches `0.2.14` |
| `dazzleduck/dazzleduck-sql-otel-collector` | — | — | — | stale, unversioned |

Every tagged release lives under the short name. The long-named repo holds only a single
stale `latest` with no version tags — the residue of the wrong default being used by
accident. The 0.2.14 release went to the short name, as did 0.2.13 and 0.2.12.

## Changes

- `dazzleduck-sql-otel-collector/pom.xml` — Jib `<to><image>` now
  `dazzleduck/dazzleduck-otel-collector`.
- `scripts/docker-publish.sh` — the module registry carried the identical wrong name and
  would have re-published to the wrong repo on the next run. Only the image field changed;
  the Maven module directory in the second field is untouched.

The runtime and compactor modules were already correct.

## Verification

Built the image locally with `jib:buildTar` (no push) and read the tags back out of the
resulting tarball:

```
['dazzleduck/dazzleduck-otel-collector:0.2.14-arm64',
 'dazzleduck/dazzleduck-otel-collector:latest-arm64']
```

`scripts/docker-publish.sh` passes `bash -n`.

## Note on the stale repo

`dazzleduck/dazzleduck-sql-otel-collector:latest` is still on Docker Hub and now
unreachable from any build. Deleting it is a Docker Hub-side action and is not part of this
PR — worth doing if nothing is pulling it, since it is a stale `latest` that no release
will ever update.

Once this merges, the explicit `-Djib.to.image` override for the otel image in #381 becomes
redundant (it stays correct either way). I will drop it from that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)