### PR TITLE
build: publish all modules to Maven Central on a v* tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,42 @@ jobs:
             done
           done
 
+  # Central coordinates are immutable: once a version is published it can never be
+  # replaced or withdrawn. This runs only after the tag/pom cross-check in `verify`.
+  publish-central:
+    name: Publish to Maven Central
+    needs: verify
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      # server-id writes the <server> entry the central-publishing plugin resolves via
+      # publishingServerId, and gpg-private-key imports the signing key into the runner.
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      # -Ddazzleduck.release=true activates the release-sign-artifacts profile, which signs
+      # every artifact; the source and javadoc jars Central requires are already bound to
+      # the verify phase in the root pom.
+      - name: Deploy to Central
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./mvnw -B -ntp -DskipTests -Ddazzleduck.release=true deploy
+
   github-release:
     name: Create GitHub release
-    needs: [verify, publish-images]
+    needs: [verify, publish-images, publish-central]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/dazzleduck-sql-client-grpc/pom.xml
+++ b/dazzleduck-sql-client-grpc/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>dazzleduck-sql-client-grpc</artifactId>
     <name>DazzleDuck Project Client gRPC</name>
+    <description>Arrow Flight SQL (gRPC) client for the DazzleDuck SQL server.</description>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/dazzleduck-sql-client/pom.xml
+++ b/dazzleduck-sql-client/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>dazzleduck-sql-client</artifactId>
     <name>DazzleDuck Project Client</name>
+    <description>HTTP client for the DazzleDuck SQL server, with Arrow-native batching and back pressure.</description>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/dazzleduck-sql-common/pom.xml
+++ b/dazzleduck-sql-common/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>dazzleduck-sql-common</artifactId>
     <name>DazzleDuck Project Common</name>
+    <description>Shared configuration keys, header constants, and utilities used across DazzleDuck SQL modules.</description>
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/dazzleduck-sql-commons/pom.xml
+++ b/dazzleduck-sql-commons/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>dazzleduck-sql-commons</artifactId>
     <name>DazzleDuck Project Commons</name>
+    <description>DuckDB connection pooling, SQL transformation, authorization, and ingestion utilities.</description>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DynamicQueueRepositoryTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DynamicQueueRepositoryTest.java
@@ -151,7 +151,13 @@ class DynamicQueueRepositoryTest {
             writeToDb(dbPath, "UPDATE " + DynamicQueueRepository.ATTACHMENT +
                     ".schema_version SET version = version + 1 WHERE id = 1");
 
-            Thread.sleep(200);
+            // The handler polls every 50ms. A fixed sleep assumes the poll thread got
+            // scheduled within it, which does not hold on a loaded CI runner, so wait for
+            // the condition itself instead.
+            long deadline = System.nanoTime() + java.time.Duration.ofSeconds(30).toNanos();
+            while (!handler.getKnownQueues().contains("q2") && System.nanoTime() < deadline) {
+                Thread.sleep(20);
+            }
 
             assertTrue(handler.getKnownQueues().contains("q2"), "hot-reload picked up the new queue");
 

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/ParquetIngestionQueueTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/ParquetIngestionQueueTest.java
@@ -46,8 +46,21 @@ public class ParquetIngestionQueueTest {
     }
 
     @AfterEach
-    public void cleanup() {
-        // Cleanup is handled by @TempDir
+    public void cleanup() throws Exception {
+        // close() interrupts the writer but abandons it if it outlives the join timeout
+        // (deliberately - it is a daemon and must not block shutdown). An abandoned writer
+        // keeps COPYing into tempDir, so letting @TempDir deletion start while one is alive
+        // races: the COPY fails and the directory cannot be emptied. Wait for quiescence
+        // first; @TempDir cleanup runs after @AfterEach.
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        while (System.nanoTime() < deadline && writerThreadsAlive()) {
+            Thread.sleep(20);
+        }
+    }
+
+    private static boolean writerThreadsAlive() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .anyMatch(t -> t.isAlive() && t.getName().startsWith("BulkIngestQueue-"));
     }
 
     @Test

--- a/dazzleduck-sql-ducklake-compactor/pom.xml
+++ b/dazzleduck-sql-ducklake-compactor/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>dazzleduck-sql-ducklake-compactor</artifactId>
     <name>DazzleDuck DuckLake Compaction Service</name>
+    <description>Compaction service that merges small DuckLake data files into larger ones.</description>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/dazzleduck-sql-flight/pom.xml
+++ b/dazzleduck-sql-flight/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>dazzleduck-sql-flight</artifactId>
     <name>DazzleDuck Project Flight Sql</name>
+    <description>Arrow Flight SQL server implementation backed by DuckDB.</description>
     <properties>
     </properties>
     <dependencies>

--- a/dazzleduck-sql-http/pom.xml
+++ b/dazzleduck-sql-http/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>dazzleduck-sql-http</artifactId>
     <name>DazzleDuck Project Http Sql</name>
+    <description>HTTP REST API server for DazzleDuck SQL, serving Arrow IPC, TSV, and JSONL results.</description>
     <dependencies>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/dazzleduck-sql-logback/pom.xml
+++ b/dazzleduck-sql-logback/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>dazzleduck-sql-logback</artifactId>
     <name>DazzleDuck Project Logback</name>
+    <description>Logback appender that forwards log events to DazzleDuck over Arrow.</description>
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/dazzleduck-sql-login/pom.xml
+++ b/dazzleduck-sql-login/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>dazzleduck-sql-login</artifactId>
     <name>DazzleDuck Project Login</name>
+    <description>JWT authentication and token issuing service for DazzleDuck SQL.</description>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/dazzleduck-sql-micrometer/pom.xml
+++ b/dazzleduck-sql-micrometer/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>dazzleduck-sql-micrometer</artifactId>
     <name>DazzleDuck Project Micrometer</name>
+    <description>Micrometer meter registry that forwards metrics to DazzleDuck over Arrow.</description>
 
     <properties>
         <!-- Override parent's Java version if needed -->

--- a/dazzleduck-sql-otel-collector/pom.xml
+++ b/dazzleduck-sql-otel-collector/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>dazzleduck-sql-otel-collector</artifactId>
     <name>DazzleDuck OpenTelemetry Collector</name>
+    <description>OpenTelemetry collector that ingests traces, metrics, and logs into DuckDB and DuckLake.</description>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/dazzleduck-sql-runtime/pom.xml
+++ b/dazzleduck-sql-runtime/pom.xml
@@ -9,6 +9,7 @@
         <version>0.2.15-SNAPSHOT</version>
     </parent>
     <name>DazzleDuck Project Runtime</name>
+    <description>Server runtime that starts the DazzleDuck Arrow Flight SQL and HTTP endpoints.</description>
     <artifactId>dazzleduck-sql-runtime</artifactId>
 
     <properties>

--- a/dazzleduck-sql-scrapper/pom.xml
+++ b/dazzleduck-sql-scrapper/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>dazzleduck-sql-scrapper</artifactId>
     <name>DazzleDuck Project Scrapper</name>
+    <description>Prometheus metrics scraping and forwarding for DazzleDuck SQL.</description>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/dazzleduck-sql-search/pom.xml
+++ b/dazzleduck-sql-search/pom.xml
@@ -9,6 +9,7 @@
         <version>0.2.15-SNAPSHOT</version>
     </parent>
     <name>DazzleDuck Project Search</name>
+    <description>Full-text search indexing for DazzleDuck SQL.</description>
     <artifactId>dazzleduck-sql-search</artifactId>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,12 @@
     <profiles>
         <profile>
             <id>release-sign-artifacts</id>
+            <!-- Deliberately NOT performRelease: that property also activates Maven's
+                 built-in release-profile, whose attach-sources execution collides with the
+                 bundle-sources execution this build already binds to the verify phase. -->
             <activation>
                 <property>
-                    <name>performRelease</name>
+                    <name>dazzleduck.release</name>
                     <value>true</value>
                 </property>
             </activation>
@@ -121,7 +124,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.2.7</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -131,7 +134,12 @@
                                 </goals>
                                 <configuration>
                                     <keyname>${gpg.keyname}</keyname>
-                                    <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                                    <!-- CI has no tty, so gpg must take the passphrase on
+                                         stdin; it comes from MAVEN_GPG_PASSPHRASE. -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
                                 </configuration>
                             </execution>
                         </executions>
@@ -223,6 +231,10 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
+                    <!-- Releases are automatic on a v* tag, so the upload promotes itself
+                         rather than waiting for someone to press publish in the portal. -->
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>validated</waitUntil>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Adds Maven Central publishing to the release workflow: **all modules**, **automatic on every
`v*` tag**, as requested.

## Read this before merging

Central coordinates are **immutable** — a published version can never be replaced or
withdrawn. With `autoPublish` enabled there is no human gate: pushing a tag publishes every
module permanently. The `verify` job's tag/pom cross-check is the only thing standing between
a mistagged commit and a burned version, which is why `publish-central` depends on it.

Central currently holds only `parent`, `common`, and `commons` at 0.0.7-0.0.9, so the next
release will look like a jump to 0.2.x. That is expected.

## Four things had to change for this to work

**1. Every module pom needed a `description`.** Central rejects poms without one and only
`dazzleduck-sql-examples` had it, so 14 descriptions were added. `name` was already present
everywhere; neither is inherited from the parent.

**2. `maven-gpg-plugin` 1.5 -> 3.2.7.** 1.5 predates `--pinentry-mode loopback`, so it cannot
sign on a runner with no tty. 3.x also reads the passphrase from `MAVEN_GPG_PASSPHRASE`
directly, so no settings.xml server entry is needed and the old `passphraseServerId` is gone.

**3. The signing profile no longer activates on `performRelease`.** That property also
activates Maven's *built-in* `release-profile`, whose `attach-sources` execution collides with
the `bundle-sources` execution this build binds to `verify`:

```
Failed to execute goal maven-source-plugin:3.3.1:jar (bundle-sources) on project
dazzleduck-sql-common: Presumably you have configured maven-source-plugin to execute
twice in your build.
```

The profile now activates on `dazzleduck.release`. **This changes the release incantation** —
`-DperformRelease=true` no longer signs anything.

**4. `autoPublish` + `waitUntil=validated`** on the central-publishing plugin, so the upload
promotes itself and the job fails loudly if Central rejects validation.

## Verification

- `./mvnw -DskipTests -Ddazzleduck.release=true -Dgpg.skip=true clean verify` -> BUILD SUCCESS.
- `help:active-profiles` confirms `release-sign-artifacts` activates on the new property.
- Every jar module produces both a sources and a javadoc jar. `dazzleduck-sql-examples` and
  the parent produce neither, which is correct: they are `packaging=pom`, and Central requires
  only a signed `.pom` for those.

**Not verified:** the signing step and the deploy itself. Signing needs your key passphrase
interactively, and a real deploy is irreversible, so neither can be rehearsed. The first tag
after this merges is the first genuine test of both.

## Secrets required before the next tag

`CENTRAL_USERNAME`, `CENTRAL_PASSWORD` (a Central portal token, not the account password),
`GPG_PRIVATE_KEY` (armored export of `BC7688F69A9CF5D5`), `GPG_PASSPHRASE`. Without them the
job fails *after* the images have already been pushed, since `publish-images` and
`publish-central` both run off `verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)