### PR TITLE
build: require a manual publish for the first Central release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,9 +231,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
-                    <!-- Releases are automatic on a v* tag, so the upload promotes itself
-                         rather than waiting for someone to press publish in the portal. -->
-                    <autoPublish>true</autoPublish>
+                    <!-- Deliberately manual for the first automated release: a tag uploads
+                         and validates the artifacts, then someone presses publish in the
+                         portal. Central coordinates are immutable, so the first run gets a
+                         human look before it becomes permanent. Set back to true once a
+                         release has gone through cleanly. -->
+                    <autoPublish>false</autoPublish>
                     <waitUntil>validated</waitUntil>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Flips `autoPublish` to `false` in the central-publishing plugin, so the **first** automated
release is reviewable instead of irreversible.

## What changes for the next tag

Pushing a `v*` tag still runs everything unattended — tests, Docker images, `mvn deploy`,
GitHub release. The only difference is the last inch of the Central step:

| | before | after |
|---|---|---|
| Upload to Central | automatic | automatic |
| Validation | automatic | automatic |
| **Becomes permanent** | **automatic** | **you press publish in the portal** |

`waitUntil=validated` is unchanged, so the job still fails loudly if Central rejects the
artifacts — you get the same signal, just without the release becoming unwithdrawable before
anyone has looked at it.

Docker publishing is untouched and stays fully automatic.

## Why

Central coordinates cannot be replaced or withdrawn once published, and this pipeline has
never run end to end — the signing step and the deploy have never been executed, since neither
could be rehearsed locally. Trading one click for the ability to inspect the first set of
artifacts before they are permanent seems worth it exactly once.

## Reverting

Set `autoPublish` back to `true` once a release has gone through cleanly. The comment in
`pom.xml` says so, so this does not quietly become permanent.

## Verification

`./mvnw -DskipTests -Ddazzleduck.release=true -Dgpg.skip=true clean verify` -> BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)