### PR TITLE
test: remove timing assumptions from two flaky ingestion tests

### DIFF
--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DynamicQueueRepositoryTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DynamicQueueRepositoryTest.java
@@ -151,7 +151,13 @@ class DynamicQueueRepositoryTest {
             writeToDb(dbPath, "UPDATE " + DynamicQueueRepository.ATTACHMENT +
                     ".schema_version SET version = version + 1 WHERE id = 1");
 
-            Thread.sleep(200);
+            // The handler polls every 50ms. A fixed sleep assumes the poll thread got
+            // scheduled within it, which does not hold on a loaded CI runner, so wait for
+            // the condition itself instead.
+            long deadline = System.nanoTime() + java.time.Duration.ofSeconds(30).toNanos();
+            while (!handler.getKnownQueues().contains("q2") && System.nanoTime() < deadline) {
+                Thread.sleep(20);
+            }
 
             assertTrue(handler.getKnownQueues().contains("q2"), "hot-reload picked up the new queue");
 

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/ParquetIngestionQueueTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/ParquetIngestionQueueTest.java
@@ -46,8 +46,21 @@ public class ParquetIngestionQueueTest {
     }
 
     @AfterEach
-    public void cleanup() {
-        // Cleanup is handled by @TempDir
+    public void cleanup() throws Exception {
+        // close() interrupts the writer but abandons it if it outlives the join timeout
+        // (deliberately - it is a daemon and must not block shutdown). An abandoned writer
+        // keeps COPYing into tempDir, so letting @TempDir deletion start while one is alive
+        // races: the COPY fails and the directory cannot be emptied. Wait for quiescence
+        // first; @TempDir cleanup runs after @AfterEach.
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        while (System.nanoTime() < deadline && writerThreadsAlive()) {
+            Thread.sleep(20);
+        }
+    }
+
+    private static boolean writerThreadsAlive() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .anyMatch(t -> t.isAlive() && t.getName().startsWith("BulkIngestQueue-"));
     }
 
     @Test


### PR DESCRIPTION
The other two flakes seen on CI, both in `dazzleduck-sql-commons`, neither reproducible
locally (this machine has far more cores than a runner). Independent of #383, which fixes a
third, different flake.

## `DynamicQueueRepositoryTest.dynamicHandlerReflectsHotReload`

```
expected: <true> but was: <false>   ("hot-reload picked up the new queue")
```

The handler polls every 50ms and the test slept 200ms, assuming the poll thread got
scheduled inside that window. Under load it does not. Now waits for the condition, bounded
at 30s — same assertion, no timing assumption.

## `ParquetIngestionQueueTest.testIngestionWithSortOrder`

```
IO Failed to delete temp directory ... could not be deleted: source1.parquet
```

`BulkIngestQueue.close()` interrupts the writer and joins with a bound, and **deliberately
abandons** a writer still alive past it (it is a daemon and must not block shutdown — see the
comment in `close()`). An abandoned writer keeps COPYing into the `@TempDir`, so letting
JUnit delete that directory races it. That also explains the
`Failed to write to queue test-queue sql COPY` errors immediately preceding the failure in
the CI log.

Rather than change 16 queue construction sites — several deliberately exercise cancellation
and write-failure paths, where draining would alter what is under test — the class now waits
for writer quiescence in `@AfterEach`, which runs before `@TempDir` cleanup.

## Verification

`./mvnw test -pl dazzleduck-sql-commons` passes: 423 tests, 0 failures, 0 errors.

Honest caveat, as with #383: neither flake reproduces on this machine, so I could not watch
either turn red then green. The hot-reload change removes a provable wrong assumption. The
temp-dir change is reasoned from the abandoned-writer path in `close()` plus the COPY errors
in the log — sound, but a mitigation of a race I could not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)