### PR TITLE
docs: rewrite module READMEs from a code-first audit; add missing ones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,20 +39,24 @@ export MAVEN_OPTS="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java
 
 ```
 dazzleduck-sql-server/
-├── dazzleduck-sql-runtime/     # Main entry point, server startup orchestration
-├── dazzleduck-sql-flight/      # Arrow Flight SQL server implementation
-├── dazzleduck-sql-http/        # HTTP REST API (Helidon-based)
-├── dazzleduck-sql-common/      # Shared utilities, type handling, config
-├── dazzleduck-sql-commons/     # DuckDB utilities, connection pool, transformations
-├── dazzleduck-sql-client/      # HTTP client (JDK 11+)
-├── dazzleduck-sql-client-grpc/ # gRPC/Flight SQL client (JDK 11+)
-├── dazzleduck-sql-login/       # JWT authentication service
-├── dazzleduck-sql-search/      # Full-text search indexing
-├── dazzleduck-sql-micrometer/  # Micrometer metrics forwarding
-├── dazzleduck-sql-logger/      # SLF4J Arrow logging provider
-├── dazzleduck-sql-logback/     # Logback appender for log forwarding
-└── dazzleduck-sql-scrapper/    # Prometheus metrics scraping
+├── dazzleduck-sql-runtime/           # Main entry point, server startup orchestration, Docker image
+├── dazzleduck-sql-flight/            # Arrow Flight SQL server implementation (also named-query + output listeners)
+├── dazzleduck-sql-http/              # HTTP REST API (Helidon 4, HTTP/2)
+├── dazzleduck-sql-common/            # Shared constants (ConfigConstants, Headers, ContentTypes), SslUtils, JWT claim extraction (JDK 11)
+├── dazzleduck-sql-commons/           # DuckDB utilities: connection pool, AST transformations, authorization, ingestion (JDK 21)
+├── dazzleduck-sql-client/            # HTTP ingestion client, Arrow batching + backpressure (JDK 11)
+├── dazzleduck-sql-client-grpc/       # gRPC/Flight SQL ingestion client (JDK 11)
+├── dazzleduck-sql-login/             # JWT login service (LoginService / ProxyLoginService)
+├── dazzleduck-sql-search/            # Inverted-index construction for full-text search (query side unimplemented)
+├── dazzleduck-sql-micrometer/        # Micrometer StepMeterRegistry → Arrow → /v1/ingest
+├── dazzleduck-sql-logback/           # Logback appender for log forwarding (JDK 11)
+├── dazzleduck-sql-scrapper/          # Prometheus endpoint scraper → Arrow → /v1/ingest
+├── dazzleduck-sql-otel-collector/    # OTLP gRPC collector (logs/traces/metrics → Parquet/DuckLake), port 4317
+├── dazzleduck-sql-ducklake-compactor/# Scheduled DuckLake minor/major compaction + snapshot housekeeping
+└── dazzleduck-sql-examples/          # docker-compose integration tests (Testcontainers, packaging=pom)
 ```
+
+Note: `dazzleduck-sql-logger` was removed (2026-02); `dazzleduck-sql-logback` is its independent replacement.
 
 ## Module Details
 
@@ -70,27 +74,36 @@ Key files: `QueryService.java`, `IngestionService.java`, `PlanningService.java`,
 |----------|--------|-------------|
 | `/v1/login` | POST | Authenticate, get JWT token |
 | `/v1/query` | GET/POST | Execute SQL — Arrow IPC (default), TSV (`Accept: text/tab-separated-values`), or JSONL/NDJSON (`Accept: application/jsonl` or `application/x-ndjson`) |
-| `/v1/plan` | POST | Generate query execution plan |
-| `/v1/ingest` | POST | Ingest Arrow data to Parquet |
-| `/v1/cancel` | POST | Cancel running query |
-| `/health` | GET | Health check |
+| `/v1/plan` | GET/POST | Query plan with splits (`x-dd-split-size` header or query param) |
+| `/v1/ingest` | POST | Ingest Arrow data to Parquet (`?ingestion_queue=` required; 429 + `Retry-After` on backpressure) |
+| `/v1/cancel` | GET/POST | Cancel running query by statement `id` |
+| `/v1/named-query` | GET/POST | List / get-by-name / execute Jinja-templated named queries (only when `named_query_table` is configured) |
+| `/v1/ui` | GET | Metrics dashboard (HTML) |
+| `/health` | GET | Health check (unversioned, unauthenticated) |
 
 TSV format: header row + tab-separated string values. Ideal for LLM agents and scripts.
 JSONL format: one JSON object per row, per line (newline-delimited, no enclosing array). Numbers/booleans/nulls keep their JSON types; temporal values are ISO-8601 strings; lists/structs/maps are real nested JSON. Streamable and append-friendly.
 
 ### dazzleduck-sql-commons
-Core DuckDB abstraction. Key classes:
-- `ConnectionPool.java` — singleton DuckDB connection management, Arrow reader, bulk ingest
-- `Transformations.java` (~600 lines) — SQL → JSON AST, CTE/subquery handling, fingerprinting
-- `ExpressionFactory.java` — build SQL AST nodes programmatically
-- `ExpressionConstants.java` — AST field/type string constants
-- `Fingerprint.java` — SHA-256 of normalized query (literals replaced with placeholders)
-- `BulkIngestQueue.java` / `ParquetIngestionQueue.java` — time+size-batched ingestion
-- `SqlAuthorizer.java`, `JwtClaimBasedAuthorizer.java` — authorization framework
-- Partition pruning: `DucklakePartitionPruning.java`, `HivePartitionPruning.java`, `SplitPlanner.java`
+Core DuckDB abstraction (JDK 21). Key classes:
+- `ConnectionPool.java` — enum-singleton DuckDB connection (`connection.duplicate()` per use), Arrow reader, record mapping, `executeOnSingleton` for startup scripts
+- `Transformations.java` (~2300 lines) — SQL ↔ JSON AST via `json_serialize_sql`, filter-CTE injection (RLS), LEFT-JOIN pruning, limit injection, table-reference collection
+- `ExpressionFactory.java` / `ExpressionConstants.java` — build SQL AST nodes / AST string constants
+- `Fingerprint.java` — SHA-256 of normalized query (literals replaced with placeholders; does not work with CTEs)
+- `ingestion/` — `BulkIngestQueue` (batching, backpressure, producer-id dedup, drain), `ParquetIngestionQueue` (COPY-based writes, transformations via `__this` placeholder), `WatermarkSpec` (per-group MIN/MAX timestamp + row count committed in the DuckLake post-ingestion transaction), `DuckLakeIngestionHandler`, `DynamicDuckLakeIngestionTaskFactoryProvider` (SQLite-backed queue registry)
+- `authorization/` — `SqlAuthorizer` with `NOOPAuthorizer`, `SelectOnlyAuthorizer`, `RestrictedDatasourceOnlyAuthorizer`, `RestrictedReadOnlyAuthorizer`, `RedirectAuthorizer` (external `/resolve` endpoint)
+- Partition pruning: `ducklake/DucklakePartitionPruning.java` (DuckLake metadata tables), `hive/HivePartitionPruning.java`, `delta/PartitionPruning.java` (Delta Kernel), `planner/SplitPlanner.java` + `planner/PartitionPrunerV2.java`
+- `TableConfigProvider.java` — config overrides read from a key/value table
+- `namedquery/` — named-query store, request/response models, validator cache
 
 ### dazzleduck-sql-common
-Shared utilities: `ConfigUtils.java` (all config key constants), `Headers.java` (all HTTP/Flight header constants + type extractors), `SslUtils.java` (env-aware SSL via `DD_TRUST_SELF_SIGNED_CERTS`), `CryptoUtils.java`.
+Shared constants and small utilities (JDK 11): `ConfigConstants.java` (all config key constants — there is no `ConfigUtils`), `Headers.java` (all HTTP/Flight header + JWT claim constants + type extractors), `ContentTypes.java`, `SslUtils.java` (env-aware SSL via `DD_TRUST_SELF_SIGNED_CERTS`), `StartupScriptProvider.java` (env-var substitution in startup SQL), `auth/JwtClaimsExtractor.java`, `types/` Arrow row writers. (`CryptoUtils` lives in the flight module.)
+
+### dazzleduck-sql-otel-collector
+OTLP gRPC receiver (default port 4317) for logs/traces/metrics → flattened Arrow schemas → `ParquetIngestionQueue` → Parquet/DuckLake. JWT auth mandatory; queue routing via the `x-dd-ingestion-queue` JWT claim (no default fallback). Embedded `/health` endpoint with MAINTENANCE-aware graceful shutdown. Config root `otel_collector`.
+
+### dazzleduck-sql-ducklake-compactor
+Standalone service running `ducklake_merge_adjacent_files` (minor/major) plus snapshot expiry and file cleanup on schedules. Config root `dazzleduck_sql_compaction`; `/health` on port 8080 (always UP). Docker image `dazzleduck/ducklake-compactor`.
 
 ## Authorization & Access Modes
 
@@ -146,19 +159,20 @@ dazzleduck_server = {
 
     flight_sql.port = 59307
     http.port = 8081
-    http.authentication = "none"     # or "jwt"
 
     ingestion.min_bucket_size = 1048576
     ingestion.max_delay_ms = 2000
 
     jwt_token.expiration = 60m
-    jwt_token.claims.generate.headers = [database,catalog,schema,table,filter,path,function]
+    jwt_token.claims.generate.headers = [database, schema, x-dd-table, x-dd-filter, x-dd-access, x-dd-path, x-dd-function, x-dd-access-type]
 
     users = [{ username = admin, password = admin, groups = [admin, general] }]
 }
 ```
 
-**CLI override:** `--conf key=value` (e.g. `--conf warehouse=/data`, `--conf http.authentication=jwt`)
+**CLI override:** `--conf key=value` (e.g. `--conf warehouse=/data`)
+
+Note: the JWT filter is always installed on versioned HTTP endpoints — the `http.authentication` key is read but no longer disables auth. Tests/demos that need to skip real tokens set `jwt_token.verify_signature = false` instead.
 
 ## Testing
 
@@ -191,8 +205,9 @@ curl -X POST http://localhost:8081/v1/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"admin"}'
 
-# Ingest Arrow data
-curl -X POST "http://localhost:8081/v1/ingest?path=file1.parquet" \
+# Ingest Arrow data (routed by ingestion queue)
+curl -X POST "http://localhost:8081/v1/ingest?ingestion_queue=my_table" \
+  -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/vnd.apache.arrow.stream" \
   --data-binary "@file.arrow"
 

--- a/README.md
+++ b/README.md
@@ -1,127 +1,56 @@
-# Flight-Sql-Duckdb
+# DazzleDuck SQL Server
 
-## An [Arrow Flight SQL Server](https://arrow.apache.org/docs/format/FlightSql.html) with [DuckDB](https://duckdb.org) back-end execution engines
-
-[<img src="https://img.shields.io/badge/dockerhub-image-green.svg?logo=Docker">](https://hub.docker.com/r/voltrondata/sqlflite)
-[<img src="https://img.shields.io/badge/Documentation-dev-yellow.svg?logo=">](https://arrow.apache.org/docs/format/FlightSql.html)
-[<img src="https://img.shields.io/badge/Arrow%20JDBC%20Driver-download%20artifact-red?logo=Apache%20Maven">](https://search.maven.org/search?q=a:flight-sql-jdbc-driver)
-[<img src="https://img.shields.io/badge/PyPI-Arrow%20ADBC%20Flight%20SQL%20driver-blue?logo=PyPI">](https://pypi.org/project/adbc-driver-flightsql/)
-[<img src="https://img.shields.io/badge/PyPI-SQLFlite%20Ibis%20Backend-blue?logo=PyPI">](https://pypi.org/project/ibis-sqlflite/)
-[<img src="https://img.shields.io/badge/PyPI-SQLFlite%20SQLAlchemy%20Dialect-blue?logo=PyPI">](https://pypi.org/project/sqlalchemy-sqlflite-adbc-dialect/)
-[<img src="https://img.shields.io/badge/API-v1-blue.svg?logo=">](https://github.com)
-
-**DazzleDuck SQL Server** is a high-performance remote DuckDB server that supports both Arrow Flight SQL and RESTful HTTP protocols. It enables multiple users to connect remotely and execute queries through various client libraries.
+**DazzleDuck SQL Server** is a high-performance remote DuckDB server that supports both
+[Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) (gRPC) and a RESTful
+HTTP API. It enables multiple users to connect remotely and execute queries through JDBC,
+ADBC, plain HTTP, or DuckDB itself.
 
 ### Key Features
-- **Dual Protocol Support**: Arrow Flight SQL (gRPC) and RESTful HTTP API (versioned with `/v1`)
-- **Multiple Client Support**: JDBC, ADBC Python drivers, and CLI tools
-- **Arrow-Native**: All data transfers use Apache Arrow format for maximum performance
-- **Versioned REST API**: Future-proof HTTP endpoints with `/v1` versioning
-- **JWT Authentication**: Secure access control for HTTP endpoints
-- **Remote Query Execution**: Run DuckDB queries remotely with distributed execution support
 
-### Client Modules
+- **Dual Protocol Support**: Arrow Flight SQL (gRPC, port `59307`) and RESTful HTTP API (port `8081`, versioned with `/v1`, HTTP/2 enabled)
+- **Arrow-Native**: query results and ingestion both use Apache Arrow IPC (ZSTD-compressed by default); TSV and JSONL/NDJSON output are also available over HTTP
+- **JWT Authentication**: all versioned HTTP endpoints and Flight SQL calls are authenticated; Basic credentials are upgraded to a server-issued JWT
+- **Row-Level Security**: four access modes with filter injection scoped by JWT claims
+- **Ingestion Pipeline**: batched Arrow-to-Parquet ingestion with backpressure, producer-id deduplication, DuckLake catalog registration, and per-group watermarks
+- **Partition Pruning**: Hive, Delta Lake, and DuckLake pruning based on query predicates, plus split planning for distributed execution
+- **Named Queries**: Jinja-templated SQL stored in a DuckDB table, executed by name over HTTP
 
-The project includes JDK 11 compatible client libraries:
+## Modules
 
-| Module | Description |
-|--------|-------------|
-| `dazzleduck-sql-client` | HTTP client (`HttpArrowProducer`) for Arrow data ingestion |
-| `dazzleduck-sql-client-grpc` | gRPC/Flight SQL client (`GrpcArrowProducer`) for Arrow data ingestion |
-| `dazzleduck-sql-common` | Shared types and utilities (LoginRequest, LoginResponse, DataType, etc.) |
-| `dazzleduck-sql-logger` | SLF4J provider for Arrow-based logging |
-| `dazzleduck-sql-logback` | Logback appender for log forwarding |
+| Module | Description | Bytecode target |
+|--------|-------------|-----------------|
+| `dazzleduck-sql-runtime` | Entry point, startup orchestration, the `dazzleduck/dazzleduck` Docker image | 17 |
+| `dazzleduck-sql-flight` | Arrow Flight SQL server (producers per access mode, auth middleware, named queries, output listeners) | 17 |
+| `dazzleduck-sql-http` | HTTP REST API on Helidon 4 (reuses the same producer as Flight SQL) | 17 |
+| `dazzleduck-sql-common` | Shared constants (`ConfigConstants`, `Headers`, `ContentTypes`), `SslUtils`, JWT claim extraction, Arrow row writers | 11 |
+| `dazzleduck-sql-commons` | DuckDB utilities: connection pool, SQL AST transformations, authorization, ingestion queues, partition pruning, split planning | 21 |
+| `dazzleduck-sql-client` | HTTP ingestion client (`HttpArrowProducer`) with Arrow batching, disk spill, and backpressure | 11 |
+| `dazzleduck-sql-client-grpc` | gRPC/Flight SQL ingestion client (`GrpcArrowProducer`) | 11 |
+| `dazzleduck-sql-login` | JWT login service (`LoginService`, `ProxyLoginService`) | 21 |
+| `dazzleduck-sql-search` | Inverted-index construction for full-text search (indexing only) | 21 |
+| `dazzleduck-sql-micrometer` | Micrometer registry that forwards application metrics as Arrow to the ingest endpoint | 21 |
+| `dazzleduck-sql-logback` | Logback appender that forwards logs as Arrow to the ingest endpoint | 11 |
+| `dazzleduck-sql-scrapper` | Prometheus endpoint scraper that forwards metrics as Arrow | 21 |
+| `dazzleduck-sql-otel-collector` | OTLP gRPC collector (logs/traces/metrics to Parquet/DuckLake), the `dazzleduck/dazzleduck-otel-collector` image | 21 |
+| `dazzleduck-sql-ducklake-compactor` | Scheduled DuckLake compaction and snapshot housekeeping, the `dazzleduck/ducklake-compactor` image | 21 |
+| `dazzleduck-sql-examples` | docker-compose integration tests for the demos under `example/docker` | 17 |
+
+Client-side artifacts (`dazzleduck-sql-client`, `dazzleduck-sql-client-grpc`,
+`dazzleduck-sql-common`, `dazzleduck-sql-logback`) target JDK 11 bytecode so they can be
+embedded in older applications. Everything is built and tested with **JDK 21**.
 
 ## Dev Setup
+
 ### Requirements
-- **Server modules**: JDK 21
-- **Client modules** (dazzleduck-sql-client, dazzleduck-sql-client-grpc, dazzleduck-sql-common, dazzleduck-sql-logger, dazzleduck-sql-logback): JDK 11+
 
-## Getting started with Docker
-
-### 1. Build the base image (one-time, or when Java/DuckDB version changes)
-
-The base image bundles the JRE and the native DuckDB JDBC driver. It must be built for each
-target platform and pushed to Docker Hub before the application image can be assembled.
-
-```bash
-DUCKDB_VERSION=$(./mvnw help:evaluate -Dexpression=duckdb.version -q -DforceStdout)
-
-# Single platform — local daemon (development)
-docker build \
-  --platform linux/arm64 \
-  --build-arg DUCKDB_VERSION=$DUCKDB_VERSION \
-  -t dazzleduck/base-jre:21-noble-duckdb-${DUCKDB_VERSION} \
-  -f dazzleduck-sql-runtime/docker/Dockerfile.base \
-  dazzleduck-sql-runtime/docker/
-
-# Multi-platform manifest push to Docker Hub (CI/CD)
-docker buildx build \
-  --platform linux/amd64,linux/arm64 \
-  --build-arg DUCKDB_VERSION=$DUCKDB_VERSION \
-  -t dazzleduck/base-jre:21-noble-duckdb-${DUCKDB_VERSION} \
-  -f dazzleduck-sql-runtime/docker/Dockerfile.base \
-  dazzleduck-sql-runtime/docker/ \
-  --push
-```
-
-### 2. Build the application image
-
-The application image is assembled by Jib (no Dockerfile required). Two platform-specific
-images are built during `mvn verify` and combined into a local multi-arch manifest list.
-
-```bash
-# Quick single-arch build — Apple Silicon (arm64)
-./mvnw package -DskipTests jib:dockerBuild -pl dazzleduck-sql-runtime -Djib.architecture=arm64
-
-# Quick single-arch build — x86-64 (amd64, requires amd64 base image)
-./mvnw package -DskipTests jib:dockerBuild -pl dazzleduck-sql-runtime
-
-# Both arm64 + amd64 + local manifest list (verify phase)
-# amd64 is skipped until the base image has an amd64 variant;
-# enable with -Dskip.docker.amd64=false once the base image supports it
-./mvnw verify -DskipTests -pl dazzleduck-sql-runtime --also-make
-```
-
-Images produced:
-
-| Tag | Description |
-|---|---|
-| `dazzleduck/dazzleduck:{version}-arm64` | arm64 platform image |
-| `dazzleduck/dazzleduck:{version}-amd64` | amd64 platform image (when enabled) |
-| `dazzleduck/dazzleduck:{version}` | local multi-arch manifest list |
-| `dazzleduck/dazzleduck:latest` | local multi-arch manifest list |
-
-To push to Docker Hub after building both platform images:
-
-```bash
-docker push dazzleduck/dazzleduck:{version}-arm64
-docker push dazzleduck/dazzleduck:{version}-amd64
-# Create and push the multi-arch manifest list
-./dazzleduck-sql-runtime/docker/manifest.sh {version}
-docker manifest push dazzleduck/dazzleduck:{version}
-docker manifest push dazzleduck/dazzleduck:latest
-```
-
-### 3. Run the container
-
-```bash
-docker run -ti -p 59307:59307 -p 8081:8081 dazzleduck/dazzleduck:latest \
-  --conf warehouse=/data \
-  --conf users.0.password="your password"
-```
-
-The server runs both Arrow Flight SQL (gRPC) on port `59307` and HTTP REST API on port `8081`.
-
-## Getting started from the command line (development)
-
-Build the project once, then start the server directly via Maven — no Docker needed:
+- JDK 21 (build and test — JDK 25 causes test failures)
+- Maven wrapper (`./mvnw`)
 
 ```bash
 # Build all modules
 ./mvnw clean package -DskipTests
 
-# Start the server
+# Start the server locally (no Docker needed)
 ./mvnw exec:java -pl dazzleduck-sql-runtime \
   -Dexec.args="--conf warehouse=warehouse --conf users.0.password='your password'"
 ```
@@ -136,115 +65,152 @@ To run a specific main class (e.g. for demos or tooling):
   -Dexec.args="[args...]"
 ```
 
-### Supported functionality
-1. Database and schema specified as part of connection url. Passed to server as header database and schema.
-2. Fetch size can be specified. It's passed to the server in header fetch_size.
-3. Bulk write to parquet file using bulk upload functionality. Idea is to bulk upload and then add those files to metadata.
-4. Username and Passwords can be specified in application.conf file.
+## Getting Started with Docker
 
-## HTTP API Endpoints
+```bash
+docker run -ti -p 59307:59307 -p 8081:8081 dazzleduck/dazzleduck:latest \
+  --conf warehouse=/data \
+  --conf users.0.password="your password"
+```
 
-All HTTP API endpoints use a `/v1` version prefix for backward compatibility and future API evolution.
+The server runs both Arrow Flight SQL (gRPC) on port `59307` and the HTTP REST API on port `8081`.
 
-### Available Endpoints
+Image build instructions (base image, Jib, multi-arch manifests) live in
+[`dazzleduck-sql-runtime/docker/README.md`](dazzleduck-sql-runtime/docker/README.md).
+Release publishing is scripted in `scripts/docker-publish.sh`, which also builds the
+`dazzleduck/dazzleduck-otel-collector`, `dazzleduck/ducklake-compactor`, and
+`dazzleduck/dazzleduck-sql-scrapper` images.
+
+## HTTP API
+
+All endpoints use a `/v1` version prefix except `/health`.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/v1/login` | POST | Authenticate and obtain JWT token |
-| `/v1/query` | GET/POST | Execute SQL queries and return results in Arrow format |
-| `/v1/plan` | POST | Generate query execution plan with splits |
-| `/v1/ingest` | POST | Ingest Arrow data to Parquet files |
-| `/v1/cancel` | POST | Cancel a running query |
-| `/v1/named-query` | GET | List named queries (paginated) |
-| `/v1/named-query/{name}` | GET | Get a named query by name |
-| `/v1/named-query` | POST | Execute a named (templated) query |
-| `/v1/ui` | GET | Access web UI dashboard |
-| `/health` | GET | Health check endpoint (unversioned) |
+| `/v1/login` | POST | Authenticate and obtain a JWT token |
+| `/v1/query` | GET/POST | Execute SQL — Arrow IPC (default), TSV, or JSONL depending on the `Accept` header |
+| `/v1/plan` | GET/POST | Query execution plan with splits (`x-dd-split-size` header or query param) |
+| `/v1/ingest` | POST | Ingest an Arrow IPC stream (`?ingestion_queue=` required) |
+| `/v1/cancel` | GET/POST | Cancel a running query by statement `id` |
+| `/v1/named-query` | GET/POST | List, inspect, and execute named queries (only registered when `named_query_table` is configured) |
+| `/v1/ui` | GET | Metrics dashboard |
+| `/health` | GET | Health check (unversioned, unauthenticated) |
 
-### API Versioning
-All HTTP API endpoints are versioned with a `/v1` prefix to ensure backward compatibility and allow for future API evolution. The health check endpoint remains unversioned as it's a standard operational endpoint.
+### Output formats
 
-## Connecting to HTTP server.
+The `Accept` header selects the response format on `/v1/query` and `/v1/named-query`:
 
-The server is running on HTTP mode on port 8081 which can used to query DuckDB with POST and GET methods. This will return data in arrow format.<p>
-The return data can itself be queried with duckdb
+| Accept value | Format |
+|--------------|--------|
+| _(default)_ | Arrow IPC stream (`application/vnd.apache.arrow.stream`), ZSTD-compressed; override with the `x-dd-arrow-compression` header (`zstd` or `none`) |
+| `text/tab-separated-values` | TSV: header row + tab-separated values. Ideal for scripts and LLM agents |
+| `application/jsonl` or `application/x-ndjson` | JSONL: one JSON object per row. Numbers/booleans/nulls keep JSON types; temporal values are ISO-8601 strings; lists/structs/maps are nested JSON |
 
-## Getting start with duckdb.
-Learn more about it here [dazzleduck](https://github.com/dazzleduck-web/dazzleduck-sql-duckdb/blob/main/README.md)
+### Useful request headers
 
-## Connecting to the flight server via Flight JDBC
-Download the [Apache Arrow Flight SQL JDBC driver](https://search.maven.org/search?q=a:flight-sql-jdbc-driver)
+Every header can also be passed as a URL query parameter.
 
-You can then use the JDBC driver to connect from your host computer to the locally running Docker Flight SQL server with this JDBC string (change the password value to match the value specified for the SQLFLITE_PASSWORD environment variable if you changed it from the example above):
+| Header | Purpose |
+|--------|---------|
+| `x-dd-fetch-size` | Rows per Arrow batch (default 10000) |
+| `x-dd-query-timeout` | Per-query timeout in seconds (capped by `max_query_timeout_ms`) |
+| `x-dd-split-size` | Target split size in bytes for `/v1/plan` |
+| `x-dd-arrow-compression` | `zstd` (default) or `none` |
+| `x-dd-partition`, `x-dd-sort-order`, `x-dd-format`, `x-dd-producer-id`, `x-dd-producer-batch-id` | Ingestion options for `/v1/ingest` |
+
+### Examples
+
+```bash
+# Get a token
+curl -X POST 'http://localhost:8081/v1/login' \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin", "password": "admin"}'
+
+# Query (Arrow IPC by default)
+curl -H "Authorization: Bearer $TOKEN" "http://localhost:8081/v1/query?q=select%201"
+
+# Query as TSV
+curl -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: text/tab-separated-values" \
+  "http://localhost:8081/v1/query?q=select%201"
+
+# Ingest Arrow data
+curl -X POST "http://localhost:8081/v1/ingest?ingestion_queue=my_table" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/vnd.apache.arrow.stream" \
+  --data-binary "@data.arrow"
+```
+
+When the ingestion pipeline is saturated, `/v1/ingest` responds `429 Too Many Requests`
+with a `Retry-After` header — clients should back off and resend the batch.
+
+Query results can also be read directly from DuckDB:
+
+```sql
+INSTALL arrow FROM community; LOAD arrow;
+CREATE SECRET http_auth (
+    TYPE http,
+    EXTRA_HTTP_HEADERS MAP {
+        'Authorization': 'Bearer <jwt-token>'
+    }
+);
+SELECT * FROM read_arrow(concat('http://localhost:8081/v1/query?q=', url_encode('select 1, 2, 3')));
+```
+
+## Connecting via Flight SQL JDBC
+
+Download the [Apache Arrow Flight SQL JDBC driver](https://search.maven.org/search?q=a:flight-sql-jdbc-driver) and connect with:
+
 ```bash
 jdbc:arrow-flight-sql://localhost:59307?database=memory&useEncryption=0&user=admin&password=admin
 ```
 
-For instructions on setting up the JDBC driver in popular Database IDE tool: [DBeaver Community Edition](https://dbeaver.io) - see this [repo](https://github.com/voltrondata/setup-arrow-jdbc-driver-in-dbeaver).
+For instructions on setting up the JDBC driver in [DBeaver Community Edition](https://dbeaver.io),
+see this [repo](https://github.com/voltrondata/setup-arrow-jdbc-driver-in-dbeaver).
 
-**Note** - if you stop/restart the Flight SQL Docker container, and attempt to connect via JDBC with the same password - you could get error: "Invalid bearer token provided. Detail: Unauthenticated".  This is because the client JDBC driver caches the bearer token signed with the previous instance's secret key.  Just change the password in the new container by changing the "SQLFLITE_PASSWORD" env var setting - and then use that to connect via JDBC.
+**Note** — if you stop/restart the server and reconnect via JDBC with the same password, you may
+get: "Invalid bearer token provided. Detail: Unauthenticated". The JDBC driver caches the bearer
+token signed with the previous instance's secret key. Change the password (`users.0.password`)
+in the new container and reconnect to force a fresh token.
 
-## Connecting to the flight server via the new [ADBC Python Flight SQL driver](https://pypi.org/project/adbc-driver-flightsql/)
+## Connecting via the ADBC Python Flight SQL driver
 
-You can now use the new Apache Arrow Python ADBC Flight SQL driver to query the Flight SQL server.  ADBC offers performance advantages over JDBC - because it minimizes serialization/deserialization, and data stays in columnar format at all phases.
+The [ADBC Flight SQL driver](https://pypi.org/project/adbc-driver-flightsql/) keeps data in
+columnar form end to end and avoids JDBC serialization overhead.
 
-You can learn more about ADBC and Flight SQL [here](https://voltrondata.com/resources/simplifying-database-connectivity-with-arrow-flight-sql-and-adbc).
-
-Ensure you have Python 3.9+ installed, then open a terminal, then run:
 ```bash
-# Create a Python virtual environment
 python3 -m venv .venv
-
-# Activate the virtual environment
 . .venv/bin/activate
-
-# Install the requirements including the new Arrow ADBC Flight SQL driver
 pip install --upgrade pip
 pip install pandas pyarrow adbc_driver_flightsql
-
-# Start the python interactive shell
 python
 ```
 
-In the Python shell - you can then run:
 ```python
 import os
-from adbc_driver_flightsql import dbapi as sqlflite, DatabaseOptions
+from adbc_driver_flightsql import dbapi, DatabaseOptions
 
-
-with sqlflite.connect(uri="grpc+tls://localhost:59307",
-                        db_kwargs={"username": os.getenv("SQLFLITE_USERNAME", "admin"),
-                                   "password": os.getenv("SQLFLITE_PASSWORD", "admin"),
-                                   DatabaseOptions.TLS_SKIP_VERIFY.value: "true"  # Not needed if you use a trusted CA-signed TLS cert
-                                   }
-                        ) as conn:
-   with conn.cursor() as cur:
-       cur.execute("select * from generate_series(20)",
-                   )
-       x = cur.fetch_arrow_table()
-       print(x)
+with dbapi.connect(
+    uri="grpc+tls://localhost:59307",
+    db_kwargs={
+        "username": os.getenv("DAZZLEDUCK_USERNAME", "admin"),
+        "password": os.getenv("DAZZLEDUCK_PASSWORD", "admin"),
+        DatabaseOptions.TLS_SKIP_VERIFY.value: "true",  # not needed with a CA-signed TLS cert
+    },
+) as conn:
+    with conn.cursor() as cur:
+        cur.execute("select * from generate_series(20)")
+        print(cur.fetch_arrow_table())
 ```
-
-You should see results:
-
-
-## Connecting via [Ibis](https://ibis-project.org)
-See: https://github.com/ibis-project/ibis-sqlflite
-
-## Connecting via [SQLAlchemy](https://www.sqlalchemy.org)
-See: https://github.com/prmoore77/sqlalchemy-sqlflite-adbc-dialect
-
-
-
-
 
 ## Named Queries
 
-Named queries allow pre-defined, parameterized SQL templates to be stored in a DuckDB table and executed by name over HTTP. Templates use [Jinja2](https://jinja.palletsprojects.com) syntax via Jinjava.
+Named queries are pre-defined, parameterized SQL templates stored in a DuckDB table and executed
+by name over HTTP. Templates use [Jinja2](https://jinja.palletsprojects.com) syntax via Jinjava.
 
 ### Setup
 
-Enable the named query endpoint by setting `named_query_table` in your configuration:
+Enable the endpoint by setting `named_query_table` in your configuration:
 
 ```hocon
 dazzleduck_server {
@@ -252,15 +218,18 @@ dazzleduck_server {
 }
 ```
 
-Create the table in DuckDB:
+Create the table in DuckDB (all eight columns are required by the store):
 
 ```sql
 CREATE TABLE named_queries (
-    name                   VARCHAR PRIMARY KEY,
+    id                     BIGINT PRIMARY KEY,
+    name                   VARCHAR UNIQUE,
     template               VARCHAR,
     validators             VARCHAR[],
     description            VARCHAR,
-    parameter_descriptions MAP(VARCHAR, VARCHAR)
+    parameter_descriptions MAP(VARCHAR, VARCHAR),
+    preferred_display      VARCHAR,
+    query_group            VARCHAR DEFAULT 'general'
 );
 ```
 
@@ -268,82 +237,50 @@ Insert a template:
 
 ```sql
 INSERT INTO named_queries VALUES (
+    1,
     'top_sales',
-    'SELECT * FROM sales WHERE region = ''{{ region }}'' LIMIT {{ limit }}',
+    'SELECT * FROM sales WHERE region = ''{{ region }}'' LIMIT {{ limit | default(''10'') }}',
     NULL,
     'Returns top sales rows for a given region',
-    MAP { 'region': 'Sales region name', 'limit': 'Maximum number of rows' }
+    MAP { 'region': 'Sales region name', 'limit': 'Maximum number of rows' },
+    'table',
+    'sales'
 );
 ```
 
-### Executing a Named Query
+A complete seeded example lives in `example/seed/create_named_queries.sql` with the demo
+stack under `example/docker/named-query-demo`.
+
+### Executing a named query
 
 ```bash
 curl -X POST http://localhost:8081/v1/named-query \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"name": "top_sales", "parameters": {"region": "WEST", "limit": "10"}}'
 ```
 
-The response is an Arrow IPC stream, identical to `/v1/query`.
+The response format follows the same `Accept` negotiation as `/v1/query` (Arrow IPC by
+default, TSV or JSONL on request). Parameter validation failures return `400` with all
+failures collected; an unknown name returns `404`.
 
-#### Query Modes
-
-An optional `mode` field controls how the SQL is executed:
-
-| Mode | Description |
-|------|-------------|
-| `EXECUTE` (default) | Run the query and return results in Arrow format |
-| `EXPLAIN` | Return the query plan without executing |
-| `EXPLAIN_ANALYZE` | Return the query plan with execution statistics |
-| `GENERATE` | Render the SQL template and return the generated SQL as plain text without executing |
+### Listing and inspecting
 
 ```bash
-# Execute
-curl -X POST http://localhost:8081/v1/named-query \
-  -H "Content-Type: application/json" \
-  -d '{"name": "top_sales", "parameters": {"region": "WEST", "limit": "10"}}'
+# Paginated list (limit is capped at 200)
+curl -H "Authorization: Bearer $TOKEN" "http://localhost:8081/v1/named-query?offset=0&limit=20"
 
-# Inspect the generated SQL before running it
-curl -X POST http://localhost:8081/v1/named-query \
-  -H "Content-Type: application/json" \
-  -d '{"name": "top_sales", "parameters": {"region": "WEST", "limit": "10"}, "mode": "GENERATE"}'
-# Returns: SELECT * FROM sales WHERE region = 'WEST' LIMIT 10
+# Full definition of one named query
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8081/v1/named-query/top_sales
 ```
 
-### Listing Named Queries
+Both return JSON including each query's `name`, `description`, parameter descriptions,
+validator descriptions, `preferred_display`, and `query_group`.
 
-```bash
-# First page
-curl http://localhost:8081/v1/named-query?offset=0&limit=20
+### Parameter validators
 
-# Response
-{
-  "items": [
-    {"name": "top_sales", "description": "Returns top sales rows for a given region"}
-  ],
-  "total": 1,
-  "offset": 0,
-  "limit": 20
-}
-```
-
-### Getting a Named Query by Name
-
-```bash
-curl http://localhost:8081/v1/named-query/top_sales
-
-# Response
-{
-  "name": "top_sales",
-  "description": "Returns top sales rows for a given region",
-  "parameterDescriptions": {"region": "Sales region name", "limit": "Maximum number of rows"},
-  "validatorDescriptions": []
-}
-```
-
-### Parameter Validators
-
-Each named query can reference a list of validator class names. Validators are Java classes that implement `NamedQueryParameterValidator` from `dazzleduck-sql-common`:
+Each named query may reference validator class names. Validators implement
+`NamedQueryParameterValidator` from `dazzleduck-sql-common`:
 
 ```java
 public class RegionValidator implements NamedQueryParameterValidator {
@@ -362,13 +299,13 @@ public class RegionValidator implements NamedQueryParameterValidator {
 }
 ```
 
-All validators run on every request and all failures are collected before returning HTTP 400. Validator instances are cached (up to 500) to avoid repeated reflection overhead.
+All validators run on every request and all failures are collected before returning HTTP 400.
+Validator instances are cached (up to 500) to avoid repeated reflection overhead.
 
 ## Security and Access Modes
 
-DazzleDuck SQL Server supports four access modes that control query permissions and external access capabilities:
-
-### Access Modes
+DazzleDuck SQL Server supports four access modes that control query permissions and external
+access capabilities:
 
 | Mode | Description | Query Types Allowed | External Access |
 |-------|-------------|---------------------|-----------------|
@@ -377,41 +314,22 @@ DazzleDuck SQL Server supports four access modes that control query permissions 
 | **RESTRICTED** | SELECT on one datasource; table/path/function scoped via JWT | SELECT on the authorized datasource only | Controlled by startup script |
 | **RESTRICT_READ_ONLY** | SELECT on any table; mandatory per-table filter always injected | SELECT on any table (filter always applied) | Disabled by default |
 
-### Configuring Access Mode
-
-Set the access mode in `application.conf` or via command-line:
+### Configuring access mode
 
 ```hocon
 dazzleduck_server {
-    access_mode = COMPLETE  # Options: COMPLETE, READ_ONLY, RESTRICTED, RESTRICT_READ_ONLY
+    access_mode = COMPLETE  # COMPLETE | READ_ONLY | RESTRICTED | RESTRICT_READ_ONLY
 }
 ```
 
-### External Access Control
+### External access control
 
-External access refers to DuckDB's ability to access external tables and functions:
-- `read_parquet`, `read_json`, `read_csv` - External file access
-- `httpfs`, `httpsfs` - HTTP/HTTPS file system access
-- `s3fs`, `gcsfs` - Cloud storage access
-
-**By access mode:**
-
-- **COMPLETE mode**: All external tables and functions are accessible by default
-- **READ_ONLY / RESTRICTED / RESTRICT_READ_ONLY modes**: External access must be explicitly enabled in startup script
-
-```sql
--- Disable external access (recommended for restricted modes)
-SET enable_external_access = false;
-
--- Enable external access (use with caution)
-SET enable_external_access = true;
-```
-
-This security feature prevents restricted users from accessing arbitrary external data sources while still allowing them to query authorized tables. Configure external access in the startup script:
+External access refers to DuckDB's ability to reach external files and functions
+(`read_parquet`, `read_json`, `read_csv`, httpfs, cloud storage). In restricted modes it should
+be disabled in the startup script:
 
 ```hocon
-startup_script_provider {
-    class = "io.dazzleduck.sql.flight.ConfigBasedStartupScriptProvider"
+dazzleduck_server.startup_script_provider {
     content = """
         INSTALL arrow FROM community;
         LOAD arrow;
@@ -422,11 +340,14 @@ startup_script_provider {
 }
 ```
 
-### JWT Claims for RESTRICTED Mode
+The startup script provider also supports `script_location` (path to a SQL file) and
+substitutes `${ENV_VAR}` references from the environment.
+
+### JWT claims for RESTRICTED mode
 
 Project-specific JWT claims and HTTP headers use the `x-dd-` prefix to avoid colliding with
-standard claim names. When using `RESTRICTED` access mode, the preferred way to specify access
-is the `x-dd-access` JWT claim.
+standard claim names. In `RESTRICTED` mode, the preferred way to grant access is the
+`x-dd-access` JWT claim.
 
 **`x-dd-access` claim — format: `[[type, name, projection, filter]]` (exactly one entry)**
 
@@ -438,15 +359,16 @@ is the `x-dd-access` JWT claim.
 | `filter` | SQL expression or `"true"` | Row-level filter; `"true"` = no restriction |
 
 Examples:
+
 ```bash
 # BASE_TABLE access with filter
--H 'x-dd-access: [["table","orders","*","tenant_id='\''abc'\''"]]]'
+-H 'x-dd-access: [["table","orders","*","tenant_id='\''abc'\''"]]'
 
 # Path-prefix access (TABLE_FUNCTION)
 -H 'x-dd-access: [["path","s3://bucket/tenant1/","*","true"]]'
 
 # Named function access
--H 'x-dd-access: [["function","read_parquet","*","tenant_id='\''abc'\''"]]]'
+-H 'x-dd-access: [["function","read_parquet","*","tenant_id='\''abc'\''"]]'
 ```
 
 **Legacy claims (backward compatible):**
@@ -459,109 +381,123 @@ Examples:
 | `x-dd-path` | Authorized path prefix (TABLE_FUNCTION) |
 | `x-dd-filter` | Optional row filter expression |
 
-### JWT Claims for RESTRICT_READ_ONLY Mode
+### JWT claims for RESTRICT_READ_ONLY mode
 
-`RESTRICT_READ_ONLY` allows SELECT on any table but **always injects the filter** into every base table via CTEs — including JOIN arms, WHERE subqueries, and EXISTS clauses.
+`RESTRICT_READ_ONLY` allows SELECT on any table but **always injects the filter** into every
+base table reference via CTEs — including JOIN arms, WHERE subqueries, and EXISTS clauses.
+Table functions and multi-statement queries are rejected. Tables not covered by the claim
+get a `false` filter (they return no rows).
 
 **`x-dd-access` claim — format: `[[type, name, projection, filter], ...]` (one or more `"table"` entries)**
 
 ```bash
 # Single table
--H 'x-dd-access: [["table","orders","*","tenant_id='\''abc'\''"]]]'
+-H 'x-dd-access: [["table","orders","*","tenant_id='\''abc'\''"]]'
 
-# Multiple tables with different filter columns (CROSS JOIN-safe)
--H 'x-dd-access: [["table","orders","*","owner_id='\''alice'\''"],["table","items","*","region='\''us'\''"]]]'
+# Multiple tables with different filter columns
+-H 'x-dd-access: [["table","orders","*","owner_id='\''alice'\''"],["table","items","*","region='\''us'\''"]]'
 ```
 
 **Legacy — `x-dd-filter` + `x-dd-table` claims (single table only):**
+
 ```bash
 -H "x-dd-table: orders" -H "x-dd-filter: tenant_id='abc'"
 ```
+
 The filter is mandatory — requests without `access` or `filter` are rejected.
+
+### Redirect authorization
+
+A token carrying `x-dd-token-type: redirect` plus `x-dd-redirect_url` makes the server resolve
+grants from an external endpoint: the authorizer sends a GET with the caller's bearer token and
+expects a JSON response listing authorized tables/functions and row filters. Responses are
+cached for five minutes.
 
 ## SSL / TLS Configuration
 
-By default, all HTTP clients in DazzleDuck enforce strict certificate and hostname validation using the JVM's default SSL context.
+By default, all HTTP clients in DazzleDuck enforce strict certificate and hostname validation
+using the JVM's default SSL context.
 
-### Self-Signed Certificates (Dev / Test)
+### Self-signed certificates (dev / test)
 
-If you are running against a server with a self-signed certificate, set the `DD_TRUST_SELF_SIGNED_CERTS` environment variable before starting the process:
+If you are running against a server with a self-signed certificate, set the
+`DD_TRUST_SELF_SIGNED_CERTS` environment variable before starting the process:
 
 ```bash
 export DD_TRUST_SELF_SIGNED_CERTS=true
 ```
 
-When this variable is set (to any non-empty value), all internal HTTP clients — including `HttpArrowProducer`, `RedirectAuthorizer`, `ProxyLoginService`, `HttpCredentialValidator`, `AuthUtils`, `JwtServerInterceptor`, and `MetricsScraper` — will skip certificate validation and hostname verification.
+When this variable is set (to any non-empty value), all internal HTTP clients — including
+`HttpArrowProducer`, `RedirectAuthorizer`, `ProxyLoginService`, `HttpCredentialValidator`,
+`AuthUtils`, `JwtServerInterceptor`, and `MetricsScraper` — will skip certificate validation
+and hostname verification.
 
-> **Warning:** Never set `DD_TRUST_SELF_SIGNED_CERTS` in production. Use a properly signed certificate instead.
+**Warning:** never set `DD_TRUST_SELF_SIGNED_CERTS` in production. Use a properly signed
+certificate instead.
 
-## Enabling Authentication in HTTP Mode.
-Authentication is supported with jwt. Client need to invoke login api with username/password this api would return jwt  token. This jwt token can be used for all subsequent invocation
-- Run the server with authentication enabled
-  `docker run -ti -v "$PWD/example/data":/local-data -p 59307:59307 -p 8081:8081 flight-sql-duckdb --conf useEncryption=false --conf warehouse=/data/warehouse --conf http.authentication=jwt`
-- Get the jwt token with login <br>
- ```curl -X POST 'http://localhost:8081/v1/login' -H "Content-Type: application/json" -d '{"username": "admin", "password" : "admin"}'```
-- Invoke api with jwt token
+## HTTP Authentication
+
+JWT authentication is always enforced on the versioned (`/v1`) HTTP endpoints — only `/health`
+and `/v1/login` are open. Clients call the login API with username/password and use the
+returned token on every subsequent request:
+
+```bash
+# Get the JWT token
+curl -X POST 'http://localhost:8081/v1/login' \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin", "password": "admin"}'
+
+# Invoke an API with the token
+curl -H "Authorization: Bearer <jwt-token>" -s "http://localhost:8081/v1/query?q=select%201"
 ```
-URL="http://localhost:8081/v1/query?q=select%201"
-curl -H "Authorization': 'Bearer <jwt-token>" -s "$URL"
-```
-- Run the query with jwt token by setting <br>
-```
-INSTALL arrow FROM community; LOAD arrow;
-CREATE SECRET http_auth (
-              TYPE http,
-              EXTRA_HTTP_HEADERS MAP {
-                 'Authorization': 'Bearer <jwt-token>'
-                 }
-              );
-SELECT * FROM read_arrow(concat('http://localhost:8081/v1/query?q=', url_encode('select 1, 2, 3')));
-```
+
+Users are configured under `dazzleduck_server.users`; setting `login_url` instead delegates
+`/v1/login` to an external login service. `jwt_token.verify_signature = false` disables
+signature verification (tests/demos only).
 
 ## Ingestion Queue Routing
 
-Producers identify their target queue via the `x-dd-ingestion-queue` JWT claim. The claim value must match one of the `ingestion_queue` entries configured in `ingestion_queue_table_mapping` (or the SQLite registry when using `DynamicDuckLakeIngestionTaskFactoryProvider`).
+Every ingested batch is routed to a named **ingestion queue**, which maps to a target path (and
+optionally a DuckLake table).
 
-| Claim | Required | Description |
-|-------|----------|-------------|
-| `x-dd-ingestion-queue` | Yes | Queue identifier. The server routes each ingested batch to the writer registered under this name. Requests without this claim are rejected with `INVALID_ARGUMENT`. |
-
-The claim is read from the JWT — it does not need to be sent as a separate request header.
-
-**Generating a token with the ingestion queue claim** (example using the login endpoint):
+- **HTTP `/v1/ingest`**: the queue is the `ingestion_queue` URL query parameter. In restricted
+  modes the JWT must also grant write access: `x-dd-access-type = WRITE` and an
+  `ingestion_queue` claim matching the requested queue.
+- **OTel collector (gRPC)**: the queue comes from the `x-dd-ingestion-queue` JWT claim; requests
+  without it are rejected with `INVALID_ARGUMENT`. There is no default fallback.
 
 ```bash
-# Login — the server embeds x-dd-ingestion-queue in the returned JWT when
-# the claim is listed in jwt_token.claims.generate.headers
+# Login — the server embeds requested claims in the returned JWT
 curl -X POST http://localhost:8081/v1/login \
   -H "Content-Type: application/json" \
-  -d '{"username": "admin", "password": "admin"}'
-```
-
-For the OTel collector (gRPC), include the JWT as a Bearer token in the `authorization` metadata header:
-
-```
-authorization: Bearer <jwt-containing-x-dd-ingestion-queue>
+  -d '{"username": "admin", "password": "admin", "claims": {"x-dd-ingestion-queue": "logs"}}'
 ```
 
 ## DuckLake Post-Ingestion Provider
 
-After Arrow data is ingested and written as Parquet, DazzleDuck can automatically register those files with a DuckLake catalog table via `ingestion_task_factory_provider` (disabled by default in `reference.conf`).
+After Arrow data is ingested and written as Parquet, DazzleDuck can automatically register those
+files with a DuckLake catalog table via `ingestion_task_factory_provider` (disabled by default).
 
-Set `class` to `io.dazzleduck.sql.commons.ingestion.DuckLakeIngestionTaskFactoryProvider` and configure `ingestion_queue_table_mapping` entries:
+Set `class` to `io.dazzleduck.sql.commons.ingestion.DuckLakeIngestionTaskFactoryProvider` and
+configure `ingestion_queue_table_mapping` entries:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `ingestion_queue` | Yes | Queue name; must match the `x-dd-ingestion-queue` JWT claim sent by the producer |
+| `ingestion_queue` | Yes | Queue name the producer targets |
 | `catalog` | Yes | DuckLake catalog owning the target table |
 | `schema` | Yes | Schema within the catalog |
 | `table` | Yes | Target table name |
 | `transformation` | No | SQL `SELECT` referencing placeholder table `__this`; omit to write all columns as-is |
-| `additional_parameters` | No | Extra key/value pairs forwarded to the post-ingestion task |
+| `additional_parameters` | No | Extra key/value pairs, including the watermark spec below |
+
+Alternatively, `DynamicDuckLakeIngestionTaskFactoryProvider` reads queue mappings from a SQLite
+registry (`db_path`), polled at `config_load_interval_ms`, so queues can be added and removed at
+runtime without a restart.
 
 ### Transformation
 
-`transformation` is a SQL `SELECT` that runs on each batch before it is persisted. The server wraps it as:
+`transformation` is a SQL `SELECT` that runs on each batch before it is persisted. The server
+wraps it as:
 
 ```sql
 WITH __this AS (SELECT * FROM read_parquet([...]) ORDER BY ...)
@@ -584,8 +520,32 @@ SELECT * FROM __this WHERE level != 'DEBUG'
 SELECT id, ts, msg, current_timestamp AS ingested_at FROM __this
 ```
 
-### Publishing the project
-- export GPG_TTY=$(tty)
-- ./mvnw -P release-sign-artifacts -DskipTests clean verify
-- ./mvnw -P release-sign-artifacts -DskipTests deploy
+### Watermarks
 
+A queue mapping can commit a watermark row per ingested batch, in the **same transaction** as
+the DuckLake file registration. Each row carries the per-group MIN timestamp, MAX timestamp, and
+row count. Configure under `additional_parameters`:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `watermark_table` | Yes | Watermark table (same catalog/schema as the target table) |
+| `watermark_timestamp_column` | Yes | Source column both MIN and MAX are computed from |
+| `watermark_min_timestamp_column` | Yes | Destination column for the MIN timestamp |
+| `watermark_max_timestamp_column` | Yes | Destination column for the MAX timestamp |
+| `watermark_row_count_column` | Yes | Destination column for the batch row count |
+| `watermark_group_columns` | No | Comma-separated grouping columns; empty = one global row per batch |
+
+A malformed spec (partial keys, blanks, typos in `watermark_*` keys) fails at startup rather
+than per batch. Watermarks are not available for queues registered via the dynamic SQLite
+provider, whose registry does not store `additional_parameters`.
+
+## Publishing
+
+Tagged releases (`v*`) publish all modules to Maven Central via the GitHub Actions release
+workflow. Manual publishing:
+
+```bash
+export GPG_TTY=$(tty)
+./mvnw -P release-sign-artifacts -DskipTests clean verify
+./mvnw -P release-sign-artifacts -DskipTests deploy
+```

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ configure `ingestion_queue_table_mapping` entries:
 | `schema` | Yes | Schema within the catalog |
 | `table` | Yes | Target table name |
 | `transformation` | No | SQL `SELECT` referencing placeholder table `__this`; omit to write all columns as-is |
+| `view` + `input_table` | No | View-based transformation (see below); both fully qualified `catalog.schema.name`, must be set together, mutually exclusive with `transformation` |
 | `additional_parameters` | No | Extra key/value pairs, including the watermark spec below |
 
 Alternatively, `DynamicDuckLakeIngestionTaskFactoryProvider` reads queue mappings from a SQLite
@@ -519,6 +520,32 @@ SELECT * FROM __this WHERE level != 'DEBUG'
 -- Add ingestion timestamp
 SELECT id, ts, msg, current_timestamp AS ingested_at FROM __this
 ```
+
+### View-Based Transformation
+
+Instead of embedding the transformation SQL in configuration, a mapping can point at a DuckDB
+view. The server reads the view's definition and rewrites every reference to `input_table`
+into the `__this` placeholder — the view body becomes the transformation:
+
+```hocon
+ingestion_queue_table_mapping = [
+    {
+        ingestion_queue = "logs"
+        catalog = "my_catalog"
+        schema  = "main"
+        table   = "logs"
+        view        = "my_catalog.main.logs_transform"   # CREATE VIEW ... AS SELECT ... FROM my_catalog.main.raw_logs
+        input_table = "my_catalog.main.raw_logs"         # the table the view reads; becomes __this
+    }
+]
+```
+
+`view` and `input_table` must both be set (and are mutually exclusive with `transformation`);
+both must be fully qualified as `catalog.schema.name`. The resolution is validated at startup,
+so a missing or malformed view fails fast. Because queue state refreshes when the DuckLake
+catalog's schema version changes (which includes view DDL), altering the view updates the
+transformation at runtime — no config change or restart needed. The dynamic SQLite provider
+supports the same pair via its `view_name` / `input_table` registry columns.
 
 ### Watermarks
 

--- a/dazzleduck-sql-client-grpc/README.md
+++ b/dazzleduck-sql-client-grpc/README.md
@@ -1,0 +1,66 @@
+# DazzleDuck SQL Client (gRPC)
+
+Arrow Flight SQL (gRPC) **ingestion** client — the Flight counterpart to
+`dazzleduck-sql-client`. It reuses the same batching, disk-spill, retry, and backpressure
+machinery (`ArrowProducer.AbstractArrowProducer`) but sends buckets via
+`FlightSqlClient.executeIngest` instead of HTTP POST.
+
+Targets **Java 11** bytecode.
+
+## How It Works
+
+`GrpcArrowProducer` accumulates rows/batches exactly like the HTTP producer, then streams each
+bucket to the Flight SQL server as an Arrow ingest call. The target ingestion queue and any
+other options are passed as ingest parameters — the queue key is `ingestion_queue`
+(`Headers.QUERY_PARAMETER_INGESTION_QUEUE`), and partition columns travel as `x-dd-partition`.
+
+Backpressure: a Flight `RESOURCE_EXHAUSTED` status raises `BackPressureException` (suggested
+wait 5 seconds), mirroring the HTTP client's handling of `429`.
+
+## Authentication
+
+HTTP Basic on the first call, upgraded automatically to the server-issued Bearer token: the
+client middleware (`auth/AuthUtils.createClientMiddlewareFactory`) captures the `Bearer` value
+the server returns on the response headers and uses it for all subsequent calls. There is no
+preconfigured-token mode in this client.
+
+## Usage
+
+```java
+Schema schema = ...;
+
+GrpcArrowProducer producer = new GrpcArrowProducer(
+        schema,
+        1024 * 1024,                    // minBatchSize
+        16 * 1024 * 1024,               // maxBatchSize
+        Duration.ofSeconds(2),          // maxSendInterval
+        Clock.systemUTC(),
+        3, 1000,                        // retryCount, retryIntervalMillis
+        List.of(),                      // partitionBy
+        10 * 1024 * 1024,               // maxInMemorySize
+        1024L * 1024 * 1024,            // maxOnDiskSize
+        allocator,
+        Location.forGrpcInsecure("localhost", 59307),
+        "admin", "admin",
+        Map.of("ingestion_queue", "my_table"),  // ingest parameters
+        Duration.ofSeconds(30));
+
+try (producer) {
+    producer.addRow(row);
+}
+```
+
+There is no builder — a single positional constructor. Note: the final timeout parameter is
+validated but not currently applied as a per-call gRPC deadline.
+
+## Key Classes
+
+| Class | Purpose |
+|-------|---------|
+| `GrpcArrowProducer` | The producer (`extends ArrowProducer.AbstractArrowProducer`) |
+| `auth/AuthUtils` | Client middleware factory for the Basic-to-Bearer upgrade |
+
+## Requirements
+
+- Java 11+ (built and tested with JDK 21)
+- Dependencies: `dazzleduck-sql-client` (base machinery), Arrow `flight-core` / `flight-sql`

--- a/dazzleduck-sql-client/README.md
+++ b/dazzleduck-sql-client/README.md
@@ -1,0 +1,89 @@
+# DazzleDuck SQL Client
+
+HTTP **ingestion** client for the DazzleDuck server, with Arrow-native batching, disk spill,
+and backpressure handling. This module is write-path only — for queries, use plain HTTP against
+`/v1/query` or a Flight SQL client.
+
+Targets **Java 11** bytecode so it can be embedded in older applications. It is the transport
+used by `dazzleduck-sql-logback`, `dazzleduck-sql-micrometer`, and `dazzleduck-sql-scrapper`.
+
+## How It Works
+
+`HttpArrowProducer` accumulates rows (`addRow(JavaRow)`) or pre-encoded Arrow batches
+(`enqueue(byte[])`) into buckets. A background sender thread flushes a bucket when it reaches
+`minBatchSize` or when `maxSendInterval` elapses, POSTing it as an Arrow IPC stream
+(ZSTD-compressed by default) to:
+
+```
+POST {baseUrl}/v1/ingest?ingestion_queue={queue}
+Content-Type: application/vnd.apache.arrow.stream
+Authorization: Bearer <jwt>
+x-dd-partition: <partition columns, when configured>
+```
+
+- **Buffering**: in-memory up to `maxInMemorySize`, then spills to temp files up to
+  `maxOnDiskSize`; beyond that new elements are rejected
+- **Backpressure**: a server `429` raises `BackPressureException` carrying the suggested wait
+  from the `Retry-After` header (default 5 seconds)
+- **Retries**: `retryCount` attempts with exponential backoff (multiplier 2, capped at 60 s)
+- **Stats**: sent/dropped/retry/backpressure counters are exposed to subclasses
+
+## Authentication
+
+Two mutually exclusive modes, chosen by constructor:
+
+1. **Login mode** — the producer POSTs `{username, password, claims}` to `{baseUrl}/v1/login`,
+   caches the JWT, and refreshes it shortly before expiry; on `401`/`403` it re-logins (up to
+   2 attempts)
+2. **Preconfigured JWT** — pass the token directly; login is skipped entirely and a rejected
+   token fails immediately (no re-login)
+
+The optional `claims` map is forwarded at login and embedded in the JWT — used for row-level
+security and for the `ingestion_queue` claim required in restricted access modes.
+
+## Usage
+
+```java
+Schema schema = ...;  // Arrow schema of the rows you will send
+
+HttpArrowProducer producer = new HttpArrowProducer(
+        schema,
+        "http://localhost:8081",
+        "admin", "admin",
+        "my_table",                     // ingestion queue
+        Duration.ofSeconds(5),          // HTTP client timeout
+        1024 * 1024,                    // minBatchSize
+        16 * 1024 * 1024,               // maxBatchSize
+        Duration.ofSeconds(2),          // maxSendInterval
+        3, 1000,                        // retryCount, retryIntervalMillis
+        List.of(),                      // partitionBy
+        10 * 1024 * 1024,               // maxInMemorySize
+        1024L * 1024 * 1024);           // maxOnDiskSize
+
+try (producer) {
+    producer.addRow(row);   // or producer.enqueue(arrowIpcBytes)
+} // close() flushes pending data
+```
+
+There is no builder — the class exposes overloaded constructors: the variant above
+(username/password, no claims), a JWT variant `(schema, baseUrl, jwt, ingestionQueue, ...)`,
+and longer variants adding a claims map, a compression codec (`ZSTD` default or
+`NO_COMPRESSION`), and a custom clock.
+
+## Key Classes
+
+| Class | Purpose |
+|-------|---------|
+| `ArrowProducer` | Interface + `AbstractArrowProducer` base: queueing, sender thread, flush timer, spill-to-disk elements, retry/stats machinery |
+| `HttpArrowProducer` | Concrete HTTP implementation (JDK `java.net.http.HttpClient`) |
+| `BackPressureException` | Carries `getSuggestedWaitMillis()` for the caller's retry pacing |
+
+## SSL
+
+`SslUtils` from `dazzleduck-sql-common` controls trust: set `DD_TRUST_SELF_SIGNED_CERTS` for
+dev/test against self-signed certificates (never in production).
+
+## Requirements
+
+- Java 11+ (built and tested with JDK 21)
+- Dependencies: `dazzleduck-sql-common`, Arrow (with ZSTD compression), SLF4J

--- a/dazzleduck-sql-common/README.md
+++ b/dazzleduck-sql-common/README.md
@@ -1,0 +1,59 @@
+# DazzleDuck SQL Common
+
+Shared configuration keys, header constants, and small utilities used across DazzleDuck SQL
+modules (package `io.dazzleduck.sql.common`).
+
+This module deliberately targets **Java 11** bytecode and has a minimal dependency footprint
+(TypeSafe Config, jjwt, Arrow vector, Jackson) so client-side artifacts can embed it in older
+applications. Do not add server-only code or heavyweight dependencies here — that belongs in
+`dazzleduck-sql-commons`.
+
+## Contents
+
+| Class | Purpose |
+|-------|---------|
+| `ConfigConstants` | Every HOCON config key constant used across the project (root `dazzleduck_server`, ingestion, JWT, HTTP client, batching, retry keys), plus `getWarehousePath` / `getTempWriteDir` helpers |
+| `Headers` | Every HTTP/Flight header and JWT claim name constant, with typed value extractors |
+| `ContentTypes` | Content-type constants: JSON, Arrow IPC stream, TSV, JSONL/NDJSON |
+| `SslUtils` | `sslContext()` / `httpClient()` factories; the `DD_TRUST_SELF_SIGNED_CERTS` env var (read once at class load) switches them to trust-all variants for dev/test |
+| `StartupScriptProvider` | SPI for loading startup SQL from config (`startup_script_provider` block: `class`, `content`, `script_location`), with `${ENV_VAR}` substitution that fails on undefined variables |
+| `ConfigBasedStartupScriptProvider` | Default implementation: inline `content` concatenated with the file at `script_location` |
+| `auth/JwtClaimsExtractor` | Parses JWT claims (optionally without signature verification) and flattens the configured claims for authorization |
+| `auth/LoginRequest` / `auth/LoginResponse` | JSON DTOs for the `/v1/login` exchange |
+| `NamedQueryParameterValidator` | SPI implemented by named-query parameter validators |
+| `types/DataType` | DuckDB type model (`toSql()`, struct/field nesting, construction from a DuckDB AST cast) |
+| `types/VectorSchemaRootWriter`, `types/JavaRow` | Write plain Java rows into Arrow vectors — the write path used by all the client-side producers |
+
+## Header and Claim Names
+
+Project-specific names carry the `x-dd-` prefix; `database`, `schema`, and the URL query
+parameter `ingestion_queue` stay unprefixed for Flight SQL / JDBC interoperability.
+
+| Constant | Wire value |
+|----------|-----------|
+| `HEADER_FETCH_SIZE` | `x-dd-fetch-size` |
+| `HEADER_DATABASE` / `HEADER_SCHEMA` | `database` / `schema` |
+| `HEADER_TABLE` / `HEADER_PATH` / `HEADER_FUNCTION` / `HEADER_FILTER` | `x-dd-table` / `x-dd-path` / `x-dd-function` / `x-dd-filter` |
+| `HEADER_ACCESS` / `HEADER_ACCESS_TYPE` | `x-dd-access` / `x-dd-access-type` |
+| `HEADER_SPLIT_SIZE` | `x-dd-split-size` |
+| `HEADER_DATA_PARTITION` / `HEADER_DATA_FORMAT` / `HEADER_SORT_ORDER` | `x-dd-partition` / `x-dd-format` / `x-dd-sort-order` |
+| `HEADER_PRODUCER_ID` / `HEADER_PRODUCER_BATCH_ID` | `x-dd-producer-id` / `x-dd-producer-batch-id` |
+| `HEADER_QUERY_TIMEOUT` | `x-dd-query-timeout` |
+| `HEADER_ARROW_COMPRESSION` | `x-dd-arrow-compression` |
+| `HEADER_TOKEN_TYPE` | `x-dd-token-type` (values `inline` / `redirect`) |
+| `HEADER_REDIRECT_URL` | `x-dd-redirect_url` (note: underscore — historical) |
+| `HEADER_INGESTION_QUEUE` / `CLAIM_INGESTION_QUEUE` | `x-dd-ingestion-queue` |
+| `QUERY_PARAMETER_INGESTION_QUEUE` | `ingestion_queue` |
+
+## SSL for Dev / Test
+
+```bash
+export DD_TRUST_SELF_SIGNED_CERTS=true
+```
+
+Any non-empty value makes every HTTP client produced by `SslUtils` skip certificate validation
+and hostname verification. Never set this in production.
+
+## Requirements
+
+- Java 11+ (bytecode target 11; built with JDK 21)

--- a/dazzleduck-sql-commons/README.md
+++ b/dazzleduck-sql-commons/README.md
@@ -1,46 +1,139 @@
-<img src="doc/image/query-fingerprinting.jpg">
+# DazzleDuck SQL Commons
 
-## Sql-Commons
-It's a collection of functions for interacting with DuckDB 
-- Connection Pooling 
-- Query Parsing/Transformation
-- Delta Lake/ Hive Partition pruning based on the query predicate
-- Detecting similar queries (https://medium.com/@tanejagagan/ac5e00cb96b5)
+Core DuckDB utilities shared by the server and tooling modules (package
+`io.dazzleduck.sql.commons`):
 
-## Requirement 
-- java 17
-- maven 
+- Connection management (`ConnectionPool`)
+- SQL parsing and AST transformation (`Transformations`, `ExpressionFactory`)
+- Query fingerprinting (`Fingerprint`)
+- Authorization framework and row-level security (`authorization/`)
+- Hive / Delta Lake / DuckLake partition pruning and split planning
+- Batched Arrow-to-Parquet ingestion with DuckLake catalog registration (`ingestion/`)
+- Named-query store and validators (`namedquery/`)
 
-## Compile project
-`./mvnw compile`
+## Requirements
 
-## Connection pooling
+- Java 21 (this module uses records, pattern matching, and virtual threads)
+- Maven wrapper (`./mvnw` from the repo root)
 
-Start using DuckDB with
-- Execute the query. `ConnectionPool.execute(sql)`
-- Print the results. `ConnectionPool.printResult(sql)`
-- Get Arrow reader for Reading. `ConnectionPool.getReader(sql)`
-- It loads the connection property from `duckdb.properties` inside resources directory
+```bash
+./mvnw compile -pl dazzleduck-sql-commons
+./mvnw test -pl dazzleduck-sql-commons
+```
 
-## Transformation
-- Read the sql tree with `Transformation.parseToTree(sql)`
-- Various transformation change the query. Used for fingerprinting algorithms 
+## Connection Pooling
+
+`ConnectionPool` is an enum singleton holding one root DuckDB connection; every caller gets a
+`connection.duplicate()`. Attachments and extensions loaded on the root connection (via
+`executeOnSingleton`, used for startup scripts) are inherited by all duplicates.
+
+- `ConnectionPool.execute(sql)` — execute a statement
+- `ConnectionPool.printResult(sql)` — print results to stdout
+- `ConnectionPool.getReader(allocator, sql, batchSize)` — stream results as Arrow
+- `ConnectionPool.collectAll(connection, sql, recordClass)` — map rows onto a Java record (positional)
+- `ConnectionPool.bulkIngestToFile(...)` — `COPY ... TO` with partitioning
+- Optional connection properties can be supplied via a `duckdb.properties` classpath resource
+
+## Transformations
+
+`Transformations` round-trips SQL through DuckDB's `json_serialize_sql` /
+`json_deserialize_sql`, exposing the query as a JSON AST:
+
+- `Transformations.parseToTree(sql)` — SQL to AST
+- `Transformations.parseToSql(tree)` — AST back to SQL
+- Generic `transform` / `collect` / `find` walkers with matcher predicates
+- `injectFilterCtes(query, filters)` — the row-level-security mechanism: wraps every base-table
+  reference in a filtered CTE (used by `RESTRICT_READ_ONLY` mode)
+- `pruneUnusedLeftJoins(...)` — removes unused LEFT JOINs when inlining a view
+  (see `LEFT_JOIN_PRUNING_SPEC.md` at the repo root)
+- `addLimit(query, limit, offset)`, min/max predicate rewriting, partition-predicate stripping
+- Two table collectors with distinct security contracts: `getAllTablesOrPathsFromSelect`
+  (FROM clause only — for pruning and split planning) and `collectAllTableReferences`
+  (whole AST including JOINs, CTE bodies, and expression subqueries — for authorization)
+
+![Tree transformation](doc/image/tree-transformation.png)
 
 ## Fingerprinting
-Replace all the literals from the where clause of a query and hash the query.
-Read more about it at https://medium.com/@tanejagagan/ac5e00cb96b5
-- `./mvnw exec:java -Dexec.mainClass="io.github.tanejagagan.sql.commons.Fingerprint"`
 
-<img src="doc/image/tree-transformation.png">
+Replaces every literal in the query with a placeholder and hashes the normalized AST with
+SHA-256, so queries differing only in constants share a fingerprint.
+Read more at https://medium.com/@tanejagagan/ac5e00cb96b5
 
-## Delta Lake partition pruning
-- `./mvnw exec:java -Dexec.mainClass="io.github.tanejagagan.sql.commons.delta.PartitionPruning"`
+```bash
+./mvnw exec:java -pl dazzleduck-sql-commons -Dexec.mainClass="io.dazzleduck.sql.commons.Fingerprint"
+```
 
-## Hive partition pruning
-`./mvnw exec:java -Dexec.mainClass="io.github.tanejagagan.sql.commons.hive.HivePartitionPruning"`
+Known limitation: does not work with CTEs.
 
-## TODO Iceberg partition pruning
+![Query fingerprinting](doc/image/query-fingerprinting.jpg)
 
-## Publish the project
-- `export GPG_TTY=$(tty)`
-- `./mvnw clean -P release-sign-artifacts -DskipTests deploy`
+## Authorization
+
+`authorization/SqlAuthorizer` with one implementation per server access mode:
+
+| Instance | Access mode | Behavior |
+|----------|-------------|----------|
+| `NOOP_AUTHORIZER` | `COMPLETE` | Passes queries through; write access always granted |
+| `SELECT_ONLY_AUTHORIZER` | `READ_ONLY` | Rejects anything that is not a SELECT / set operation |
+| `RESTRICTED_DATASOURCE_AUTHORIZER` | `RESTRICTED` | Scopes SELECT to one table/path/function from the `x-dd-access` JWT claim (exactly one entry) or legacy claims; injects the row filter into the WHERE clause |
+| `RESTRICT_READ_ONLY_AUTHORIZER` | `RESTRICT_READ_ONLY` | SELECT on any table; injects per-table filters as CTEs; rejects table functions and multi-statement queries; unlisted tables get a `false` filter |
+
+`RedirectAuthorizer` resolves grants from an external endpoint when the JWT carries
+`x-dd-token-type: redirect` and `x-dd-redirect_url`, with a five-minute response cache.
+
+## Partition Pruning and Split Planning
+
+| Class | Source | Mechanism |
+|-------|--------|-----------|
+| `hive/HivePartitionPruning` | Hive-style directory layouts | Lists files with `read_blob`, unescapes partition path segments, filters by the query predicate |
+| `delta/PartitionPruning` | Delta Lake tables | Delta Kernel scan with the WHERE clause translated to a Delta predicate |
+| `ducklake/DucklakePartitionPruning` | DuckLake catalogs | Queries DuckLake metadata tables and prunes on per-file column min/max statistics |
+| `planner/PartitionPrunerV2` | dispatch | Routes `read_parquet` / `read_hive` / `read_delta` / DuckLake catalogs to the right pruner |
+| `planner/SplitPlanner` | all | Groups pruned files into size-bounded splits and rewrites the FROM clause per split (`read_parquet(list_value(...))`) |
+
+Demo mains:
+
+```bash
+./mvnw exec:java -pl dazzleduck-sql-commons -Dexec.mainClass="io.dazzleduck.sql.commons.delta.PartitionPruning"
+./mvnw exec:java -pl dazzleduck-sql-commons -Dexec.mainClass="io.dazzleduck.sql.commons.hive.HivePartitionPruning"
+```
+
+## Ingestion
+
+The `ingestion/` package implements the server's write path:
+
+- `BulkIngestQueue` — abstract time+size-batched queue: buckets batches until `min_bucket_size`
+  or `max_delay_ms`, combines adjacent buckets, enforces `max_pending_write` backpressure
+  (clients get a computed retry-after), deduplicates by producer-id/batch-id, rolls back
+  producer sequences on failed writes, and drains cleanly on shutdown
+- `ParquetIngestionQueue` — writes buckets with `COPY (...) TO` (Parquet, optional
+  `PARTITION_BY`), applies per-queue SQL transformations via the `__this` placeholder
+- `WatermarkSpec` — per-group MIN timestamp, MAX timestamp, and row count computed per batch and
+  inserted into a watermark table in the same transaction as the DuckLake file registration
+- `DuckLakeIngestionTaskFactoryProvider` — static queue-to-table mapping from config
+  (`ingestion_queue_table_mapping`)
+- `DynamicDuckLakeIngestionTaskFactoryProvider` — SQLite-backed queue registry polled at
+  runtime (`db_path`, `config_load_interval_ms`); with `manage_tables = true`,
+  `DuckLakeTableManager` reconciles target tables non-destructively (CREATE / ADD COLUMN / DROP COLUMN)
+- `DuckLakePostIngestionTask` — registers written files with `ducklake_add_data_files` and
+  inserts the watermark rows in one transaction
+
+## Other Utilities
+
+- `TableConfigProvider` — overlays configuration values read from a key/value table
+  (config block `config_provider`)
+- `config/ConfigBasedProvider` — reflective provider loader (`class` key)
+- `namedquery/` — `NamedQueryStore`, request/response models, and the reflective validator cache
+- `util/HeaderUtils` — CSV header parsing, identifier quoting, and expression validation for
+  ingestion headers
+- `util/CommandLineConfigUtil` — `--conf key=value` command-line parsing into HOCON
+- `auth/Validator` — SHA-256 password hashing and constant-time comparison
+
+## Publishing
+
+Handled by the repo-level release workflow (tag `v*`), or manually:
+
+```bash
+export GPG_TTY=$(tty)
+./mvnw clean -P release-sign-artifacts -DskipTests deploy
+```

--- a/dazzleduck-sql-commons/README.md
+++ b/dazzleduck-sql-commons/README.md
@@ -108,6 +108,11 @@ The `ingestion/` package implements the server's write path:
   producer sequences on failed writes, and drains cleanly on shutdown
 - `ParquetIngestionQueue` — writes buckets with `COPY (...) TO` (Parquet, optional
   `PARTITION_BY`), applies per-queue SQL transformations via the `__this` placeholder
+- View-based transformations — a mapping may declare `view` + `input_table` (fully qualified,
+  mutually exclusive with `transformation`): `DuckLakeIngestionHandler` reads the view's
+  definition from `duckdb_views()` and rewrites the input-table reference to `__this`
+  (`Transformations.rewriteTableAsThis`), so the transformation is maintained as SQL DDL and
+  picked up on schema-version refresh without a restart
 - `WatermarkSpec` — per-group MIN timestamp, MAX timestamp, and row count computed per batch and
   inserted into a watermark table in the same transaction as the DuckLake file registration
 - `DuckLakeIngestionTaskFactoryProvider` — static queue-to-table mapping from config

--- a/dazzleduck-sql-ducklake-compactor/README.md
+++ b/dazzleduck-sql-ducklake-compactor/README.md
@@ -22,7 +22,11 @@ All settings live under the `dazzleduck_sql_compaction` HOCON root in `applicati
 | `major_compaction_max_size` | `64MB` | Only compact files smaller than this during major pass |
 | `housekeeping_frequency` | `5 minutes` | How often to expire snapshots and delete orphaned files |
 | `snapshot_retention` | `15 minutes` | Expire snapshots older than this during housekeeping |
+| `health_port` | `8080` | Port for the `GET /health` endpoint |
 | `startup_script_provider` | — | How to load the startup SQL (attach catalogs, load extensions) |
+| `config_provider` | — | Optional: overlay config values read from a table (see below) |
+
+The bundled defaults live in this module's `application.conf` (not `reference.conf`).
 
 ### Startup Script
 
@@ -41,6 +45,33 @@ dazzleduck_sql_compaction.startup_script_provider {
   content = "ATTACH 'ducklake:...' AS mydb (DATA_PATH 's3://...');"
 }
 ```
+
+The startup script runs before configuration overrides are read, so catalogs referenced by the
+config-provider table must be attached here.
+
+### Configuration Overrides from a Table
+
+Settings can be overlaid from a two-column key/value table (readable after the startup script
+has attached its catalog):
+
+```hocon
+dazzleduck_sql_compaction.config_provider {
+  table = "mydb.main.compactor_config"
+  # key_column   = "config_key"   (default)
+  # value_column = "value"        (default)
+  # prefix       = ""             (optional key prefix filter)
+}
+```
+
+A configured table that cannot be read is a fatal startup error by design — silently falling
+back to file defaults would hide a broken override source.
+
+## Health Check
+
+`GET /health` on `health_port` (default 8080) returns uptime plus per-database compaction
+counters (total minor/major compactions, files compacted, last/next execution time, current
+small/medium/total file counts). Note: the status is always `UP` while the process is running —
+it does not reflect failing compaction cycles.
 
 ## Build
 
@@ -83,7 +114,10 @@ Micrometer metrics are emitted via the logging registry by default:
 
 | Metric | Tags | Description |
 |--------|------|-------------|
-| `ducklake.compaction.duration` | `type` (minor/major/housekeeping), `step`, `database` | Time per compaction step |
+| `ducklake.compaction.duration` | `type` (minor/major/housekeeping), `step` (merge/expire/cleanup), `database` | Time per compaction step |
+| `ducklake.compaction.minor` | `database` | Total minor compactions run |
+| `ducklake.compaction.major` | `database` | Total major compactions run |
+| `ducklake.files.compacted` | `database` | Total files compacted |
 | `ducklake.files.total` | `database` | Total active Parquet files |
 | `ducklake.files.small` | `database` | Files below `minor_compaction_max_size` |
 | `ducklake.files.medium` | `database` | Files between minor and major thresholds |

--- a/dazzleduck-sql-flight/README.md
+++ b/dazzleduck-sql-flight/README.md
@@ -1,0 +1,141 @@
+# DazzleDuck SQL Flight
+
+The Arrow Flight SQL server implementation backed by DuckDB. This module contains the producer
+hierarchy (one class per access mode), the gRPC authentication middleware, statement and cursor
+lifecycle management, the ingestion bridge, metrics/audit recorders, and the adaptor that lets
+the HTTP module reuse the exact same producer.
+
+## Running Standalone
+
+```bash
+# Run through the runtime module so the Arrow --add-opens flags are applied
+./mvnw exec:java -pl dazzleduck-sql-runtime \
+  -Dexec.mainClass="io.dazzleduck.sql.flight.server.Main" \
+  -Dexec.args="--conf warehouse=warehouse"
+```
+
+In normal deployments the server is started by `dazzleduck-sql-runtime`, which builds one
+producer and shares it between Flight SQL and HTTP.
+
+## Producers
+
+`FlightSqlProducerFactory.build()` selects the producer from the `access_mode` config key:
+
+| Access mode | Producer | Behavior |
+|-------------|----------|----------|
+| `COMPLETE` | `DuckDBFlightSqlProducer` | All SQL, no authorization |
+| `READ_ONLY` | `SelectOnlyFlightSqlProducer` | Parses to AST, permits SELECT / set operations only; blocks prepared-statement updates |
+| `RESTRICT_READ_ONLY` | `RestrictedReadOnlyFlightSqlProducer` | As above, plus blocks the raw-SQL schema probe (`getSchemaStatement`) that would bypass authorization |
+| `RESTRICTED` | `RestrictedFlightSqlProducer` | Statement queries and bulk ingest only (catalog/schema/prepared-statement RPCs are unimplemented); adds split-based parallelization via `x-dd-split-size`; bulk ingest requires write access from JWT claims |
+
+All producers implement `FlightSqlHttpProducer` (`FlightSqlProducer` + `HttpFlightAdaptor`),
+which adds the HTTP-facing entry points: `acceptPutStatementBulkIngest` from an input stream,
+`tryCancel`, and direct streaming as Arrow IPC (`getStreamStatementDirect`), TSV (`streamTsv`),
+and JSONL (`streamJsonl`).
+
+## Flight SQL RPC Coverage
+
+Implemented: statement create/close/execute, prepared statements (except
+`acceptPutPreparedStatementQuery`), bulk ingest, cancel, SQL info, catalogs, schemas, tables,
+table types.
+
+Unimplemented: type info, primary/exported/imported keys, cross reference, `listFlights`.
+
+## Authentication
+
+`AdvanceServerCallHeaderAuthMiddleware` wraps `AdvanceJWTTokenAuthenticator`:
+
+1. A `Bearer` token is validated (signature verified unless `jwt_token.verify_signature = false`),
+   checked for expiry, and each header listed in `jwt_token.claims.validate.headers` must match
+   the corresponding JWT claim.
+2. Otherwise `Basic` credentials are validated — against the `users` config list
+   (`ConfBasedCredentialValidator`), or against an external login service when `login_url` is
+   set (`HttpCredentialValidator`) — and a JWT is minted with one claim per header in
+   `jwt_token.claims.generate.headers`. The token is returned on the outgoing headers, so
+   clients (including JDBC) transparently switch from Basic to Bearer.
+
+Authorization is delegated to the `SqlAuthorizer` implementations in `dazzleduck-sql-commons`
+(see that module's README). Every `StatementHandle` is HMAC-signed with `secret_key`, so a
+handle produced at plan time cannot be tampered with before execution, and all statement caches
+are keyed by peer identity — one user cannot fetch or cancel another user's cursor.
+
+## Statement and Cursor Lifecycle
+
+- Prepared statements: Guava cache, max 4000, expire 10 minutes after access
+- Statements/cursors: cache bounded by `max_cursors_total`, expiring after `cursor_ttl_ms`;
+  per-identity limit `max_cursors_per_identity`; exceeding either returns `RESOURCE_EXHAUSTED`
+- Query timeout: client `x-dd-query-timeout` (seconds) wins but is capped by
+  `max_query_timeout_ms`; otherwise `query_timeout_ms` applies
+- Results are streamed from DuckDB's native Arrow export with a child allocator per statement
+
+## Ingestion
+
+Bulk-ingest data is written to a temp Arrow file, validated, and handed to the
+`ParquetIngestionQueue` for the target `ingestion_queue`. Saturation surfaces as
+`RESOURCE_EXHAUSTED` (Flight) or HTTP 429 with `Retry-After`. Per-queue Micrometer meters are
+registered on queue creation and unregistered on deletion.
+
+## Named Queries
+
+`namedquery/DefaultNamedQueryServiceAdaptor` renders Jinja templates (Jinjava) stored in the
+table named by `named_query_table`, runs validators, and streams results through the same
+output listeners as regular queries. The HTTP module exposes this at `/v1/named-query`.
+
+## Metrics and Audit
+
+- `MicroMeterFlightRecorder` — counters/gauges named `dazzleduck.flight.*`, tagged
+  `service.name`, `host.name`, `container.id`, `producer.id`; defaults to a
+  `LoggingMeterRegistry` when none is supplied
+- `Auditor` — JSON `StatementAudit` records (START/END/CANCEL/ERROR/TIMEOUT with query, timings,
+  bytes out) to the logger `dazzleduck.audit`
+- `SqlProducerMBean` — running/open/completed/cancelled statement counts and details, consumed
+  by the HTTP `/v1/ui` dashboard
+
+## Configuration
+
+Defaults ship in this module's `reference.conf` under the `dazzleduck_server` root:
+
+| Key | Default |
+|-----|---------|
+| `flight_sql.port` / `flight_sql.host` | `59307` / `0.0.0.0` |
+| `flight_sql.use_encryption` | `true` (TLS from `keystore` / `server_cert` classpath resources) |
+| `flight_sql.data_processor_locations` | self — set to worker endpoints for distributed planning |
+| `access_mode` | `COMPLETE` |
+| `warehouse` | `${user.dir}/warehouse` |
+| `secret_key` | dev placeholder — **change in production** |
+| `query_timeout_ms` / `max_query_timeout_ms` | `120000` / `300000` |
+| `cursor_ttl_ms` / `max_cursors_per_identity` / `max_cursors_total` | `60000` / `50` / `2000` |
+| `ingestion.min_bucket_size` / `max_bucket_size` / `max_batches` / `max_pending_write` / `max_delay_ms` | 1 MB / 1 GB / 2048 / 256 MB / 2000 |
+| `jwt_token.expiration` / `generation` / `verify_signature` | `60m` / `true` / `true` |
+| `users` | `admin`/`admin` — **change in production** |
+| `startup_script_provider.*` | installs and loads the community `arrow` extension |
+| `ingestion_task_factory_provider.*` | NOOP provider writing under the warehouse |
+
+The full request-header vocabulary (`x-dd-fetch-size`, `x-dd-split-size`,
+`x-dd-arrow-compression`, ingestion headers, authorization claims) is defined in
+`io.dazzleduck.sql.common.Headers` — see the root README.
+
+## Key Files
+
+```
+src/main/java/io/dazzleduck/sql/flight/
+├── server/
+│   ├── Main.java                          # Standalone entry point
+│   ├── FlightSqlProducerFactory.java      # Config-driven producer construction
+│   ├── DuckDBFlightSqlProducer.java       # Base producer (~1500 lines)
+│   ├── SelectOnlyFlightSqlProducer.java
+│   ├── RestrictedReadOnlyFlightSqlProducer.java
+│   ├── RestrictedFlightSqlProducer.java
+│   ├── HttpFlightAdaptor.java             # Bridge used by dazzleduck-sql-http
+│   ├── StatementHandle.java               # HMAC-signed statement handle
+│   ├── ResultSetStreamUtil.java           # DuckDB → Arrow streaming
+│   ├── ErrorHandling.java                 # Exception → Flight status mapping
+│   ├── DirectOutputStreamListener.java    # Arrow IPC output
+│   ├── TsvOutputStreamListener.java       # TSV output
+│   ├── JsonOutputStreamListener.java      # JSON / JSONL output
+│   └── auth2/                             # Authenticators, middleware, credential validators
+├── namedquery/                            # Named-query adaptors (Jinjava)
+├── context/SyntheticFlightContext.java    # Fabricates a Flight context from HTTP requests
+├── optimizer/                             # QueryOptimizer SPI (NOOP default)
+└── MicroMeterFlightRecorder.java / Auditor.java
+```

--- a/dazzleduck-sql-http/README.md
+++ b/dazzleduck-sql-http/README.md
@@ -4,11 +4,15 @@ This module provides HTTP REST API endpoints for the DazzleDuck SQL Server, buil
 
 ## Overview
 
-- **Framework**: Helidon WebServer
+- **Framework**: Helidon WebServer 4.x with HTTP/2 (h2 when TLS is enabled, h2c otherwise, with HTTP/1.1 fallback)
 - **API Version**: v1
-- **Base Path**: `/v1` (except health check and UI)
-- **Authentication**: JWT token-based (required for all versioned endpoints by default)
-- **Data Format**: Apache Arrow IPC streaming format for query results
+- **Base Path**: `/v1` (except the health check)
+- **Authentication**: JWT token-based, always enforced on all versioned endpoints
+- **Data Formats**: Apache Arrow IPC (default, ZSTD-compressed), TSV, and JSONL/NDJSON via `Accept` negotiation
+
+The module is a thin adapter over the same `DuckDBFlightSqlProducer` used by the Arrow Flight
+SQL server: each HTTP request becomes a synthetic Flight call context, so authorization, access
+modes, metrics, and ingestion behave identically on both protocols.
 
 ## API Endpoints
 
@@ -114,9 +118,23 @@ Execute SQL queries and return results in Apache Arrow format.
 | 500 Internal Server Error | Execution error |
 | 504 Gateway Timeout | Query timeout exceeded |
 
-- **Content-Type**: `application/vnd.apache.arrow.stream`
-- **Body**: Binary Apache Arrow IPC stream
-- **Timeout**: Default 120 seconds (configurable)
+**Response format** is selected by the `Accept` request header:
+
+| Accept | Content-Type returned | Body |
+|--------|----------------------|------|
+| _(default)_ | `application/vnd.apache.arrow.stream` | Arrow IPC stream, ZSTD-compressed (override with `x-dd-arrow-compression: none`) |
+| `text/tab-separated-values` | `text/tab-separated-values; charset=utf-8` | Header row + tab-separated values |
+| `application/jsonl` or `application/x-ndjson` | `application/jsonl; charset=utf-8` | One JSON object per row |
+
+**Other request headers** (each also accepted as a URL query parameter):
+
+| Header | Description |
+|--------|-------------|
+| `x-dd-fetch-size` | Rows per Arrow batch (default 10000) |
+| `x-dd-query-timeout` | Per-query timeout in seconds; must be non-negative and below the server's `max_query_timeout_ms` |
+| `x-dd-arrow-compression` | `zstd` (default) or `none` |
+
+- **Timeout**: Default 120 seconds (`query_timeout_ms`)
 
 ---
 
@@ -143,7 +161,7 @@ Get query execution plan with endpoint locations and statement handles for distr
 **Headers**:
 | Header | Type | Required | Description |
 |--------|------|----------|-------------|
-| split_size | long | No | Target split size in bytes for partitioning (default: 1GB) |
+| `x-dd-split-size` | long | No | Target split size in bytes for partitioning (default: 1GB); also accepted as a query parameter |
 
 **Response**:
 | Status | Description |
@@ -188,7 +206,7 @@ When using `split_size` header to partition large queries:
 ```bash
 curl -X POST http://localhost:8081/v1/plan \
   -H "Content-Type: application/json" \
-  -H "split_size: 1" \
+  -H "x-dd-split-size: 1" \
   -d '{"query": "SELECT * FROM read_parquet(...)"}'
 ```
 
@@ -266,7 +284,7 @@ Bulk ingest data in Arrow format into tables.
 **Query Parameters**:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| ingestion_queue | string | Yes | Target table path (cannot start with "/" or contain "..") |
+| ingestion_queue | string | Yes | Target ingestion queue (cannot start with "/" or contain ".."). In restricted access modes the JWT must grant write access to this queue |
 
 **Headers**:
 | Header | Type | Required | Description |
@@ -297,6 +315,7 @@ x-dd-partition: year,month
 | 200 OK | Ingestion completed |
 | 400 Bad Request | Invalid parameters |
 | 415 Unsupported Media Type | Wrong content type |
+| 429 Too Many Requests | Ingestion backpressure — retry after the number of seconds in the `Retry-After` response header |
 | 500 Internal Server Error | Ingestion error |
 
 ---
@@ -321,6 +340,24 @@ Web-based monitoring dashboard for real-time metrics and query management.
 - Open prepared statements
 - Running bulk ingestion status
 - Query cancellation support
+
+---
+
+### Named Queries
+
+**Endpoint**: `/v1/named-query` — registered only when `named_query_table` is set in the
+configuration.
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/v1/named-query` | GET | Paginated list (`offset` default 0, `limit` default 20, max 200), JSON |
+| `/v1/named-query/{name}` | GET | Full named-query definition, JSON; `404` if unknown |
+| `/v1/named-query` | POST | Execute — body `{"name": "...", "parameters": {...}}`; response follows the same `Accept` negotiation as `/v1/query` (Arrow IPC / TSV / JSONL) |
+
+Errors: missing/blank `name` → `400`; validator failures → `400` with all failures collected;
+unknown template → `404`; timeout → `504`.
+
+See the root `README.md` for the named-query table schema, template syntax, and examples.
 
 ---
 
@@ -460,7 +497,7 @@ When passing header values in query parameters or HTTP headers, remember to URL-
 
 **Example**:
 ```bash
-curl -X POST "http://localhost:8080/v1/ingest?ingestion_queue=my_table" \
+curl -X POST "http://localhost:8081/v1/ingest?ingestion_queue=my_table" \
   -H "Content-Type: application/vnd.apache.arrow.stream" \
   -H "x-dd-partition: year,month" \
   -H "x-dd-project: col1,\"col2 + col3\",col4" \
@@ -471,16 +508,20 @@ curl -X POST "http://localhost:8080/v1/ingest?ingestion_queue=my_table" \
 
 ## Authentication
 
-### JWT Authentication (Required)
+### JWT Authentication (Always Enforced)
 
-All versioned API endpoints require a valid JWT Bearer token for authentication.
+All versioned API endpoints require a valid JWT Bearer token. The authentication filter is
+always installed — the `http.authentication` config key is read but no longer disables it.
+For tests and demos, set `jwt_token.verify_signature = false` to skip signature verification
+instead.
 
 **Protected Endpoints**:
 - `/v1/query`
 - `/v1/plan`
-- `/v1/ingest`
+- `/v1/ingest` (additionally requires write access to the requested `ingestion_queue`)
 - `/v1/cancel`
 - `/v1/ui`
+- `/v1/named-query`
 
 **Unprotected Endpoints**:
 - `/health` - Health check (always accessible)
@@ -491,29 +532,38 @@ All versioned API endpoints require a valid JWT Bearer token for authentication.
 Authorization: Bearer <JWT token>
 ```
 
-**Note**: To disable authentication (not recommended for production), set `http.authentication` to `"none"` in your configuration.
+When `login_url` is configured, `/v1/login` proxies credentials to that external login service
+instead of validating against the local `users` list.
 
 ### CORS Configuration
 
-- **Default Allow-Origin**: `*` (configurable)
+- **Default Allow-Origin**: `["https://dazzleduck-ui.netlify.app"]` (configurable via `http.allow-origin`)
 - **Allowed Methods**: GET, POST
-- **Allowed Headers**: Content-Type, Authorization
+- **Allowed Headers**: Content-Type, Authorization, x-dd-arrow-compression
 
 ---
 
 ## Configuration
 
+All keys live under the `dazzleduck_server` HOCON root.
+
 | Key | Description | Default |
 |-----|-------------|---------|
-| `http.host` | Server host | localhost |
-| `http.port` | Server port | 8080 |
-| `http.authentication` | Auth mode ("none" or "jwt") | jwt |
-| `jwt_token.expiration` | JWT token expiration | - |
-| `jwt_token.claims.generate.headers` | Headers to extract as JWT claims | - |
-| `jwt_token.claims.validate.headers` | Headers to validate | - |
-| `allow-origin` | CORS allow-origin value | * |
-| `warehouse_path` | DuckDB warehouse path | - |
-| `secret_key` | Base64-encoded JWT secret key | - |
+| `http.host` | Server host | `0.0.0.0` |
+| `http.port` | Server port | `8081` |
+| `http.allow-origin` | CORS allow-origin list | `["https://dazzleduck-ui.netlify.app"]` |
+| `http.tls.enabled` | Enable TLS (activates HTTP/2 h2) | `false` |
+| `warehouse` | DuckDB warehouse path | `${user.dir}/warehouse` |
+| `secret_key` | Base64-encoded JWT/HMAC secret key | dev placeholder — change in production |
+| `access_mode` | `COMPLETE`, `READ_ONLY`, `RESTRICTED`, `RESTRICT_READ_ONLY` | `COMPLETE` |
+| `query_timeout_ms` | Default query timeout | `120000` |
+| `max_query_timeout_ms` | Upper bound for client `x-dd-query-timeout` | `300000` |
+| `jwt_token.expiration` | JWT token expiration | `60m` |
+| `jwt_token.verify_signature` | Verify JWT signatures | `true` |
+| `jwt_token.claims.generate.headers` | Headers embedded as JWT claims on login | see flight `reference.conf` |
+| `named_query_table` | Table holding named queries; enables `/v1/named-query` | unset |
+| `login_url` | External login service; makes `/v1/login` a proxy | unset |
+| `ingestion.*` | Ingestion queue tuning (`min_bucket_size`, `max_delay_ms`, `max_pending_write`, ...) | see flight `reference.conf` |
 
 ---
 
@@ -522,7 +572,9 @@ Authorization: Bearer <JWT token>
 | Content-Type | Usage |
 |--------------|-------|
 | `application/json` | JSON requests/responses |
-| `application/vnd.apache.arrow.stream` | Arrow IPC streaming format |
+| `application/vnd.apache.arrow.stream` | Arrow IPC streaming format (default query results, ingestion body) |
+| `text/tab-separated-values` | TSV query results |
+| `application/jsonl` / `application/x-ndjson` | JSONL/NDJSON query results |
 | `text/html` | UI dashboard pages |
 | `text/css` | CSS stylesheets |
 | `application/javascript` | JavaScript |
@@ -556,12 +608,12 @@ Authorization: Bearer <JWT token>
 ```bash
 # JWT authentication is required by default
 # First, login to get a token
-curl -X POST http://localhost:8080/v1/login \
+curl -X POST http://localhost:8081/v1/login \
   -H "Content-Type: application/json" \
   -d '{"username": "admin", "password": "secret"}'
 
 # Use the returned token in subsequent requests
-curl -X POST http://localhost:8080/v1/query \
+curl -X POST http://localhost:8081/v1/query \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
   -d '{"query": "SELECT * FROM users"}' \
@@ -571,14 +623,14 @@ curl -X POST http://localhost:8080/v1/query \
 ### Check Health Status
 
 ```bash
-curl http://localhost:8080/health
+curl http://localhost:8081/health
 ```
 
 ### Ingest Data
 
 ```bash
 # JWT authentication is required by default
-curl -X POST "http://localhost:8080/v1/ingest?ingestion_queue=my_table" \
+curl -X POST "http://localhost:8081/v1/ingest?ingestion_queue=my_table" \
   -H "Content-Type: application/vnd.apache.arrow.stream" \
   -H "Authorization: Bearer <token>" \
   -H "x-dd-format: parquet" \
@@ -592,17 +644,20 @@ curl -X POST "http://localhost:8080/v1/ingest?ingestion_queue=my_table" \
 ```
 dazzleduck-sql-http/
 └── src/main/java/io/dazzleduck/sql/http/server/
-    ├── Main.java                        # Application entry point
-    ├── QueryService.java                # Query execution endpoint
+    ├── Main.java                        # Application entry point (also embeddable via Main.start)
+    ├── QueryService.java                # Query execution endpoint (Arrow/TSV/JSONL)
     ├── HealthCheckService.java          # Health check endpoint
     ├── PlanningService.java             # Query planning endpoint
     ├── CancelService.java               # Query cancellation endpoint
     ├── IngestionService.java            # Data ingestion endpoint
+    ├── NamedQueryService.java           # Named-query endpoints (conditional)
     ├── UIService.java                   # Metrics dashboard UI
     ├── AbstractQueryBasedService.java   # Base service for query endpoints
+    ├── ControllerService.java           # Synthetic Flight context + error mapping
     ├── JwtAuthenticationFilter.java     # JWT authentication filter
-    ├── QueryRequest.java                # Query request model
-    ├── ContentTypes.java                # Content type constants
-    ├── HttpConfig.java                  # HTTP configuration
-    └── HttpException.java               # Exception base class
+    ├── ParameterUtils.java              # Header-or-query-param extraction
+    ├── FlightToHttpEndpointMapper.java  # Flight locations to HTTP endpoint URLs
+    └── model/                           # QueryRequest, PlanResponse, Descriptor, HttpConfig
 ```
+
+Content-type constants live in `io.dazzleduck.sql.common.ContentTypes`.

--- a/dazzleduck-sql-logback/README.md
+++ b/dazzleduck-sql-logback/README.md
@@ -48,11 +48,8 @@ Create a standard Logback XML file (any filename) in `src/main/resources/`:
         <baseUrl>http://localhost:8081</baseUrl>
         <username>admin</username>
         <password>admin</password>
-        <claims>
-            <database>logs_db</database>
-            <schema>public</schema>
-            <environment>production</environment>
-        </claims>
+        <!-- claims is a comma-separated list of key=value pairs -->
+        <claims>database=logs_db,schema=public,environment=production</claims>
         <ingestionQueue>app-logs</ingestionQueue>
     </appender>
 
@@ -202,26 +199,26 @@ refreshed automatically before it expires.
 </appender>
 ```
 
-### Preconfigured JWT
+### Preconfigured Token
 
 When your deployment already provides a token (e.g. a sidecar injects it via an
-environment variable, or an external auth service issues it), pass the full
-`Bearer <token>` string directly. Login is skipped entirely and the token is used
-as-is for every request. If the server rejects it the call fails immediately —
-there is no re-login attempt.
+environment variable, or an external auth service issues it), pass the **raw** JWT via the
+`token` property — the `Bearer ` prefix is added automatically at startup. Login is skipped
+entirely and the token is used as-is for every request. If the server rejects it the call
+fails immediately — there is no re-login attempt.
 
 ```xml
 <appender name="LOG_FORWARDER" class="io.dazzleduck.sql.logback.LogForwardingAppender">
     <baseUrl>http://localhost:8081</baseUrl>
-    <jwt>Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...</jwt>
+    <token>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...</token>
     <ingestionQueue>app-logs</ingestionQueue>
 </appender>
 ```
 
-`jwt` and `username`/`password` are mutually exclusive. Setting `jwt` overrides
-the login flow; `username` and `password` are ignored when `jwt` is present.
+A non-blank `token` takes precedence over `username`/`password`; a blank or absent token
+falls back to the login flow.
 
-Programmatic equivalent:
+Programmatic equivalent (the builder takes the full header value, prefix included):
 
 ```java
 LogForwarderConfig config = LogForwarderConfig.builder()
@@ -242,8 +239,8 @@ All properties that can appear inside the `<appender>` element:
 | `baseUrl` | DazzleDuck server URL | `http://localhost:8081` |
 | `username` | Authentication username (login mode) | `admin` |
 | `password` | Authentication password (login mode) | `admin` |
-| `jwt` | Preconfigured `Bearer <token>` (skips login; mutually exclusive with username/password) | _(none)_ |
-| `claims` | Custom JWT claims for row-level security (login mode only) | `{}` |
+| `token` | Preconfigured raw JWT (`Bearer ` prefix added automatically; skips login, takes precedence over username/password) | _(none)_ |
+| `claims` | Custom JWT claims as comma-separated `key=value` pairs (login mode only) | _(none)_ |
 | `ingestionQueue` | Target ingestion queue name | `log` |
 | `minBatchSize` | Min bytes to accumulate before sending | `1024` |
 | `partitionBy` | Comma-separated partition column names | _(none)_ |

--- a/dazzleduck-sql-login/README.md
+++ b/dazzleduck-sql-login/README.md
@@ -1,0 +1,76 @@
+# DazzleDuck SQL Login
+
+JWT authentication and token-issuing service. It is used two ways:
+
+1. **As a library** — `dazzleduck-sql-http` registers `LoginService` (or `ProxyLoginService`)
+   at `POST /v1/login` on the main server.
+2. **As a standalone service** — `io.dazzleduck.sql.login.Main` starts its own Helidon server
+   (default port 8080) exposing the same endpoint, configured under the separate HOCON root
+   `dazzleduck_login_service`.
+
+The module has no DuckDB dependency.
+
+## Endpoint
+
+### `POST /v1/login`
+
+Request:
+
+```json
+{
+  "username": "admin",
+  "password": "admin",
+  "claims": { "x-dd-table": "orders", "x-dd-filter": "tenant_id = 'abc'" }
+}
+```
+
+`claims` is an optional string-to-string map; the server embeds each entry as a JWT claim.
+Claim names understood downstream are listed in the root README (`database`, `schema`,
+`x-dd-table`, `x-dd-filter`, `x-dd-path`, `x-dd-function`, `x-dd-access`,
+`x-dd-ingestion-queue`, ...).
+
+Response `200`:
+
+```json
+{ "accessToken": "<jwt>", "username": "admin", "tokenType": "Bearer" }
+```
+
+Any failure (bad credentials or otherwise) returns `401` with an empty body.
+
+## Implementations
+
+| Class | Behavior |
+|-------|----------|
+| `LoginService` | Validates credentials against the configured `users` list (SHA-256 hashed passwords, constant-time comparison) and mints an HMAC-signed JWT with the requested claims and `jwt_token.expiration` |
+| `ProxyLoginService` | Forwards the raw JSON body to an external login URL and relays the backend's status and body verbatim. Selected by the HTTP module when `dazzleduck_server.login_url` is set |
+| `ProxyResolveAccessService` | Mock `/resolve` endpoint for redirect-authorization tests — returns a hard-coded grant set. Test fixture only; do not use in production |
+
+## Configuration (standalone mode)
+
+HOCON root `dazzleduck_login_service` (this module's `reference.conf`):
+
+```hocon
+dazzleduck_login_service {
+    http.port = 8080
+    http.host = "localhost"
+    users = [{ username = admin, password = admin, groups = [admin, general] }]
+    jwt_token.expiration = 60m
+    secret_key = "..."   # base64 HMAC key — must match the server that verifies the tokens
+}
+```
+
+The `secret_key` must be shared with whatever verifies the issued tokens (the Flight/HTTP
+server's `dazzleduck_server.secret_key`). The bundled default is a well-known dev key —
+**change it in production**.
+
+## Security Notes
+
+- Requested claims are embedded **as sent** — there is no server-side allow-list. Do not expose
+  this login service to callers who should not be able to choose their own authorization claims;
+  in that situation issue tokens from a trusted external service and use `login_url` /
+  preconfigured tokens instead.
+- Tokens are HMAC-signed (`jjwt`); expiration granularity is minutes.
+
+## Requirements
+
+- Java 21

--- a/dazzleduck-sql-micrometer/README.md
+++ b/dazzleduck-sql-micrometer/README.md
@@ -194,7 +194,7 @@ Counter counter = Counter.builder("api.calls")
 | `baseUrl` | Target server URL | `http://localhost:8081` |
 | `username` | Authentication username (login mode) | `admin` |
 | `password` | Authentication password (login mode) | `admin` |
-| `jwt` | Preconfigured `Bearer <token>` (skips login; mutually exclusive with username/password) | _(none)_ |
+| `jwt` | Preconfigured `Bearer` token string (skips login; builder-only, mutually exclusive with username/password) | _(none)_ |
 | `targetPath` | Server endpoint path | `metrics` |
 | `stepInterval` | How often metrics are published | `10 seconds` |
 | `httpClientTimeout` | HTTP request timeout | `3 seconds` |
@@ -251,17 +251,8 @@ MicrometerForwarder forwarder = MicrometerForwarder.createAndStart(config);
 `jwt` and `username`/`password` are mutually exclusive. Setting `jwt` overrides
 the login flow; `username` and `password` are ignored when `jwt` is present.
 
-Via `application.conf`:
-
-```hocon
-dazzleduck_micrometer {
-  http {
-    base_url        = "http://localhost:8081"
-    jwt             = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-    ingestion_queue = "metrics"
-  }
-}
-```
+Note: the preconfigured JWT is available only through the programmatic builder —
+`MetricsRegistryFactory` / `application.conf` supports the username/password mode.
 
 ---
 
@@ -271,16 +262,20 @@ Claims are key-value pairs sent to the server during login. The server embeds th
 
 Use claims when the server is configured with `access_mode = RESTRICTED` and you need to scope metric ingestion to a specific database, schema, or table. Claims apply only in username/password mode — when using a preconfigured JWT the token already encodes any required claims.
 
-### Supported Claim Keys
+### Common Claim Keys
+
+Claims are forwarded verbatim to `/v1/login`; the server embeds them in the JWT. The claim
+names the server understands are:
 
 | Key | Description |
 |-----|-------------|
-| `database` | Target database |
-| `catalog` | Target catalog |
-| `schema` | Target schema |
-| `table` | Target table |
-| `filter` | Row-level filter expression |
-| `path` | Storage path |
+| `database` | Target database (unprefixed — Flight SQL / JDBC interop) |
+| `schema` | Target schema (unprefixed) |
+| `x-dd-table` | Authorized table |
+| `x-dd-filter` | Row-level filter expression |
+| `x-dd-path` | Authorized storage path prefix |
+| `x-dd-function` | Authorized table function |
+| `x-dd-access` | Full access tuple list (see the root README) |
 
 ### Programmatic Configuration
 

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -6,19 +6,26 @@ An OTLP gRPC collector that receives OpenTelemetry signals (logs, traces, metric
 
 ```
 OTLP Exporter
-     │  gRPC (port 4317)
+     │  gRPC (port 4317), JWT with x-dd-ingestion-queue claim
      ▼
 OtelCollectorServer
      │
-     ├── OtelLogService      → SignalWriter → ParquetIngestionQueue → Parquet files
-     ├── OtelTraceService    → SignalWriter → ParquetIngestionQueue → Parquet files
-     └── OtelMetricsService  → SignalWriter → ParquetIngestionQueue → Parquet files
+     ├── OtelLogService      ┐
+     ├── OtelTraceService    ├─→ IngestionHandler → ParquetIngestionQueue → Parquet files (+ DuckLake)
+     └── OtelMetricsService  ┘
 ```
 
 Each incoming export request is:
-1. Flattened from the 3-level OTLP hierarchy (Resource → Scope → Record) into a flat Arrow batch
-2. Written to a temp Arrow file
-3. Handed to `SignalWriter`, which batches by size (`min_bucket_size`) and time (`max_delay_ms`) before flushing to Parquet
+1. Routed to an ingestion queue by the `x-dd-ingestion-queue` claim in the caller's JWT — there
+   is no default queue; requests without the claim are rejected with `INVALID_ARGUMENT`
+2. Flattened from the 3-level OTLP hierarchy (Resource → Scope → Record) into a flat Arrow batch
+   and written to a temp Arrow file
+3. Handed to the queue's `ParquetIngestionQueue`, which batches by size (`min_bucket_size`) and
+   time (`max_delay_ms`) before flushing to Parquet — and, when a DuckLake provider is
+   configured, registers the files with the catalog in the same post-ingestion transaction
+
+Queues are never pre-created: the configured `IngestionHandler` is the single registry, so
+queues added or removed at runtime (dynamic provider) become routable without a restart.
 
 ## Features
 
@@ -38,24 +45,38 @@ Configuration is loaded from HOCON (`application.conf`) with environment variabl
 otel_collector {
     grpc_port = 4317
 
-    logs_output_path    = "./otel-logs"
-    traces_output_path  = "./otel-traces"
-    metrics_output_path = "./otel-metrics"
+    health {
+        port = 8081                       # GET /health
+        shutdown_grace_period_ms = 2000   # MAINTENANCE/LB-drain window; 0 to skip
+    }
+
+    # Startup SQL run before any queue is created (load extensions, ATTACH DuckLake catalogs)
+    startup_script_provider {
+        content = "INSTALL arrow FROM community; LOAD arrow;"
+        # script_location = "/config/startup.sql"
+    }
 
     ingestion {
         min_bucket_size = 1048576   # 1 MB — flush when accumulated batch size exceeds this
         max_delay_ms    = 5000      # flush after this many ms even if min_bucket_size not reached
+        queue_config_refresh_delay_ms = 120000
     }
 
-    # Columns to partition Parquet output by
-    partition_by = []
-
-    # Optional SQL expressions appended as: SELECT *, <transformations>
-    # Example: transformations = "cast(timestamp as date) as date"
+    # One entry per ingestion queue. Without a provider class, batches are written
+    # as plain Parquet under output_path. Per-queue keys: transformation,
+    # partition_by, min_bucket_size, max_delay_ms, and (with DuckLake)
+    # catalog / schema / table / additional_parameters.
+    ingestion_task_factory_provider {
+        ingestion_queue_table_mapping = [
+            { ingestion_queue = "logs",    output_path = "./otel-logs" }
+            { ingestion_queue = "traces",  output_path = "./otel-traces" }
+            { ingestion_queue = "metrics", output_path = "./otel-metrics" }
+        ]
+    }
 
     # Authentication (required)
     authentication = "jwt"
-    secret_key     = "<base64-encoded-hmac-key>"
+    secret_key     = "base64-encoded-hmac-key"
 
     # Local users (Basic auth → JWT)
     users = [
@@ -228,23 +249,33 @@ Wide-table design — all metric types (GAUGE, SUM, HISTOGRAM, EXPONENTIAL_HISTO
 
 ### Export Metrics
 
-| Metric | Type | Tags |
-|--------|------|------|
-| `dazzleduck.otel.export.requests` | FunctionCounter | `signal=logs\|traces\|metrics` |
-| `dazzleduck.otel.export.records` | FunctionCounter | `signal=logs\|traces\|metrics` |
-| `dazzleduck.otel.export.errors` | FunctionCounter | `signal=logs\|traces\|metrics` |
-| `dazzleduck.otel.export.latency` | Timer (p50/p95/p99) | `signal=..., max.delay.ms=<configured>` |
+All meters are tagged with the ingestion `queue` id.
 
-`export.latency` covers the full RPC duration — from receiving the request to `onCompleted` or `onError`, including Arrow serialization and `SignalWriter` queue submission.
+| Metric | Type |
+|--------|------|
+| `dazzleduck.otel.export.requests` | FunctionCounter |
+| `dazzleduck.otel.export.records` | FunctionCounter |
+| `dazzleduck.otel.export.errors` | FunctionCounter |
+| `dazzleduck.otel.export.latency` | Timer (p50/p95/p99) |
+
+`export.latency` covers the full RPC duration — from receiving the request to `onCompleted` or `onError`, including Arrow serialization and queue submission.
 
 ### Writer Metrics
 
-| Metric | Type | Tags |
-|--------|------|------|
-| `dazzleduck.otel.writer.bytes_written` | FunctionCounter | `signal=...` |
-| `dazzleduck.otel.writer.batches_written` | FunctionCounter | `signal=...` |
-| `dazzleduck.otel.writer.pending_batches` | Gauge | `signal=...` |
-| `dazzleduck.otel.writer.pending_buckets` | Gauge | `signal=...` |
+Registered per queue when the queue is created, and unregistered when the queue is removed.
+
+| Metric | Type |
+|--------|------|
+| `dazzleduck.otel.writer.bytes_written` | FunctionCounter |
+| `dazzleduck.otel.writer.batches_written` | FunctionCounter |
+| `dazzleduck.otel.writer.bytes_failed` | FunctionCounter |
+| `dazzleduck.otel.writer.batches_failed` | FunctionCounter |
+| `dazzleduck.otel.writer.write_failures` | FunctionCounter |
+| `dazzleduck.otel.writer.producer_id_evictions` | FunctionCounter |
+| `dazzleduck.otel.writer.data_phase_ms` | FunctionCounter |
+| `dazzleduck.otel.writer.post_ingest_phase_ms` | FunctionCounter |
+| `dazzleduck.otel.writer.pending_batches` | Gauge |
+| `dazzleduck.otel.writer.pending_buckets` | Gauge |
 
 ### Registering a Real Registry
 
@@ -257,30 +288,51 @@ server.start();
 
 ## DuckLake Integration
 
-To register written Parquet files into a DuckLake catalog, configure an `IngestionTaskFactory` per signal:
-
-```java
-CollectorProperties props = new CollectorConfig().toProperties();
-props.setLogIngestionTaskFactory(myDuckLakeFactory);
-props.setTraceIngestionTaskFactory(myDuckLakeFactory);
-props.setMetricIngestionTaskFactory(myDuckLakeFactory);
-```
-
-Or via HOCON using `ConfigBasedProvider`:
+To register written Parquet files into a DuckLake catalog, set a provider `class` on
+`ingestion_task_factory_provider` and add the DuckLake fields per queue (the catalog must be
+attached by the startup script):
 
 ```hocon
 otel_collector {
-    log_ingestion_task_factory_provider {
+    startup_script_provider {
+        content = "INSTALL ducklake; LOAD ducklake; ATTACH 'ducklake:...' AS my_catalog (DATA_PATH 's3://...');"
+    }
+
+    ingestion_task_factory_provider {
         class = "io.dazzleduck.sql.commons.ingestion.DuckLakeIngestionTaskFactoryProvider"
-        catalog = "my_catalog"
-        mappings = [
-            { queue = "logs",    table = "my_catalog.logs" }
-            { queue = "traces",  table = "my_catalog.spans" }
-            { queue = "metrics", table = "my_catalog.metrics" }
+        ingestion_queue_table_mapping = [
+            {
+                ingestion_queue = "logs"
+                catalog = "my_catalog"
+                schema  = "main"
+                table   = "logs"
+                # transformation = "CAST(timestamp AS DATE) AS date, severity_text AS level"
+                # additional_parameters {   # optional per-batch watermark row, committed
+                #     watermark_table                = "ingest_watermark"   # with the file registration
+                #     watermark_timestamp_column     = "timestamp"
+                #     watermark_min_timestamp_column = "min_timestamp"
+                #     watermark_max_timestamp_column = "max_timestamp"
+                #     watermark_row_count_column     = "row_count"
+                #     watermark_group_columns        = "county,state"      # optional
+                # }
+            }
         ]
     }
 }
 ```
+
+For runtime add/remove of queues, use the dynamic provider backed by a SQLite registry:
+
+```hocon
+otel_collector.ingestion_task_factory_provider {
+    class = "io.dazzleduck.sql.commons.ingestion.DynamicDuckLakeIngestionTaskFactoryProvider"
+    db_path = "/var/data/ingestion-queues.db"
+    config_load_interval_ms = 5000
+}
+```
+
+Watermarks are not available for dynamically registered queues — the SQLite registry does not
+store `additional_parameters`.
 
 ## Building
 
@@ -299,4 +351,14 @@ Or with an external config file:
 
 ```bash
 java -cp ... io.dazzleduck.sql.otel.collector.Main -c /etc/otel-collector.conf
+```
+
+## Docker
+
+The collector is published as `dazzleduck/dazzleduck-otel-collector` (multi-arch). Local build via Jib:
+
+```bash
+./mvnw package -DskipTests jib:dockerBuild -pl dazzleduck-sql-otel-collector
+# Apple Silicon:
+./mvnw package -DskipTests jib:dockerBuild -pl dazzleduck-sql-otel-collector -Djib.architecture=arm64
 ```

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -306,7 +306,13 @@ otel_collector {
                 catalog = "my_catalog"
                 schema  = "main"
                 table   = "logs"
+                # Inline transformation (SELECT over the __this placeholder):
                 # transformation = "CAST(timestamp AS DATE) AS date, severity_text AS level"
+                # ... OR a view-based transformation — the view's definition is used, with
+                # input_table rewritten to __this. Mutually exclusive with transformation;
+                # editing the view updates the transformation at runtime, no restart:
+                # view        = "my_catalog.main.logs_transform"
+                # input_table = "my_catalog.main.raw_logs"
                 # additional_parameters {   # optional per-batch watermark row, committed
                 #     watermark_table                = "ingest_watermark"   # with the file registration
                 #     watermark_timestamp_column     = "timestamp"

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -45,10 +45,7 @@ Configuration is loaded from HOCON (`application.conf`) with environment variabl
 otel_collector {
     grpc_port = 4317
 
-    health {
-        port = 8081                       # GET /health
-        shutdown_grace_period_ms = 2000   # MAINTENANCE/LB-drain window; 0 to skip
-    }
+    # health { port, shutdown_grace_period_ms } — see the Health Check section below
 
     # Startup SQL run before any queue is created (load extensions, ATTACH DuckLake catalogs)
     startup_script_provider {

--- a/dazzleduck-sql-runtime/README.md
+++ b/dazzleduck-sql-runtime/README.md
@@ -1,0 +1,71 @@
+# DazzleDuck SQL Runtime
+
+The process launcher and startup orchestrator — this module produces the published
+`dazzleduck/dazzleduck` Docker image. It owns no query logic: it loads and validates
+configuration, runs the startup SQL script, builds **one shared** `DuckDBFlightSqlProducer`,
+and hands that same producer to the HTTP server and/or the Flight SQL server.
+
+## Startup Sequence
+
+`Main.main` → `Runtime.start(args)`:
+
+1. Parse `--conf key=value` overrides (repeatable) and merge them over the classpath
+   `reference.conf` defaults and system properties
+2. Validate the warehouse path (local paths are created if missing and must be writable
+   directories; `s3://` paths get basic bucket-name validation)
+3. Load and execute the startup script (`startup_script_provider`) on the singleton DuckDB
+   connection — extensions and attached catalogs are inherited by all connections
+4. Start the servers listed in `networking_modes` — `flight-sql` (port 59307) and/or `http`
+   (port 8081) — sharing one producer and allocator
+5. A JVM shutdown hook closes the servers, producer, and allocator
+
+## Running
+
+```bash
+# From source
+./mvnw exec:java -pl dazzleduck-sql-runtime \
+  -Dexec.args="--conf warehouse=warehouse --conf users.0.password='your password'"
+
+# Docker
+docker run -ti -p 59307:59307 -p 8081:8081 dazzleduck/dazzleduck:latest \
+  --conf warehouse=/data \
+  --conf users.0.password="your password"
+```
+
+The Arrow `--add-opens` JVM flags are preconfigured by the exec plugin and the container
+entrypoint.
+
+The container entrypoint also supports running an arbitrary main class: if the first argument
+starts with `io.dazzleduck.`, that class is run instead of the server (used by the demo
+containers). Optional jars dropped into `/app/extra` (e.g. Hadoop for Delta Lake support) are
+added to the classpath.
+
+## Configuration
+
+This module's own `reference.conf` contributes exactly one key:
+
+```hocon
+dazzleduck_server = { networking_modes = [flight-sql, http] }
+```
+
+Valid `networking_modes` values are `flight-sql` and `http`; an empty or unknown value fails
+startup. Every other key (`warehouse`, `secret_key`, `access_mode`, ports, JWT, ingestion, ...)
+comes from the flight and http modules' `reference.conf` files — see those modules' READMEs and
+the root README.
+
+## Docker Image
+
+Built with Jib on top of a custom base image (`dazzleduck/base-jre`) that bundles the JRE and a
+platform-stripped DuckDB JDBC driver. Build instructions, base-image rationale, and multi-arch
+publishing live in [`docker/README.md`](docker/README.md).
+
+## Key Files
+
+```
+src/main/java/io/dazzleduck/sql/runtime/
+├── Main.java      # CLI entry point, banner, shutdown hook, exit codes
+└── Runtime.java   # Config validation, startup script, server lifecycle
+```
+
+The module also publishes a test-jar containing `SharedTestServer`, reused by other modules'
+integration tests.

--- a/dazzleduck-sql-runtime/docker/README.md
+++ b/dazzleduck-sql-runtime/docker/README.md
@@ -45,7 +45,7 @@ Only needed when upgrading Java, DuckDB version, or example data/startup scripts
 ```bash
 # Read version directly from pom.xml
 DUCKDB_VERSION=$(./mvnw help:evaluate -Dexpression=duckdb.version -q -DforceStdout)
-JAVA_VERSION=21   # or 25 for JDK 25
+JAVA_VERSION=25   # must match the base-jre tag referenced by the module poms (currently 25)
 
 # Multi-platform — push to Docker Hub (CI/CD)
 docker buildx build \
@@ -133,7 +133,7 @@ To rebuild the base for ARM64 only:
 
 ```bash
 DUCKDB_VERSION=$(./mvnw help:evaluate -Dexpression=duckdb.version -q -DforceStdout)
-JAVA_VERSION=21
+JAVA_VERSION=25
 docker build \
   --platform linux/arm64 \
   --build-arg JAVA_VERSION=$JAVA_VERSION \

--- a/dazzleduck-sql-scrapper/README.md
+++ b/dazzleduck-sql-scrapper/README.md
@@ -37,8 +37,8 @@ It works with any system that exposes a standard Prometheus text format endpoint
 ./mvnw package jib:dockerBuild -pl dazzleduck-sql-scrapper -DskipTests
 ```
 
-The fat JAR lands in `target/dazzleduck-sql-scrapper-<version>.jar`.
-The Docker image is tagged `dazzleduck-sql-scrapper:latest`.
+The fat JAR lands in `target/` named after the module and version.
+The Docker image is tagged `dazzleduck/dazzleduck-sql-scrapper:latest` (amd64).
 
 ---
 
@@ -51,7 +51,7 @@ The Docker image is tagged `dazzleduck-sql-scrapper:latest`.
 ```
 
 Jib builds the image directly from Maven without needing a Docker daemon or a `docker build` step.
-The output image is `dazzleduck-sql-scrapper:latest`.
+The output image is `dazzleduck/dazzleduck-sql-scrapper:latest`.
 
 ### How Environment Variables Work
 
@@ -93,7 +93,7 @@ The entrypoint script converts this into a HOCON list and passes it via `--confi
 services:
 
   dazzleduck-scrapper:
-    image: dazzleduck-sql-scrapper:latest
+    image: dazzleduck/dazzleduck-sql-scrapper:latest
     container_name: dazzleduck-scrapper
     depends_on:
       - metrics-log-backend
@@ -106,7 +106,6 @@ services:
       - collector.enabled=true
       - collector.target-prefix=http://envoy:9901
       - collector.base-url=http://metrics-log-backend:8081
-      - collector.server-url=http://metrics-log-backend:8081/ingest
       - collector.path=envoy_metrics
 
       # ---- scrape settings ----
@@ -131,7 +130,7 @@ services:
 services:
 
   dazzleduck-scrapper:
-    image: dazzleduck-sql-scrapper:latest
+    image: dazzleduck/dazzleduck-sql-scrapper:latest
     container_name: dazzleduck-scrapper
     depends_on:
       - my-spring-app
@@ -141,7 +140,6 @@ services:
 
       - collector.enabled=true
       - collector.base-url=http://dazzleduck-server:8081
-      - collector.server-url=http://dazzleduck-server:8081/ingest
       - collector.path=app_metrics
       - collector.scrape-interval-ms=15000
 
@@ -164,7 +162,7 @@ mount a HOCON config file into the container:
 services:
 
   dazzleduck-scrapper:
-    image: dazzleduck-sql-scrapper:latest
+    image: dazzleduck/dazzleduck-sql-scrapper:latest
     volumes:
       - ./collector.conf:/etc/collector/collector.conf:ro
     command: ["--config", "/etc/collector/collector.conf"]
@@ -181,8 +179,7 @@ collector {
         "http://app:8080/actuator/prometheus"
     ]
 
-    base-url   = "http://metrics-log-backend:8081"
-    server-url = "http://metrics-log-backend:8081/ingest"
+    base-url = "http://metrics-log-backend:8081"
     path = "metrics"
 
     scrape-interval-ms = 15000
@@ -262,13 +259,11 @@ collector {
     # "http://host:port" + "/actuator/prometheus" → "http://host:port/actuator/prometheus"
     target-prefix = "http://localhost:8080"
 
-    # DazzleDuck server base URL (used for login + ingest)
+    # DazzleDuck server base URL — the forwarder logs in at {base-url}/v1/login and
+    # ingests at {base-url}/v1/ingest?ingestion_queue={path}
     base-url = "http://localhost:8081"
 
-    # Full ingest endpoint URL
-    server-url = "http://localhost:8081/ingest"
-
-    # Table/path name used when storing metrics on the server
+    # Ingestion queue name used when storing metrics on the server
     path = "scraped_metrics"
 
     # How often to scrape targets (milliseconds)
@@ -377,8 +372,7 @@ collector {
         "/stats/prometheus"
     ]
 
-    base-url   = "http://localhost:8081"
-    server-url = "http://localhost:8081/ingest"
+    base-url = "http://localhost:8081"
     path = "envoy_metrics"
 
     scrape-interval-ms = 15000
@@ -410,8 +404,7 @@ collector {
         "http://envoy-egress:9901/stats/prometheus"
     ]
 
-    base-url   = "http://localhost:8081"
-    server-url = "http://localhost:8081/ingest"
+    base-url = "http://localhost:8081"
     path = "envoy_metrics"
 
     scrape-interval-ms = 15000
@@ -557,7 +550,6 @@ public class Example {
         props.setEnabled(true);
         props.setTargets(List.of("http://envoy-host:9901/stats/prometheus?usedonly"));
         props.setBaseUrl("http://localhost:8081");
-        props.setServerUrl("http://localhost:8081/ingest");
         props.setPath("envoy_metrics");
         props.setScrapeIntervalMs(15000);
         props.setFlushThreshold(100);
@@ -611,14 +603,14 @@ long dropped      = collector.getMetricsDroppedCount();
 
 - Check that `collector.enabled = true` is set
 - Verify the target URL is reachable: `curl http://envoy-host:9901/stats/prometheus`
-- Check that `base-url`, `server-url`, and `path` point to the correct DazzleDuck instance
+- Check that `base-url` and `path` point to the correct DazzleDuck instance
 - Increase log level to DEBUG: `logging.level = "DEBUG"`
 
 **Too many metrics / buffer fills up quickly**
 
 - Add `?usedonly` to the target URL to filter zero-value metrics
 - Add `?filter=<regex>` to focus on specific metric families
-- Reduce `scrape-interval-ms` to scrape less frequently
+- Increase `scrape-interval-ms` to scrape less frequently
 - Increase `tailing.flush-threshold` and `tailing.flush-interval-ms`
 
 **Authentication failures**

--- a/dazzleduck-sql-search/README.md
+++ b/dazzleduck-sql-search/README.md
@@ -1,0 +1,34 @@
+# DazzleDuck SQL Search
+
+Inverted-index construction for full-text search over Parquet files, built entirely as DuckDB
+SQL plus Arrow round-trips (no external search engine at runtime).
+
+**Status: indexing only.** The query side (`Plan`, `Split`) consists of interfaces with no
+implementations yet — this module currently builds indexes but does not serve searches.
+
+## How Indexing Works
+
+`Indexer.create(sourcePrefix, sourceFiles, sourceFields, timeField, tokenizationFunctions, indexFile)`:
+
+1. Reads the source Parquet files with `read_parquet(..., filename = true)`, carrying
+   `file_row_number` and `filename` through the pipeline
+2. Tokenizes the requested VARCHAR columns in Java (via a `MappedReader` function from
+   `dazzleduck-sql-commons`) into an Arrow struct of token lists
+3. UNPIVOTs / UNNESTs / GROUPs the tokens in DuckDB into a posting-list Parquet file:
+   token, column, source file, and the row numbers containing the token
+
+Posting lists for very frequent tokens (more than 1000 rows in a file) store `NULL` row
+numbers — for those tokens the index degrades to a file-level filter rather than row-level.
+
+## Key Types
+
+| Type | Purpose |
+|------|---------|
+| `Indexer` | Static entry point and SQL construction (`create`, `constructInputSql`, `constructWriteSql`) |
+| `TokenizationFunction` | `String` to `String[]` tokenizer applied per column |
+| `Plan` / `Split` | Query-side SPI — **not yet implemented** |
+
+## Requirements
+
+- Java 21
+- Depends on `dazzleduck-sql-commons` (`ConnectionPool`, `MappedReader`)


### PR DESCRIPTION
## Summary

Code-first documentation audit of all 15 modules. Every README was verified against the current source; stale content was corrected and the seven modules that had no README at all now have one.

### Updated (10 files)

- **README.md** — dropped stale sqlflite/voltrondata branding and env vars; full module table with per-module JDK targets; TSV/JSONL output docs; corrected the named-query DDL to the 8 columns the store actually requires; removed the "Query Modes" section (the `mode` request field does not exist); documented watermark config keys and per-protocol ingestion-queue routing
- **CLAUDE.md** — module tree fixed (removed `dazzleduck-sql-logger`; added `otel-collector`, `ducklake-compactor`, `examples`); `ConfigUtils` corrected to `ConfigConstants`; current claim-header defaults
- **dazzleduck-sql-commons** — rewritten: Java 21, `io.dazzleduck.sql.commons` packages, authorization / ingestion / DuckLake-Hive-Delta pruning / split planning coverage
- **dazzleduck-sql-http** — Accept-based TSV/JSONL negotiation, `/v1/named-query` endpoints, `x-dd-split-size` (was `split_size`), 429 + `Retry-After` backpressure, note that the JWT filter is always installed, real config defaults (port 8081, CORS origin)
- **dazzleduck-sql-logback** — appender property is `token` (raw JWT), not `jwt`; `claims` is a comma-separated key=value string
- **dazzleduck-sql-micrometer** — preconfigured JWT is builder-only (the documented HOCON key is never read); real claim key names
- **dazzleduck-sql-otel-collector** — replaced removed `SignalWriter` / `logs_output_path` docs with the current `ingestion_queue_table_mapping` shape, watermark spec, queue-tagged metrics (10 writer meters), new `dazzleduck/dazzleduck-otel-collector` image name
- **ducklake-compactor / scrapper / runtime docker** — health endpoint + table-backed config overrides; correct image names; vestigial `server-url` removed; JRE 25 base image

### New (7 files)

READMEs for `flight`, `common`, `login`, `client`, `client-grpc`, `search`, and `runtime`. Client constructor examples were verified against the actual signatures; the search README states plainly that the query side is unimplemented; the login README carries a security note about unfiltered client-supplied claims.

All files follow the repo MDX rules (no raw HTML, no bare angle brackets, fenced code blocks).

### Follow-up commits

- Documented the **view-based ingestion transformation** (`view` + `input_table` mapping keys) in the root, otel-collector, and commons READMEs. The matching end-to-end test lives in its own PR: #392.
- Deduplicated the `health` config block in the otel-collector README (canonical copy in its Health Check section).

## Test plan

- Docs-only change; no code touched
- Documentation facts cross-checked against source during the audit (constructor signatures, config keys in `reference.conf`, endpoint routing, header constants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
