### PR TITLE
feat(otel-collector): cluster scoping via the x-dd-cluster JWT claim

### DIFF
--- a/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/Headers.java
+++ b/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/Headers.java
@@ -64,6 +64,10 @@ public class Headers {
     // JWT claim carrying the target ingestion queue ID; same wire value as HEADER_INGESTION_QUEUE.
     public static final String CLAIM_INGESTION_QUEUE = "x-dd-ingestion-queue";
 
+    // JWT claim binding a token to one cluster (audience-style check). A collector configured
+    // with a cluster name rejects tokens whose claim is absent or different.
+    public static final String CLAIM_CLUSTER = "x-dd-cluster";
+
     public static final Set<String> SUPPORTED_HEADERS = Set.of(HEADER_FETCH_SIZE, HEADER_DATABASE, HEADER_SCHEMA, HEADER_SPLIT_SIZE,
             HEADER_DATA_PARTITION, HEADER_DATA_FORMAT, HEADER_PRODUCER_ID, HEADER_PRODUCER_BATCH_ID, HEADER_SORT_ORDER,
             HEADER_APP_DATA_TRANSFORMATION, HEADER_PATH, HEADER_TABLE, HEADER_FUNCTION, HEADER_FILTER, HEADER_ACCESS,

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -105,6 +105,27 @@ grpcurl -plaintext \
 
 **Login delegation:** Set `login_url` to forward Basic auth credentials to an external HTTP service (same pattern as the DazzleDuck Flight SQL server).
 
+### Cluster Scoping
+
+Optionally bind tokens to one cluster (an audience-style check). Configure the cluster this
+collector serves:
+
+```hocon
+otel_collector {
+    cluster = "prod-east"
+}
+```
+
+| Collector `cluster` config | JWT `x-dd-cluster` claim | Result |
+|---|---|---|
+| set | matching | allowed (queue check still applies) |
+| set | different or absent | rejected — `PERMISSION_DENIED` |
+| unset (default) | anything | check skipped — behavior unchanged |
+
+This stops a token minted for one cluster being replayed against another cluster's collector
+when the deployments share a `secret_key` or login service. Roll out by first adding the
+`x-dd-cluster` claim to issued tokens everywhere, then enabling `cluster` on each collector.
+
 ## Health Check
 
 The collector runs a small embedded HTTP server (plain JDK `HttpServer`, no extra dependency)

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorServer.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelCollectorServer.java
@@ -1,5 +1,6 @@
 package io.dazzleduck.sql.otel.collector;
 
+import io.dazzleduck.sql.common.Headers;
 import io.dazzleduck.sql.commons.auth.Validator;
 import io.dazzleduck.sql.commons.ingestion.IngestionHandler;
 import io.dazzleduck.sql.otel.collector.auth.JwtServerInterceptor;
@@ -101,7 +102,13 @@ public class OtelCollectorServer implements Closeable {
                     .addService(traceService)
                     .addService(metricsService);
             builder.intercept(new JwtServerInterceptor(secretKey, userHashMap,
-                    props.getJwtExpiration(), props.getLoginUrl(), props.isVerifySignature()));
+                    props.getJwtExpiration(), props.getLoginUrl(), props.isVerifySignature(),
+                    props.getCluster()));
+
+            if (props.getCluster() != null) {
+                log.info("Cluster scoping enabled — tokens must carry {} = '{}'",
+                        Headers.CLAIM_CLUSTER, props.getCluster());
+            }
 
             if (props.getLoginUrl() != null) {
                 log.info("JWT authentication enabled with login delegation to {}", props.getLoginUrl());

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/auth/JwtServerInterceptor.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/auth/JwtServerInterceptor.java
@@ -44,9 +44,12 @@ public class JwtServerInterceptor implements ServerInterceptor {
     private final Map<String, byte[]> userHashMap;
     private final Duration jwtExpiration;
     private final String loginUrl;
+    /** Cluster this collector serves; null disables the {@value Headers#CLAIM_CLUSTER} claim check. */
+    private final String expectedCluster;
 
     public JwtServerInterceptor(SecretKey secretKey, Map<String, byte[]> userHashMap,
-                                Duration jwtExpiration, String loginUrl, boolean verifySignature) {
+                                Duration jwtExpiration, String loginUrl, boolean verifySignature,
+                                String expectedCluster) {
         this.secretKey = secretKey;
         this.verifySignature = verifySignature;
         this.jwtParser = verifySignature
@@ -55,6 +58,7 @@ public class JwtServerInterceptor implements ServerInterceptor {
         this.userHashMap = userHashMap;
         this.jwtExpiration = jwtExpiration;
         this.loginUrl = loginUrl;
+        this.expectedCluster = expectedCluster;
         if (!verifySignature) {
             log.warn("JWT signature verification is disabled — tokens are not cryptographically validated");
         }
@@ -68,8 +72,7 @@ public class JwtServerInterceptor implements ServerInterceptor {
 
         String authHeader = headers.get(AUTHORIZATION_KEY);
         if (authHeader == null) {
-            call.close(Status.UNAUTHENTICATED.withDescription("Missing Authorization header"), new Metadata());
-            return new ServerCall.Listener<>() {};
+            return closeCall(call, Status.UNAUTHENTICATED.withDescription("Missing Authorization header"));
         }
 
         if (authHeader.startsWith(BASIC_PREFIX)) {
@@ -77,8 +80,7 @@ public class JwtServerInterceptor implements ServerInterceptor {
         } else if (authHeader.startsWith(BEARER_PREFIX)) {
             return handleBearer(authHeader.substring(BEARER_PREFIX.length()), call, headers, next);
         } else {
-            call.close(Status.UNAUTHENTICATED.withDescription("Unsupported Authorization scheme"), new Metadata());
-            return new ServerCall.Listener<>() {};
+            return closeCall(call, Status.UNAUTHENTICATED.withDescription("Unsupported Authorization scheme"));
         }
     }
 
@@ -88,8 +90,7 @@ public class JwtServerInterceptor implements ServerInterceptor {
             String decoded = new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
             int colonPos = decoded.indexOf(':');
             if (colonPos == -1) {
-                call.close(Status.UNAUTHENTICATED.withDescription("Invalid Basic auth format"), new Metadata());
-                return new ServerCall.Listener<>() {};
+                return closeCall(call, Status.UNAUTHENTICATED.withDescription("Invalid Basic auth format"));
             }
             String username = decoded.substring(0, colonPos);
             String password = decoded.substring(colonPos + 1);
@@ -106,18 +107,21 @@ public class JwtServerInterceptor implements ServerInterceptor {
                     super.sendHeaders(responseHeaders);
                 }
             };
-            // Extract queue claim from the newly issued token and propagate to context
-            // so services can route to the correct ingestion queue on this same call.
+            // Extract the claims from the newly issued token and run the same authorization
+            // and queue-context propagation as the Bearer path. A token we cannot parse is
+            // terminal — proceeding would bypass every claim-based check.
             String bearerValue = token.startsWith(BEARER_PREFIX) ? token.substring(BEARER_PREFIX.length()) : token;
+            io.jsonwebtoken.Claims claims;
             try {
-                var claims = JwtClaimsExtractor.parseJwtClaims(bearerValue, jwtParser, verifySignature);
-                return startCallWithQueueContext(claims, wrappedCall, headers, next);
-            } catch (Exception ignored) {}
-            return next.startCall(wrappedCall, headers);
+                claims = JwtClaimsExtractor.parseJwtClaims(bearerValue, jwtParser, verifySignature);
+            } catch (Exception e) {
+                log.warn("Issued token could not be parsed: {}", e.getMessage());
+                return closeCall(call, Status.UNAUTHENTICATED.withDescription("Authentication failed"));
+            }
+            return startAuthorizedCall(claims, wrappedCall, headers, next);
         } catch (Exception e) {
             log.debug("Basic auth failed: {}", e.getMessage());
-            call.close(Status.UNAUTHENTICATED.withDescription("Authentication failed"), new Metadata());
-            return new ServerCall.Listener<>() {};
+            return closeCall(call, Status.UNAUTHENTICATED.withDescription("Authentication failed"));
         }
     }
 
@@ -151,25 +155,38 @@ public class JwtServerInterceptor implements ServerInterceptor {
             String token, ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
         try {
             var claims = JwtClaimsExtractor.parseJwtClaims(token, jwtParser, verifySignature);
-            return startCallWithQueueContext(claims, call, headers, next);
+            return startAuthorizedCall(claims, call, headers, next);
         } catch (Exception e) {
             log.debug("JWT validation failed: {}", e.getMessage());
-            call.close(Status.UNAUTHENTICATED.withDescription("Invalid or expired JWT token"), new Metadata());
-            return new ServerCall.Listener<>() {};
+            return closeCall(call, Status.UNAUTHENTICATED.withDescription("Invalid or expired JWT token"));
         }
     }
 
-    private <ReqT, RespT> ServerCall.Listener<ReqT> startCallWithQueueContext(
+    /** Applies claim-based authorization, then starts the call with the queue context set. */
+    private <ReqT, RespT> ServerCall.Listener<ReqT> startAuthorizedCall(
             io.jsonwebtoken.Claims claims,
             ServerCall<ReqT, RespT> call,
             Metadata headers,
             ServerCallHandler<ReqT, RespT> next) {
+        if (expectedCluster != null) {
+            String cluster = claims.get(Headers.CLAIM_CLUSTER, String.class);
+            if (!expectedCluster.equals(cluster)) {
+                log.debug("Cluster claim rejected: expected '{}', token had '{}'", expectedCluster, cluster);
+                return closeCall(call, Status.PERMISSION_DENIED.withDescription(
+                        "Token " + Headers.CLAIM_CLUSTER + " claim is missing or does not match this collector"));
+            }
+        }
         String queueId = claims.get(Headers.CLAIM_INGESTION_QUEUE, String.class);
         if (queueId != null) {
             Context ctx = Context.current().withValue(QUEUE_CONTEXT_KEY, queueId);
             return Contexts.interceptCall(ctx, call, headers, next);
         }
         return next.startCall(call, headers);
+    }
+
+    private static <ReqT, RespT> ServerCall.Listener<ReqT> closeCall(ServerCall<ReqT, RespT> call, Status status) {
+        call.close(status, new Metadata());
+        return new ServerCall.Listener<>() {};
     }
 
     private String generateToken(String subject) {

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/config/CollectorConfig.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/config/CollectorConfig.java
@@ -186,6 +186,14 @@ public class CollectorConfig {
         return getString("login_url", null);
     }
 
+    /**
+     * Cluster this collector serves. When set, every call must carry a matching
+     * {@code x-dd-cluster} JWT claim; when unset, the claim is ignored.
+     */
+    public String getCluster() {
+        return getString("cluster", null);
+    }
+
     public Map<String, String> getUsers() {
         String fullPath = CONFIG_PREFIX + ".users";
         var users = new HashMap<String, String>();
@@ -233,6 +241,7 @@ public class CollectorConfig {
         props.setAuthentication(getAuthentication());
         props.setSecretKey(getSecretKey());
         props.setLoginUrl(getLoginUrl());
+        props.setCluster(getCluster());
         props.setUsers(getUsers());
         props.setJwtExpiration(getJwtExpiration());
         props.setServiceName(getServiceName());

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/config/CollectorProperties.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/config/CollectorProperties.java
@@ -31,6 +31,8 @@ public class CollectorProperties {
     private String authentication = "jwt";
     private String secretKey = null;
     private String loginUrl = null;
+    // Cluster this collector serves; null disables the x-dd-cluster claim check.
+    private String cluster = null;
     private Map<String, String> users = new HashMap<>();
     private Duration jwtExpiration = Duration.ofHours(1);
     private MeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -106,6 +108,14 @@ public class CollectorProperties {
 
     public void setLoginUrl(String loginUrl) {
         this.loginUrl = loginUrl;
+    }
+
+    public String getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(String cluster) {
+        this.cluster = cluster;
     }
 
     public Map<String, String> getUsers() {

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -129,6 +129,13 @@ otel_collector {
     # The claim value must match one of the ingestion_queue values in ingestion_queue_table_mapping.
     # There is no default fallback — requests without the claim are rejected with INVALID_ARGUMENT.
 
+    # Optional cluster scoping (audience-style check). When set, every call must carry a
+    # matching x-dd-cluster JWT claim; a missing or different claim is rejected with
+    # PERMISSION_DENIED. This stops a token minted for one cluster being replayed against
+    # another cluster's collector when they share a secret_key or login service.
+    # When unset (the default), the claim is ignored and behavior is unchanged.
+    # cluster = "prod-east"
+
     # Base64-encoded HMAC secret key. Required when authentication = "jwt".
     # Change this in production!
     secret_key = "Y2hhbmdlLW1lLWluLXByb2R1Y3Rpb24tdGhpcy1rZXktbXVzdC1iZS1hdC1sZWFzdC02NC1ieXRlcy1sb25nISE="

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorClusterClaimTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorClusterClaimTest.java
@@ -1,0 +1,173 @@
+package io.dazzleduck.sql.otel.collector;
+
+import io.dazzleduck.sql.common.Headers;
+import io.dazzleduck.sql.otel.collector.config.CollectorProperties;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.SECRET_KEY_BASE64;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.bearerMetadata;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.findFreePort;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.noopHandler;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.sampleLogRequest;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.smallBucketConfig;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.tokenWithQueueClaim;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorLoginDelegationTest.basicAuthMetadata;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for cluster scoping via the {@value Headers#CLAIM_CLUSTER} JWT claim.
+ * <p>
+ * When {@code otel_collector.cluster} is configured, every call must carry a matching
+ * claim (audience-style check); a missing or different claim is rejected with
+ * {@code PERMISSION_DENIED}. When the config is unset the claim is ignored entirely,
+ * so existing deployments and gradual rollouts are unaffected.
+ */
+public class OtelCollectorClusterClaimTest {
+
+    private static final String CLUSTER = "prod-east";
+    private static final String QUEUE = "logs";
+
+    @BeforeAll
+    static void loadExtensions() throws Exception {
+        io.dazzleduck.sql.commons.ConnectionPool.executeBatch(new String[]{
+                "INSTALL arrow FROM community", "LOAD arrow"
+        });
+    }
+
+    /** Shared server/channel/stub lifecycle; subclasses choose the cluster config. */
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    abstract static class ServerFixture {
+
+        OtelCollectorServer server;
+        ManagedChannel channel;
+        LogsServiceGrpc.LogsServiceBlockingStub stub;
+
+        /** Value for {@code otel_collector.cluster}; null = enforcement off. */
+        abstract String cluster();
+
+        abstract String tempDirPrefix();
+
+        @BeforeAll
+        void setup() throws Exception {
+            var outputPath = Files.createTempDirectory(tempDirPrefix()).resolve("output");
+            Files.createDirectories(outputPath); // operator provisions the output dir
+
+            CollectorProperties props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO); // no LB-drain wait in tests
+            props.setGrpcPort(findFreePort());
+            props.setIngestionHandler(noopHandler(outputPath.toString(), QUEUE));
+            props.setIngestionConfig(smallBucketConfig());
+            props.setAuthentication("jwt");
+            props.setSecretKey(SECRET_KEY_BASE64);
+            props.setUsers(Map.of("admin", "admin")); // for the Basic-auth path
+            props.setCluster(cluster());
+
+            server = new OtelCollectorServer(props);
+            server.start();
+
+            channel = ManagedChannelBuilder.forAddress("localhost", props.getGrpcPort()).usePlaintext().build();
+            stub = LogsServiceGrpc.newBlockingStub(channel);
+        }
+
+        @AfterAll
+        void cleanup() throws Exception {
+            if (channel != null) { channel.shutdown(); channel.awaitTermination(5, TimeUnit.SECONDS); }
+            if (server != null) server.close();
+        }
+    }
+
+    @Nested
+    class WithClusterConfigured extends ServerFixture {
+
+        @Override String cluster() { return CLUSTER; }
+        @Override String tempDirPrefix() { return "otel-cluster-enforced"; }
+
+        @Test
+        void matchingClusterClaim_succeeds() {
+            var s = stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(
+                    bearerMetadata(tokenWithQueueClaim(QUEUE, CLUSTER))));
+            assertDoesNotThrow(() -> s.export(sampleLogRequest()));
+        }
+
+        @Test
+        void wrongClusterClaim_returnsPermissionDenied() {
+            var s = stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(
+                    bearerMetadata(tokenWithQueueClaim(QUEUE, "prod-west"))));
+            var ex = assertThrows(StatusRuntimeException.class, () -> s.export(sampleLogRequest()));
+            assertEquals(Status.Code.PERMISSION_DENIED, ex.getStatus().getCode());
+        }
+
+        @Test
+        void missingClusterClaim_returnsPermissionDenied() {
+            var s = stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(
+                    bearerMetadata(tokenWithQueueClaim(QUEUE))));
+            var ex = assertThrows(StatusRuntimeException.class, () -> s.export(sampleLogRequest()));
+            assertEquals(Status.Code.PERMISSION_DENIED, ex.getStatus().getCode());
+            assertTrue(ex.getStatus().getDescription().contains(Headers.CLAIM_CLUSTER),
+                    "Rejection must name the claim. Actual: " + ex.getStatus().getDescription());
+        }
+
+        @Test
+        void clusterCheckRunsBeforeQueueCheck() {
+            // Wrong cluster AND unknown queue: the cluster rejection (PERMISSION_DENIED,
+            // naming the claim) must win over the queue check (INVALID_ARGUMENT).
+            var s = stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(
+                    bearerMetadata(tokenWithQueueClaim("no-such-queue", "prod-west"))));
+            var ex = assertThrows(StatusRuntimeException.class, () -> s.export(sampleLogRequest()));
+            assertEquals(Status.Code.PERMISSION_DENIED, ex.getStatus().getCode());
+            assertTrue(ex.getStatus().getDescription().contains(Headers.CLAIM_CLUSTER),
+                    "Cluster check must run before queue validation. Actual: " + ex.getStatus().getDescription());
+        }
+
+        @Test
+        void basicAuth_localTokenHasNoClusterClaim_returnsPermissionDenied() {
+            // Locally minted tokens carry no claims at all, so under enforcement a
+            // Basic-authenticated call is rejected by the cluster check like any other
+            // claim-less token.
+            var s = stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(
+                    basicAuthMetadata("admin", "admin")));
+            var ex = assertThrows(StatusRuntimeException.class, () -> s.export(sampleLogRequest()));
+            assertEquals(Status.Code.PERMISSION_DENIED, ex.getStatus().getCode());
+        }
+    }
+
+    @Nested
+    class WithoutClusterConfigured extends ServerFixture {
+
+        @Override String cluster() { return null; }
+        @Override String tempDirPrefix() { return "otel-cluster-off"; }
+
+        @Test
+        void tokenWithClusterClaim_isIgnoredAndSucceeds() {
+            // Gradual rollout: tokens may carry the claim before any collector enforces it.
+            var s = stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(
+                    bearerMetadata(tokenWithQueueClaim(QUEUE, "some-cluster"))));
+            assertDoesNotThrow(() -> s.export(sampleLogRequest()));
+        }
+
+        @Test
+        void tokenWithoutClusterClaim_succeeds() {
+            var s = stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(
+                    bearerMetadata(tokenWithQueueClaim(QUEUE))));
+            assertDoesNotThrow(() -> s.export(sampleLogRequest()));
+        }
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorCustomQueueTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorCustomQueueTest.java
@@ -107,15 +107,23 @@ public class OtelCollectorCustomQueueTest {
 
     /** Generates a signed JWT embedding the given queue ID as a claim. */
     static String tokenWithQueueClaim(String queueId) {
+        return tokenWithQueueClaim(queueId, null);
+    }
+
+    /** Generates a signed JWT with the queue claim and, when non-null, a cluster claim. */
+    static String tokenWithQueueClaim(String queueId, String cluster) {
         SecretKey key = Validator.fromBase64String(SECRET_KEY_BASE64);
         Calendar exp = Calendar.getInstance();
         exp.add(Calendar.HOUR, 1);
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .subject("admin")
                 .claim(Headers.CLAIM_INGESTION_QUEUE, queueId)
                 .expiration(exp.getTime())
-                .signWith(key)
-                .compact();
+                .signWith(key);
+        if (cluster != null) {
+            builder.claim(Headers.CLAIM_CLUSTER, cluster);
+        }
+        return builder.compact();
     }
 
     static Metadata bearerMetadata(String token) {


### PR DESCRIPTION
## Summary

Adds **cluster scoping** to the OTel collector: an audience-style check binding JWTs to one cluster, mirroring how the `x-dd-ingestion-queue` claim is checked today.

When `otel_collector.cluster` is configured, every gRPC call must carry a matching `x-dd-cluster` JWT claim; a missing or different claim is rejected with `PERMISSION_DENIED` (distinct from the queue check's `INVALID_ARGUMENT`, since this is an authorization failure on a well-formed request). When the config is unset — the default — the claim is ignored entirely, so existing deployments and gradual rollouts are unaffected.

**Why:** in multi-cluster deployments that share a `secret_key` or a central login service, a token minted for cluster A's collector is otherwise perfectly valid on cluster B's collector. Nothing in the token binds it to a deployment. This closes that replay gap.

| Collector `cluster` config | JWT `x-dd-cluster` claim | Result |
|---|---|---|
| set | matching | allowed (queue check still applies) |
| set | different or absent | rejected — `PERMISSION_DENIED` |
| unset (default) | anything | check skipped — behavior unchanged |

## Changes

- `Headers.CLAIM_CLUSTER` constant (`x-dd-cluster`) in `dazzleduck-sql-common`, next to the queue claim
- `cluster` config key on `CollectorConfig` / `CollectorProperties`, documented in `reference.conf` and the module README (with the rollout matrix)
- Enforcement lives in exactly one place — `JwtServerInterceptor.startAuthorizedCall` — covering both the Bearer path and the Basic path (which mints/receives a token and runs the same authorization on it). A locally issued token whose claims cannot be parsed is now terminal (`UNAUTHENTICATED`) instead of silently proceeding without claims, removing a pre-existing swallowed-exception fall-through.
- A `/simplify` review pass was applied before committing: the `closeCall` helper is now used at all seven rejection sites, the rejection message is unified and names the claim, the startup log uses the `Headers` constant, and the tests reuse the sibling suites' token builder (`tokenWithQueueClaim` gained a cluster overload) and `basicAuthMetadata` helper, with a shared `ServerFixture` base for the two nested classes.

## Design notes

- Claim name follows the project's `x-dd-` convention; single-value config now, shaped so an allowlist (`clusters = [...]`) can drop in later for shared multi-cluster collectors.
- Enforcement is deliberately otel-collector-only for now; the same replay gap exists on HTTP `/v1/ingest` and Flight bulk ingest and can adopt the same claim in a follow-up.
- Locally minted (Basic auth) tokens carry no claims, so under enforcement they are rejected — consistent with the strict contract. Stamping the collector's own cluster into locally issued tokens is a possible follow-up if Basic auth should stay usable under enforcement.

## Test plan

`OtelCollectorClusterClaimTest` covers the full matrix over a real gRPC channel: matching / wrong / missing claim, config-unset ignore (both with and without the claim), cluster check ordering before the queue check (asserted via the claim-naming description), and the Basic-auth path.

Verified locally on JDK 21: all 7 new tests pass; the module suite is green except the pre-existing Windows-only `OtelCollectorConfigDuckLakeTest` failure (raw Windows temp path interpolated into HOCON), which exists on `main` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
