### PR TITLE
fix: stop concurrent startup scripts racing on the singleton connection

### DIFF
--- a/dazzleduck-sql-client/src/test/java/io/dazzleduck/sql/client/HttpArrowProducerTest.java
+++ b/dazzleduck-sql-client/src/test/java/io/dazzleduck/sql/client/HttpArrowProducerTest.java
@@ -30,11 +30,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = "dazzleduck-singleton-connection", mode = ResourceAccessMode.READ_WRITE)
 public class HttpArrowProducerTest {
 
     private static SharedTestServer server;

--- a/dazzleduck-sql-client/src/test/java/io/dazzleduck/sql/client/HttpArrowProducerTimeoutTest.java
+++ b/dazzleduck-sql-client/src/test/java/io/dazzleduck/sql/client/HttpArrowProducerTimeoutTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.ByteArrayOutputStream;
 import java.time.Clock;
@@ -26,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
+@ResourceLock(value = "dazzleduck-singleton-connection", mode = ResourceAccessMode.READ_WRITE)
 public class HttpArrowProducerTimeoutTest {
 
     private static SharedTestServer server;

--- a/dazzleduck-sql-client/src/test/java/io/dazzleduck/sql/client/ProducerResilienceTest.java
+++ b/dazzleduck-sql-client/src/test/java/io/dazzleduck/sql/client/ProducerResilienceTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +45,7 @@ import static org.awaitility.Awaitility.await;
 @Tag("slow")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = "dazzleduck-singleton-connection", mode = ResourceAccessMode.READ_WRITE)
 public class ProducerResilienceTest {
 
     private static final Logger logger = LoggerFactory.getLogger(ProducerResilienceTest.class);

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ConnectionPool.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ConnectionPool.java
@@ -498,14 +498,24 @@ public enum ConnectionPool {
      */
     public static void executeOnSingleton(String script) {
         String[] statements = splitStatements(script);
-        try (Statement statement = INSTANCE.connection.createStatement()) {
+        // The singleton connection is process-wide, so several servers starting in the
+        // same JVM run their startup scripts against it at once. A DuckDB connection is
+        // not safe for concurrent statement execution, so serialise on it here.
+        synchronized (INSTANCE.connection) {
             for (String sql : statements) {
-                if (!sql.isBlank()) {
+                if (sql.isBlank()) {
+                    continue;
+                }
+                // A fresh statement per SQL: reusing one across the script lets a failure
+                // in an earlier statement surface against a later one, which reports the
+                // opaque "unsuccessful or closed pending query result" instead of the
+                // actual error.
+                try (Statement statement = INSTANCE.connection.createStatement()) {
                     statement.execute(sql);
+                } catch (SQLException e) {
+                    throw new RuntimeSqlException("Failed to execute on singleton connection: " + sql, e);
                 }
             }
-        } catch (SQLException e) {
-            throw new RuntimeSqlException(e);
         }
     }
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/RuntimeSqlException.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/RuntimeSqlException.java
@@ -8,4 +8,9 @@ public class RuntimeSqlException extends RuntimeException {
         super(sqlException);
         this.sqlException = sqlException;
     }
+
+    public RuntimeSqlException(String message, SQLException sqlException){
+        super(message, sqlException);
+        this.sqlException = sqlException;
+    }
 }


### PR DESCRIPTION
Fixes the intermittent `HttpArrowProducerTimeoutTest` failure that CI hit twice on #381:

```
io.dazzleduck.sql.commons.RuntimeSqlException: java.sql.SQLException:
  Invalid Input Error: Attempting to execute an unsuccessful or closed pending query result
    at ConnectionPool.executeOnSingleton(ConnectionPool.java:508)
    at Runtime.executeStartupScript(Runtime.java:113)
    at SharedTestServer.start(SharedTestServer.java:73)
    at HttpArrowProducerTimeoutTest.setup(HttpArrowProducerTimeoutTest.java:39)
```

## What the CI log proves

`dazzleduck-sql-client` is the only module with a `junit-platform.properties` enabling
parallel execution, and three of its classes carry `@Execution(ExecutionMode.CONCURRENT)`.
In the failing run two servers began starting 6 ms apart on different workers, with no
completion in between:

```
00:06:22.962 [ForkJoinPool-1-worker-4] Starting test server - HTTP port: 35783 ...
00:06:22.968 [ForkJoinPool-1-worker-4] Starting test server - HTTP port: 36737 ...
```

`Runtime.start` runs the startup script through `ConnectionPool.executeOnSingleton`, which
executes against the **process-wide singleton connection** rather than a duplicate — by
design, so `ATTACH`/`LOAD` persist to every later connection. A DuckDB connection is not
safe for concurrent statement execution, so two servers starting at once execute on the
same connection concurrently.

## Changes

- **`executeOnSingleton` serialises on the singleton connection.** Multiple `Runtime`
  instances in one JVM is a real pattern, not only a test artifact.
- **A fresh `Statement` per SQL.** One `Statement` was reused across the whole script, so a
  failure in an earlier statement could surface against a later one — which is why the error
  was the opaque "unsuccessful or closed pending query result" rather than the real cause.
  The failing SQL is now in the exception message.
- **A JUnit `@ResourceLock`** on the three client classes that start a `SharedTestServer`,
  so their startups cannot overlap.

## Verification — please read

**I could not reproduce the failure locally**, so I cannot claim to have observed it turn
red then green. What I tried, all green: the client module 10× in a loop; a synthetic
concurrent `executeOnSingleton` test; the same mixed with `getConnection()`; and a run with
a clean `HOME` so the arrow extension was installed fresh rather than served from the local
cache. This machine has far more cores than a runner, which likely closes the window.

What I did verify:

- `./mvnw -B -ntp clean verify` passes on JDK 21 — 894 tests, BUILD SUCCESS.
- The overlap the log shows is **gone**: counting `Starting test server` lines that follow
  another with no `Test server started successfully` between them goes from present in the
  CI failure to **0** across the full local run.

So the overlap is fixed and proven; the causal link from that overlap to the DuckDB error is
strong inference from the stack trace, not a reproduction. If it recurs, the new message
now names the failing statement, which should settle it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)