### PR TITLE
feat(otel-collector): per-queue claims column from JWT claims (extract_claims)

### DIFF
--- a/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ConfigConstants.java
+++ b/dazzleduck-sql-common/src/main/java/io/dazzleduck/sql/common/ConfigConstants.java
@@ -43,6 +43,7 @@ public class ConfigConstants {
     public static final String TRANSFORMATION_KEY = "transformation";
     public static final String VIEW_KEY           = "view";
     public static final String INPUT_TABLE_KEY    = "input_table";
+    public static final String EXTRACT_CLAIMS_KEY = "extract_claims";
 
     // Cursor / open-query protection keys
     public static final String CURSOR_TTL_MS_KEY              = "cursor_ttl_ms";

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
@@ -356,7 +356,7 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
                     existing.partitionColumns(), existing.partitionProjections(),
                     existing.schemaChangeId(), clock.instant());
         }
-        return buildState(mapping, currentSchemaChangeId, clock.instant());
+        return buildState(mapping, currentSchemaChangeId, clock.instant(), existing == null);
     }
 
     /**
@@ -364,10 +364,13 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
      * Accepts a pre-fetched {@code schemaChangeId} to avoid a redundant round-trip when
      * called from {@link #getOrRefreshState}.
      */
-    private static QueueState buildState(QueueIdToTableMapping mapping, long schemaChangeId, Instant refreshedAt) {
+    private static QueueState buildState(QueueIdToTableMapping mapping, long schemaChangeId, Instant refreshedAt,
+                                         boolean firstBuild) {
         String path           = fetchPath(mapping.catalog(), mapping.schema(), mapping.table());
         String transformation = resolveTransformation(mapping);
-        warnIfClaimsColumnMissing(mapping);
+        if (firstBuild) {
+            warnIfClaimsColumnMissing(mapping, transformation);
+        }
         List<ResolvedPartition> partitions = fetchPartitions(mapping.catalog(), mapping.schema(), mapping.table());
         String[] tokens      = partitions.stream().map(ResolvedPartition::token).toArray(String[]::new);
         String[] projections = partitions.stream().map(ResolvedPartition::projection)
@@ -378,7 +381,7 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
     /** Convenience overload that fetches schema change ID itself (used at construction time). */
     private static QueueState buildState(QueueIdToTableMapping mapping, Instant refreshedAt) {
         long schemaChangeId = fetchSchemaChangeId(mapping.catalog(), mapping.schema(), mapping.table());
-        return buildState(mapping, schemaChangeId, refreshedAt);
+        return buildState(mapping, schemaChangeId, refreshedAt, true);
     }
 
     private static String resolveTransformation(QueueIdToTableMapping mapping) {
@@ -428,11 +431,14 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
     /**
      * DuckLake registration tolerates extra file columns, so with {@code extract_claims} on
      * a target table missing the claims column silently drops the data — warn loudly instead.
+     * A transformation controls the output shape (it may consume claims without persisting
+     * them), so only raw pass-through mappings are checked, and only on the queue's first
+     * state build.
      */
-    private static void warnIfClaimsColumnMissing(QueueIdToTableMapping mapping) {
-        if (!mapping.extractClaims()) return;
+    private static void warnIfClaimsColumnMissing(QueueIdToTableMapping mapping, String transformation) {
+        if (!mapping.extractClaims() || transformation != null) return;
         try (var conn = ConnectionPool.getConnection()) {
-            if (!DuckLakeTableManager.currentColumnNames(conn, mapping).contains(CLAIMS_COLUMN)) {
+            if (!DuckLakeTableManager.hasColumn(conn, mapping, CLAIMS_COLUMN)) {
                 logger.warn("Queue '{}' has extract_claims enabled but table {}.{}.{} has no '{}' column — "
                                 + "claims will be silently dropped at registration. "
                                 + "Run: ALTER TABLE {}.{}.{} ADD COLUMN {} MAP(VARCHAR, VARCHAR)",

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionHandler.java
@@ -180,15 +180,25 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
 
     @Override
     public WatermarkSpec getWatermarkSpec(String queueId) {
-        QueueIdToTableMapping mapping = queueIdsToTableMappings.get(queueId);
-        if (mapping == null) mapping = queueIdsToTableMappings.get(extractSuffix(queueId));
+        QueueIdToTableMapping mapping = mappingFor(queueId);
         return mapping == null ? null : WatermarkSpec.fromParameters(queueId, mapping.additionalParameters());
     }
 
     @Override
+    public boolean extractClaims(String queueId) {
+        QueueIdToTableMapping mapping = mappingFor(queueId);
+        return mapping != null && mapping.extractClaims();
+    }
+
+    /** Mapping for {@code queueId}, resolved exact-first with the path-suffix fallback. */
+    private QueueIdToTableMapping mappingFor(String queueId) {
+        String key = resolveStateKey(queueId);
+        return key == null ? null : queueIdsToTableMappings.get(key);
+    }
+
+    @Override
     public PostIngestionTask createPostIngestionTask(IngestionResult result) {
-        QueueIdToTableMapping mapping = queueIdsToTableMappings.get(result.queueName());
-        if (mapping == null) mapping = queueIdsToTableMappings.get(extractSuffix(result.queueName()));
+        QueueIdToTableMapping mapping = mappingFor(result.queueName());
         if (mapping == null) {
             // No DuckLake mapping for this queue — write-only mode, no catalog registration.
             logger.atDebug().log("No DuckLake mapping for queue '{}', skipping catalog registration", result.queueName());
@@ -335,8 +345,7 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
      * partition columns.
      */
     private QueueState computeRefreshedState(String key, QueueState existing) {
-        QueueIdToTableMapping mapping = queueIdsToTableMappings.get(key);
-        if (mapping == null) mapping = queueIdsToTableMappings.get(extractSuffix(key));
+        QueueIdToTableMapping mapping = mappingFor(key);
         if (mapping == null) return existing; // unknown queue — leave unchanged
 
         long currentSchemaChangeId = fetchSchemaChangeId(mapping.catalog(), mapping.schema(), mapping.table());
@@ -358,6 +367,7 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
     private static QueueState buildState(QueueIdToTableMapping mapping, long schemaChangeId, Instant refreshedAt) {
         String path           = fetchPath(mapping.catalog(), mapping.schema(), mapping.table());
         String transformation = resolveTransformation(mapping);
+        warnIfClaimsColumnMissing(mapping);
         List<ResolvedPartition> partitions = fetchPartitions(mapping.catalog(), mapping.schema(), mapping.table());
         String[] tokens      = partitions.stream().map(ResolvedPartition::token).toArray(String[]::new);
         String[] projections = partitions.stream().map(ResolvedPartition::projection)
@@ -412,6 +422,26 @@ public class DuckLakeIngestionHandler implements IngestionHandler {
         } catch (SQLException e) {
             logger.atDebug().setCause(e).log("Failed to get schema_version for catalog {}", catalogName);
             return 0L;
+        }
+    }
+
+    /**
+     * DuckLake registration tolerates extra file columns, so with {@code extract_claims} on
+     * a target table missing the claims column silently drops the data — warn loudly instead.
+     */
+    private static void warnIfClaimsColumnMissing(QueueIdToTableMapping mapping) {
+        if (!mapping.extractClaims()) return;
+        try (var conn = ConnectionPool.getConnection()) {
+            if (!DuckLakeTableManager.currentColumnNames(conn, mapping).contains(CLAIMS_COLUMN)) {
+                logger.warn("Queue '{}' has extract_claims enabled but table {}.{}.{} has no '{}' column — "
+                                + "claims will be silently dropped at registration. "
+                                + "Run: ALTER TABLE {}.{}.{} ADD COLUMN {} MAP(VARCHAR, VARCHAR)",
+                        mapping.ingestionQueue(), mapping.catalog(), mapping.schema(), mapping.table(),
+                        CLAIMS_COLUMN, mapping.catalog(), mapping.schema(), mapping.table(), CLAIMS_COLUMN);
+            }
+        } catch (SQLException e) {
+            logger.atDebug().setCause(e).log("Could not verify '{}' column on {}.{}.{}",
+                    CLAIMS_COLUMN, mapping.catalog(), mapping.schema(), mapping.table());
         }
     }
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionTaskFactoryProvider.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeIngestionTaskFactoryProvider.java
@@ -42,9 +42,12 @@ public class DuckLakeIngestionTaskFactoryProvider extends AbstractIngestionTaskF
             }
             String view       = c.hasPath(ConfigConstants.VIEW_KEY)        ? c.getString(ConfigConstants.VIEW_KEY)        : null;
             String inputTable = c.hasPath(ConfigConstants.INPUT_TABLE_KEY) ? c.getString(ConfigConstants.INPUT_TABLE_KEY) : null;
+            boolean extractClaims = c.hasPath(ConfigConstants.EXTRACT_CLAIMS_KEY)
+                    && c.getBoolean(ConfigConstants.EXTRACT_CLAIMS_KEY);
             QueueIdToTableMapping mapping = new QueueIdToTableMapping(
                     ingestionQueue, c.getString("catalog"), c.getString("schema"), c.getString("table"),
-                    additionalParameters, transformation, view, inputTable);
+                    additionalParameters, transformation, view, inputTable)
+                    .withExtractClaims(extractClaims);
             mappings.put(mapping.ingestionQueue(), mapping);
         });
         return mappings;

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeTableManager.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeTableManager.java
@@ -118,7 +118,7 @@ public final class DuckLakeTableManager {
         return mapping.transformation();
     }
 
-    private static List<String> currentColumnNames(DuckDBConnection conn, QueueIdToTableMapping mapping)
+    static List<String> currentColumnNames(DuckDBConnection conn, QueueIdToTableMapping mapping)
             throws SQLException {
         List<String> names = new ArrayList<>();
         try (PreparedStatement ps = conn.prepareStatement(

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeTableManager.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakeTableManager.java
@@ -118,7 +118,14 @@ public final class DuckLakeTableManager {
         return mapping.transformation();
     }
 
-    static List<String> currentColumnNames(DuckDBConnection conn, QueueIdToTableMapping mapping)
+    /** Case-insensitive column-presence check, sharing this class's identifier-folding rule. */
+    static boolean hasColumn(DuckDBConnection conn, QueueIdToTableMapping mapping, String column)
+            throws SQLException {
+        String target = lower(column);
+        return currentColumnNames(conn, mapping).stream().anyMatch(name -> lower(name).equals(target));
+    }
+
+    private static List<String> currentColumnNames(DuckDBConnection conn, QueueIdToTableMapping mapping)
             throws SQLException {
         List<String> names = new ArrayList<>();
         try (PreparedStatement ps = conn.prepareStatement(

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DynamicDuckLakeIngestionTaskFactoryProvider.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DynamicDuckLakeIngestionTaskFactoryProvider.java
@@ -1,4 +1,6 @@
 package io.dazzleduck.sql.commons.ingestion;
+
+import io.dazzleduck.sql.common.ConfigConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +46,19 @@ public class DynamicDuckLakeIngestionTaskFactoryProvider extends AbstractIngesti
             }
         } catch (SQLException e) {
             throw new RuntimeException("Failed to load ingestion queue mappings from: " + dbPath, e);
+        }
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        if (config == null || !config.hasPath(ConfigConstants.INGESTION_QUEUE_TABLE_MAPPING_KEY)) return;
+        if (config.getConfigList(ConfigConstants.INGESTION_QUEUE_TABLE_MAPPING_KEY).stream()
+                .anyMatch(c -> c.hasPath(ConfigConstants.EXTRACT_CLAIMS_KEY)
+                        && c.getBoolean(ConfigConstants.EXTRACT_CLAIMS_KEY))) {
+            logger.warn("ingestion_queue_table_mapping is ignored by the dynamic provider — queue "
+                    + "configuration comes from the SQLite registry only; extract_claims will not take "
+                    + "effect and no claims column will be written");
         }
     }
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionHandler.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/IngestionHandler.java
@@ -2,6 +2,9 @@ package io.dazzleduck.sql.commons.ingestion;
 
 public interface IngestionHandler {
 
+    /** Name of the per-row JWT-claims MAP column stamped when {@link #extractClaims} is on. */
+    String CLAIMS_COLUMN = "claims";
+
     PostIngestionTask createPostIngestionTask(IngestionResult ingestionResult);
 
     String getTargetPath(String queueId);
@@ -25,6 +28,9 @@ public interface IngestionHandler {
     default WatermarkSpec getWatermarkSpec(String queueId) { return null; }
 
     default boolean supportPartitionByHeader() { return true; }
+
+    /** Whether ingested rows carry a {@value #CLAIMS_COLUMN} MAP column from the caller's JWT. */
+    default boolean extractClaims(String queueId) { return false; }
 
     // -----------------------------------------------------------------------
     // Queue lifecycle

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/QueueIdToTableMapping.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/QueueIdToTableMapping.java
@@ -22,6 +22,8 @@ import java.util.Map;
  *                    {@code "severity_number INTEGER, body VARCHAR"}), nullable; used only by
  *                    {@code manageTables} as the {@code __this} input over which the transformation
  *                    is described to derive the target table's columns
+ * @param extractClaims when true, ingested rows carry a {@code claims} MAP column from the
+ *                      caller's JWT (see {@code IngestionHandler#extractClaims})
  */
 public record QueueIdToTableMapping(
         String ingestionQueue,
@@ -33,7 +35,8 @@ public record QueueIdToTableMapping(
         String transformation,
         String view,
         String inputTable,
-        String inputSchema) {
+        String inputSchema,
+        boolean extractClaims) {
 
     /** Validates invariants on every construction path. */
     public QueueIdToTableMapping {
@@ -56,13 +59,13 @@ public record QueueIdToTableMapping(
     public QueueIdToTableMapping(String ingestionQueue, String catalog, String schema, String table,
                                  Map<String, String> additionalParameters, String transformation,
                                  String view, String inputTable) {
-        this(ingestionQueue, null, catalog, schema, table, additionalParameters, transformation, view, inputTable, null);
+        this(ingestionQueue, null, catalog, schema, table, additionalParameters, transformation, view, inputTable, null, false);
     }
 
     /** Convenience constructor for mappings that use an explicit transformation or none at all. */
     public QueueIdToTableMapping(String ingestionQueue, String catalog, String schema, String table,
                                  Map<String, String> additionalParameters, String transformation) {
-        this(ingestionQueue, null, catalog, schema, table, additionalParameters, transformation, null, null, null);
+        this(ingestionQueue, null, catalog, schema, table, additionalParameters, transformation, null, null, null, false);
     }
 
     public boolean hasViewTransformation() {
@@ -72,6 +75,12 @@ public record QueueIdToTableMapping(
     /** Returns a copy of this mapping with {@code inputSchema} set (registry-sourced field). */
     public QueueIdToTableMapping withInputSchema(String inputSchema) {
         return new QueueIdToTableMapping(ingestionQueue, outputPath, catalog, schema, table,
-                additionalParameters, transformation, view, inputTable, inputSchema);
+                additionalParameters, transformation, view, inputTable, inputSchema, extractClaims);
+    }
+
+    /** Returns a copy of this mapping with {@code extractClaims} set. */
+    public QueueIdToTableMapping withExtractClaims(boolean extractClaims) {
+        return new QueueIdToTableMapping(ingestionQueue, outputPath, catalog, schema, table,
+                additionalParameters, transformation, view, inputTable, inputSchema, extractClaims);
     }
 }

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/ExtractClaimsMappingTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/ExtractClaimsMappingTest.java
@@ -1,0 +1,88 @@
+package io.dazzleduck.sql.commons.ingestion;
+
+import com.typesafe.config.ConfigFactory;
+import io.dazzleduck.sql.commons.ConnectionPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the {@code extract_claims} queue-mapping flag: record defaults, provider
+ * config parsing, and the {@link DuckLakeIngestionHandler} lookup.
+ */
+class ExtractClaimsMappingTest {
+
+    @TempDir
+    Path tempDir;
+
+    private static final String CATALOG = "extract_claims_lake";
+
+    @BeforeAll
+    static void loadExtensions() throws Exception {
+        ConnectionPool.executeBatch(new String[]{"INSTALL ducklake", "LOAD ducklake"});
+    }
+
+    @AfterEach
+    void detach() throws Exception {
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn, "DETACH DATABASE IF EXISTS " + CATALOG);
+        }
+    }
+
+    @Test
+    void mapping_defaultsToFalse_andSurvivesWithInputSchema() {
+        var mapping = new QueueIdToTableMapping("q", "cat", "main", "t", Map.of(), null);
+        assertFalse(mapping.extractClaims(), "extract_claims must default to false");
+
+        var enabled = mapping.withExtractClaims(true);
+        assertTrue(enabled.extractClaims());
+        assertTrue(enabled.withInputSchema("id BIGINT").extractClaims(),
+                "withInputSchema must preserve extract_claims");
+    }
+
+    @Test
+    void provider_parsesExtractClaimsPerMapping() {
+        var config = ConfigFactory.parseString("""
+                ingestion_queue_table_mapping = [
+                    { ingestion_queue = "with_claims",    catalog = "c", schema = "s", table = "t1", extract_claims = true }
+                    { ingestion_queue = "without_claims", catalog = "c", schema = "s", table = "t2" }
+                ]
+                """);
+        var provider = new DuckLakeIngestionTaskFactoryProvider();
+        provider.setConfig(config);
+        Map<String, QueueIdToTableMapping> mappings = provider.loadMappings();
+
+        assertTrue(mappings.get("with_claims").extractClaims());
+        assertFalse(mappings.get("without_claims").extractClaims());
+    }
+
+    @Test
+    void handler_looksUpFlagPerQueue() throws Exception {
+        Path dataPath = tempDir.resolve("data");
+        Files.createDirectories(dataPath);
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.executeBatchInTxn(conn, new String[]{
+                    "ATTACH 'ducklake:%s' AS %s (DATA_PATH '%s')"
+                            .formatted(tempDir.resolve("catalog"), CATALOG, dataPath),
+                    // Deliberately no 'claims' column: runs the missing-column warning path (not asserted).
+                    "CREATE TABLE %s.main.events (id BIGINT)".formatted(CATALOG)
+            });
+        }
+
+        var mapping = new QueueIdToTableMapping("q", CATALOG, "main", "events", Map.of(), null)
+                .withExtractClaims(true);
+        var handler = new DuckLakeIngestionHandler(Map.of("q", mapping));
+
+        assertTrue(handler.extractClaims("q"));
+        assertFalse(handler.extractClaims("unknown-queue"));
+    }
+}

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -136,8 +136,9 @@ ALTER TABLE my_catalog.main.logs SET PARTITIONED BY (org_id);
 Notes:
 
 - DuckLake target tables need the column: `ALTER TABLE ... ADD COLUMN claims MAP(VARCHAR, VARCHAR)`.
-  A missing column is warned about at queue refresh — without it the claims are silently
-  dropped during file registration.
+  For raw pass-through mappings, a missing column is warned about when the queue's state is
+  first built — without it the claims are silently dropped during file registration. Mappings
+  with a transformation/view control their own output shape and are not checked.
 - **Privacy**: enabling the flag persists token claims into the data. Make sure nothing
   sensitive is minted into tokens before turning it on.
 - Changing the flag requires a restart (a bucket must not mix batches with and without the

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -105,6 +105,44 @@ grpcurl -plaintext \
 
 **Login delegation:** Set `login_url` to forward Basic auth credentials to an external HTTP service (same pattern as the DazzleDuck Flight SQL server).
 
+### JWT Claims Column
+
+A queue mapping can opt into recording the caller's verified JWT claims on every ingested row:
+
+```hocon
+otel_collector.ingestion_task_factory_provider.ingestion_queue_table_mapping = [
+    { ingestion_queue = "logs", catalog = "my_catalog", schema = "main", table = "logs",
+      extract_claims = true }
+]
+```
+
+With `extract_claims = true`, each signal schema gains a trailing `claims` column of type
+`MAP(VARCHAR, VARCHAR)` — the same shape as `attributes` and `resource_attributes` — holding
+every claim from the token except the registered ones (`exp`, `iat`, `nbf`, `iss`, `aud`,
+`jti`). `sub` and custom claims are included, values stringified. The value is stamped per
+request at batch-write time, so it stays correct even when the ingestion queue combines
+batches from different tokens into one Parquet write.
+
+This makes per-request data available to transformations. For example, one shared view can
+derive a first-class column from any claim, ready for partitioning:
+
+```sql
+CREATE VIEW my_catalog.main.logs_transform AS
+SELECT *, claims['org_id'] AS org_id FROM my_catalog.main.raw_logs;
+
+ALTER TABLE my_catalog.main.logs SET PARTITIONED BY (org_id);
+```
+
+Notes:
+
+- DuckLake target tables need the column: `ALTER TABLE ... ADD COLUMN claims MAP(VARCHAR, VARCHAR)`.
+  A missing column is warned about at queue refresh — without it the claims are silently
+  dropped during file registration.
+- **Privacy**: enabling the flag persists token claims into the data. Make sure nothing
+  sensitive is minted into tokens before turning it on.
+- Changing the flag requires a restart (a bucket must not mix batches with and without the
+  column). Not available for queues registered via the dynamic SQLite provider.
+
 ## Health Check
 
 The collector runs a small embedded HTTP server (plain JDK `HttpServer`, no extra dependency)
@@ -147,7 +185,7 @@ and its export ack returned rather than the call being cut off mid-RPC.
 
 ## Arrow Schemas
 
-All schemas flatten the OTLP 3-level hierarchy (Resource → Scope → Record). Resource and scope fields are promoted to top-level columns.
+All schemas flatten the OTLP 3-level hierarchy (Resource → Scope → Record). Resource and scope fields are promoted to top-level columns. Queues with `extract_claims = true` additionally get a trailing `claims` map column (see [JWT Claims Column](#jwt-claims-column)); the tables below show the base schemas.
 
 ### Logs
 

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/ClaimsColumnWriter.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/ClaimsColumnWriter.java
@@ -1,0 +1,41 @@
+package io.dazzleduck.sql.otel.collector;
+
+import io.dazzleduck.sql.commons.ingestion.IngestionHandler;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.impl.UnionMapWriter;
+import org.apache.arrow.vector.util.Text;
+
+import java.util.Map;
+
+/**
+ * Fills the trailing claims map column with the caller's verified JWT claims — the same map
+ * on every row, since one export request has exactly one token. Runs after the per-signal
+ * batch writer, which only touches the base columns.
+ */
+final class ClaimsColumnWriter {
+
+    private ClaimsColumnWriter() {}
+
+    static void write(VectorSchemaRoot root, Map<String, String> claims) {
+        int rowCount = root.getRowCount();
+        MapVector claimsVec = (MapVector) root.getVector(IngestionHandler.CLAIMS_COLUMN);
+        UnionMapWriter writer = claimsVec.getWriter();
+
+        // Encode each key/value to UTF-8 once, not once per row.
+        Text[] keys = claims.keySet().stream().map(Text::new).toArray(Text[]::new);
+        Text[] values = claims.values().stream().map(Text::new).toArray(Text[]::new);
+
+        for (int i = 0; i < rowCount; i++) {
+            writer.setPosition(i);
+            writer.startMap();
+            for (int k = 0; k < keys.length; k++) {
+                OtelSchemaFields.writeEntry(writer, keys[k], values[k]);
+            }
+            writer.endMap();
+        }
+        // The batch writer's setRowCount stamped this vector's value count while it was
+        // still empty — refresh it now that the maps are written.
+        claimsVec.setValueCount(rowCount);
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/ClaimsColumnWriter.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/ClaimsColumnWriter.java
@@ -22,9 +22,15 @@ final class ClaimsColumnWriter {
         MapVector claimsVec = (MapVector) root.getVector(IngestionHandler.CLAIMS_COLUMN);
         UnionMapWriter writer = claimsVec.getWriter();
 
-        // Encode each key/value to UTF-8 once, not once per row.
-        Text[] keys = claims.keySet().stream().map(Text::new).toArray(Text[]::new);
-        Text[] values = claims.values().stream().map(Text::new).toArray(Text[]::new);
+        // Single entrySet pass: encodes once per batch and keeps key/value pairing guaranteed.
+        Text[] keys = new Text[claims.size()];
+        Text[] values = new Text[claims.size()];
+        int n = 0;
+        for (Map.Entry<String, String> claim : claims.entrySet()) {
+            keys[n] = new Text(claim.getKey());
+            values[n] = new Text(claim.getValue());
+            n++;
+        }
 
         for (int i = 0; i < rowCount; i++) {
             writer.setPosition(i);

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/LogRecordBatchWriter.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/LogRecordBatchWriter.java
@@ -10,7 +10,6 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.impl.UnionMapWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
@@ -101,15 +100,7 @@ public class LogRecordBatchWriter {
         writer.setPosition(index);
         writer.startMap();
         for (KeyValue kv : kvList) {
-            writer.startEntry();
-            ((BaseWriter.ListWriter) writer.key()).varChar().writeVarChar(kv.getKey());
-            String val = LogRecordConverter.anyValueToString(kv.getValue());
-            if (val != null) {
-                ((BaseWriter.ListWriter) writer.value()).varChar().writeVarChar(val);
-            } else {
-                ((BaseWriter.ListWriter) writer.value()).varChar().writeNull();
-            }
-            writer.endEntry();
+            OtelSchemaFields.writeEntry(writer, kv.getKey(), LogRecordConverter.anyValueToString(kv.getValue()));
         }
         writer.endMap();
     }

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/MetricBatchWriter.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/MetricBatchWriter.java
@@ -251,15 +251,7 @@ public class MetricBatchWriter {
         writer.setPosition(index);
         writer.startMap();
         for (KeyValue kv : kvList) {
-            writer.startEntry();
-            ((BaseWriter.ListWriter) writer.key()).varChar().writeVarChar(kv.getKey());
-            String val = LogRecordConverter.anyValueToString(kv.getValue());
-            if (val != null) {
-                ((BaseWriter.ListWriter) writer.value()).varChar().writeVarChar(val);
-            } else {
-                ((BaseWriter.ListWriter) writer.value()).varChar().writeNull();
-            }
-            writer.endEntry();
+            OtelSchemaFields.writeEntry(writer, kv.getKey(), LogRecordConverter.anyValueToString(kv.getValue()));
         }
         writer.endMap();
     }

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelLogService.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelLogService.java
@@ -59,7 +59,7 @@ public class OtelLogService extends LogsServiceGrpc.LogsServiceImplBase implemen
         var sample = metrics.startSample();
 
         try {
-            Path arrowFile = base.writeArrowFile(entries, OtelLogSchema.SCHEMA, LogRecordBatchWriter::write);
+            Path arrowFile = base.writeArrowFile(queueId, entries, OtelLogSchema.SCHEMA, LogRecordBatchWriter::write);
             base.addBatch(queue, arrowFile).whenComplete(
                     OtelServiceBase.batchCompleteHandler(arrowFile, recordCount, queueId,
                             sample, metrics,

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelMetricsService.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelMetricsService.java
@@ -59,7 +59,7 @@ public class OtelMetricsService extends MetricsServiceGrpc.MetricsServiceImplBas
         var sample = metrics.startSample();
 
         try {
-            Path arrowFile = base.writeArrowFile(entries, OtelMetricSchema.SCHEMA, MetricBatchWriter::write);
+            Path arrowFile = base.writeArrowFile(queueId, entries, OtelMetricSchema.SCHEMA, MetricBatchWriter::write);
             base.addBatch(queue, arrowFile).whenComplete(
                     OtelServiceBase.batchCompleteHandler(arrowFile, metricCount, queueId,
                             sample, metrics,

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelSchemaFields.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelSchemaFields.java
@@ -1,15 +1,56 @@
 package io.dazzleduck.sql.otel.collector;
 
+import io.dazzleduck.sql.commons.ingestion.IngestionHandler;
+import org.apache.arrow.vector.complex.writer.BaseWriter;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.Text;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Shared Arrow field builder helpers used across otel signal schemas.
  */
 class OtelSchemaFields {
+
+    private static final Map<Schema, Schema> WITH_CLAIMS = new ConcurrentHashMap<>();
+
+    /**
+     * Returns {@code base} with the {@link IngestionHandler#CLAIMS_COLUMN} map column appended
+     * LAST, so the base schema's column indices — and therefore the per-signal batch writers —
+     * stay valid on either variant. Memoized per base schema.
+     */
+    static Schema withClaimsColumn(Schema base) {
+        return WITH_CLAIMS.computeIfAbsent(base, b -> {
+            List<Field> fields = new ArrayList<>(b.getFields());
+            fields.add(mapField(IngestionHandler.CLAIMS_COLUMN));
+            return new Schema(fields);
+        });
+    }
+
+    static void writeEntry(BaseWriter.MapWriter writer, String key, String value) {
+        writer.startEntry();
+        ((BaseWriter.ListWriter) writer.key()).varChar().writeVarChar(key);
+        if (value != null) {
+            ((BaseWriter.ListWriter) writer.value()).varChar().writeVarChar(value);
+        } else {
+            ((BaseWriter.ListWriter) writer.value()).varChar().writeNull();
+        }
+        writer.endEntry();
+    }
+
+    /** Pre-encoded variant — a plain byte copy, no per-call UTF-8 encoding. */
+    static void writeEntry(BaseWriter.MapWriter writer, Text key, Text value) {
+        writer.startEntry();
+        ((BaseWriter.ListWriter) writer.key()).varChar().writeVarChar(key);
+        ((BaseWriter.ListWriter) writer.value()).varChar().writeVarChar(value);
+        writer.endEntry();
+    }
 
     static Field mapField(String name) {
         return new Field(name,

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelServiceBase.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelServiceBase.java
@@ -30,6 +30,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -141,15 +142,31 @@ class OtelServiceBase implements Closeable {
         return queue.add(batch).thenApply(ignored -> null);
     }
 
+    /** Verified JWT claims for the queue, or {@code null} when it does not extract claims. */
+    private Map<String, String> claimsFor(String queueId) {
+        if (!handler.extractClaims(queueId)) {
+            return null;
+        }
+        Map<String, String> claims = JwtServerInterceptor.CLAIMS_CONTEXT_KEY.get();
+        return claims != null ? claims : Map.of();
+    }
+
     /**
      * Serialises {@code entries} to a temporary Arrow IPC file using the provided schema
      * and batch writer. Deletes the partial file before rethrowing on any failure.
+     * Queues with {@code extract_claims} get the claims-column schema variant, filled from
+     * the caller's verified JWT claims after the batch writer runs.
      */
-    <E> Path writeArrowFile(List<E> entries, Schema schema,
+    <E> Path writeArrowFile(String queueId, List<E> entries, Schema schema,
                              BiConsumer<List<E>, VectorSchemaRoot> batchWriter) throws IOException {
+        Map<String, String> claims = claimsFor(queueId);
+        Schema effective = claims == null ? schema : OtelSchemaFields.withClaimsColumn(schema);
         Path tempFile = tempDir.resolve("batch_" + UUID.randomUUID() + ".arrow");
-        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(effective, allocator)) {
             batchWriter.accept(entries, root);
+            if (claims != null) {
+                ClaimsColumnWriter.write(root, claims);
+            }
             try (FileOutputStream fos = new FileOutputStream(tempFile.toFile());
                  ArrowStreamWriter writer = io.dazzleduck.sql.commons.io.ResultStreams.newArrowStreamWriter(
                          root, null, fos,

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelTraceService.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelTraceService.java
@@ -59,7 +59,7 @@ public class OtelTraceService extends TraceServiceGrpc.TraceServiceImplBase impl
         var sample = metrics.startSample();
 
         try {
-            Path arrowFile = base.writeArrowFile(entries, OtelTraceSchema.SCHEMA, SpanBatchWriter::write);
+            Path arrowFile = base.writeArrowFile(queueId, entries, OtelTraceSchema.SCHEMA, SpanBatchWriter::write);
             base.addBatch(queue, arrowFile).whenComplete(
                     OtelServiceBase.batchCompleteHandler(arrowFile, spanCount, queueId,
                             sample, metrics,

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/SpanBatchWriter.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/SpanBatchWriter.java
@@ -153,15 +153,7 @@ public class SpanBatchWriter {
         }
         mw.startMap();
         for (KeyValue kv : kvList) {
-            mw.startEntry();
-            ((BaseWriter.ListWriter) mw.key()).varChar().writeVarChar(kv.getKey());
-            String val = LogRecordConverter.anyValueToString(kv.getValue());
-            if (val != null) {
-                ((BaseWriter.ListWriter) mw.value()).varChar().writeVarChar(val);
-            } else {
-                ((BaseWriter.ListWriter) mw.value()).varChar().writeNull();
-            }
-            mw.endEntry();
+            OtelSchemaFields.writeEntry(mw, kv.getKey(), LogRecordConverter.anyValueToString(kv.getValue()));
         }
         mw.endMap();
     }
@@ -170,15 +162,7 @@ public class SpanBatchWriter {
         writer.setPosition(index);
         writer.startMap();
         for (KeyValue kv : kvList) {
-            writer.startEntry();
-            ((BaseWriter.ListWriter) writer.key()).varChar().writeVarChar(kv.getKey());
-            String val = LogRecordConverter.anyValueToString(kv.getValue());
-            if (val != null) {
-                ((BaseWriter.ListWriter) writer.value()).varChar().writeVarChar(val);
-            } else {
-                ((BaseWriter.ListWriter) writer.value()).varChar().writeNull();
-            }
-            writer.endEntry();
+            OtelSchemaFields.writeEntry(writer, kv.getKey(), LogRecordConverter.anyValueToString(kv.getValue()));
         }
         writer.endMap();
     }

--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/auth/JwtServerInterceptor.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/auth/JwtServerInterceptor.java
@@ -6,6 +6,7 @@ import io.dazzleduck.sql.common.auth.JwtClaimsExtractor;
 import io.dazzleduck.sql.common.auth.LoginResponse;
 import io.dazzleduck.sql.commons.auth.Validator;
 import io.grpc.*;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import org.slf4j.Logger;
@@ -21,7 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Calendar;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class JwtServerInterceptor implements ServerInterceptor {
 
@@ -30,6 +33,19 @@ public class JwtServerInterceptor implements ServerInterceptor {
     /** gRPC context key populated from the {@value Headers#CLAIM_INGESTION_QUEUE} JWT claim. */
     public static final Context.Key<String> QUEUE_CONTEXT_KEY =
             Context.key(Headers.CLAIM_INGESTION_QUEUE);
+
+    /**
+     * gRPC context key carrying the caller's verified JWT claims minus the registered token
+     * claims ({@code exp}, {@code iat}, {@code nbf}, {@code iss}, {@code aud}, {@code jti}),
+     * values stringified. Consumed by signal services for queues with {@code extract_claims} on.
+     */
+    public static final Context.Key<Map<String, String>> CLAIMS_CONTEXT_KEY =
+            Context.key("verified-claims");
+
+    /** Token-plumbing claims that never reach the claims column. */
+    private static final Set<String> REGISTERED_CLAIMS = Set.of(
+            Claims.EXPIRATION, Claims.ISSUED_AT, Claims.NOT_BEFORE,
+            Claims.ISSUER, Claims.AUDIENCE, Claims.ID);
     private static final Metadata.Key<String> AUTHORIZATION_KEY =
             Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
     private static final String BEARER_PREFIX = "Bearer ";
@@ -111,7 +127,7 @@ public class JwtServerInterceptor implements ServerInterceptor {
             String bearerValue = token.startsWith(BEARER_PREFIX) ? token.substring(BEARER_PREFIX.length()) : token;
             try {
                 var claims = JwtClaimsExtractor.parseJwtClaims(bearerValue, jwtParser, verifySignature);
-                return startCallWithQueueContext(claims, wrappedCall, headers, next);
+                return startCallWithClaimContexts(claims, wrappedCall, headers, next);
             } catch (Exception ignored) {}
             return next.startCall(wrappedCall, headers);
         } catch (Exception e) {
@@ -151,7 +167,7 @@ public class JwtServerInterceptor implements ServerInterceptor {
             String token, ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
         try {
             var claims = JwtClaimsExtractor.parseJwtClaims(token, jwtParser, verifySignature);
-            return startCallWithQueueContext(claims, call, headers, next);
+            return startCallWithClaimContexts(claims, call, headers, next);
         } catch (Exception e) {
             log.debug("JWT validation failed: {}", e.getMessage());
             call.close(Status.UNAUTHENTICATED.withDescription("Invalid or expired JWT token"), new Metadata());
@@ -159,17 +175,28 @@ public class JwtServerInterceptor implements ServerInterceptor {
         }
     }
 
-    private <ReqT, RespT> ServerCall.Listener<ReqT> startCallWithQueueContext(
-            io.jsonwebtoken.Claims claims,
+    private <ReqT, RespT> ServerCall.Listener<ReqT> startCallWithClaimContexts(
+            Claims claims,
             ServerCall<ReqT, RespT> call,
             Metadata headers,
             ServerCallHandler<ReqT, RespT> next) {
+        Context ctx = Context.current().withValue(CLAIMS_CONTEXT_KEY, filterClaims(claims));
         String queueId = claims.get(Headers.CLAIM_INGESTION_QUEUE, String.class);
         if (queueId != null) {
-            Context ctx = Context.current().withValue(QUEUE_CONTEXT_KEY, queueId);
-            return Contexts.interceptCall(ctx, call, headers, next);
+            ctx = ctx.withValue(QUEUE_CONTEXT_KEY, queueId);
         }
-        return next.startCall(call, headers);
+        return Contexts.interceptCall(ctx, call, headers, next);
+    }
+
+    /** Drops the registered token claims and stringifies the rest. */
+    static Map<String, String> filterClaims(Claims claims) {
+        Map<String, String> filtered = new LinkedHashMap<>();
+        claims.forEach((key, value) -> {
+            if (value != null && !REGISTERED_CLAIMS.contains(key)) {
+                filtered.put(key, String.valueOf(value));
+            }
+        });
+        return filtered;
     }
 
     private String generateToken(String subject) {

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -69,6 +69,8 @@ otel_collector {
                 # transformation  = "CAST(timestamp AS DATE) AS date, severity_text AS level"
                 # min_bucket_size = 1048576
                 # max_delay_ms    = 5000
+                # Stamp caller JWT claims onto rows. PRIVACY note + DDL: README "JWT Claims Column".
+                # extract_claims = true
                 # DuckLake fields (required when class is set):
                 # catalog = "my_catalog"
                 # schema  = "main"

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorClaimsColumnTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorClaimsColumnTest.java
@@ -1,0 +1,159 @@
+package io.dazzleduck.sql.otel.collector;
+
+import io.dazzleduck.sql.commons.ConnectionPool;
+import io.dazzleduck.sql.commons.ingestion.IngestionHandler;
+import io.dazzleduck.sql.otel.collector.config.CollectorProperties;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.MetadataUtils;
+import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.SECRET_KEY_BASE64;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.bearerMetadata;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.findFreePort;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.noopHandler;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.sampleLogRequest;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.sampleMetricRequest;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.sampleTraceRequest;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.smallBucketConfig;
+import static io.dazzleduck.sql.otel.collector.OtelCollectorCustomQueueTest.tokenWithQueueClaim;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * End-to-end tests for the per-queue {@code extract_claims} claims column: with the flag on,
+ * ingested rows carry a {@code claims} map built from the caller's JWT (registered claims
+ * excluded); with the flag off, the written schema is unchanged.
+ */
+public class OtelCollectorClaimsColumnTest {
+
+    private static final String ORG_ID = "acme";
+
+    @BeforeAll
+    static void loadExtensions() throws Exception {
+        ConnectionPool.executeBatch(new String[]{"INSTALL arrow FROM community", "LOAD arrow"});
+    }
+
+    static long count(String sql) throws Exception {
+        Long result = ConnectionPool.collectFirst(sql, Long.class);
+        assertNotNull(result);
+        return result;
+    }
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    abstract static class ServerFixture {
+
+        Path outputRoot;
+        OtelCollectorServer server;
+        ManagedChannel channel;
+
+        abstract IngestionHandler handler();
+
+        @BeforeAll
+        void setup() throws Exception {
+            outputRoot = Files.createTempDirectory("otel-claims-test");
+            for (String q : new String[]{"logs", "traces", "metrics"}) {
+                Files.createDirectories(outputRoot.resolve(q));
+            }
+            var props = new CollectorProperties();
+            props.setShutdownGracePeriod(Duration.ZERO);
+            props.setGrpcPort(findFreePort());
+            props.setIngestionHandler(handler());
+            props.setIngestionConfig(smallBucketConfig());
+            props.setAuthentication("jwt");
+            props.setSecretKey(SECRET_KEY_BASE64);
+
+            server = new OtelCollectorServer(props);
+            server.start();
+            channel = ManagedChannelBuilder.forAddress("localhost", props.getGrpcPort()).usePlaintext().build();
+        }
+
+        @AfterAll
+        void cleanup() throws Exception {
+            try {
+                if (channel != null) { channel.shutdown(); channel.awaitTermination(5, TimeUnit.SECONDS); }
+            } finally {
+                if (server != null) server.close();
+            }
+        }
+
+        String parquetGlob(String queue) {
+            return "read_parquet('%s/%s/*.parquet')".formatted(outputRoot.toString().replace('\\', '/'), queue);
+        }
+    }
+
+    @Nested
+    class WithExtractClaims extends ServerFixture {
+
+        @Override IngestionHandler handler() {
+            return noopHandler(id -> outputRoot.resolve(id).toString(), true, "logs", "traces", "metrics");
+        }
+
+        @Test
+        void logs_rowsCarryFilteredClaims() throws Exception {
+            var stub = LogsServiceGrpc.newBlockingStub(channel).withInterceptors(
+                    MetadataUtils.newAttachHeadersInterceptor(bearerMetadata(tokenWithQueueClaim("logs", Map.of("org_id", ORG_ID)))));
+            stub.export(sampleLogRequest());
+
+            assertEquals(1, count("SELECT COUNT(*) FROM " + parquetGlob("logs")
+                    + " WHERE claims['org_id'] = '" + ORG_ID + "'"
+                    + " AND claims['sub'] = 'admin'"
+                    + " AND claims['x-dd-ingestion-queue'] = 'logs'"));
+            assertEquals(0, count("SELECT COUNT(*) FROM " + parquetGlob("logs")
+                    + " WHERE list_contains(map_keys(claims), 'exp')"));
+        }
+
+        @Test
+        void traces_haveClaimsColumn() throws Exception {
+            var stub = TraceServiceGrpc.newBlockingStub(channel).withInterceptors(
+                    MetadataUtils.newAttachHeadersInterceptor(bearerMetadata(tokenWithQueueClaim("traces", Map.of("org_id", ORG_ID)))));
+            stub.export(sampleTraceRequest());
+            assertOrgClaimStamped("traces");
+        }
+
+        @Test
+        void metrics_haveClaimsColumn() throws Exception {
+            var stub = MetricsServiceGrpc.newBlockingStub(channel).withInterceptors(
+                    MetadataUtils.newAttachHeadersInterceptor(bearerMetadata(tokenWithQueueClaim("metrics", Map.of("org_id", ORG_ID)))));
+            stub.export(sampleMetricRequest());
+            assertOrgClaimStamped("metrics");
+        }
+
+        private void assertOrgClaimStamped(String queue) throws Exception {
+            assertEquals(1, count("SELECT COUNT(*) FROM " + parquetGlob(queue)
+                    + " WHERE claims['org_id'] = '" + ORG_ID + "'"));
+        }
+    }
+
+    @Nested
+    class WithoutExtractClaims extends ServerFixture {
+
+        @Override IngestionHandler handler() {
+            return noopHandler(outputRoot.resolve("logs").toString(), "logs");
+        }
+
+        @Test
+        void logs_writtenWithoutClaimsColumn() throws Exception {
+            var stub = LogsServiceGrpc.newBlockingStub(channel).withInterceptors(
+                    MetadataUtils.newAttachHeadersInterceptor(bearerMetadata(tokenWithQueueClaim("logs", Map.of("org_id", ORG_ID)))));
+            stub.export(sampleLogRequest());
+
+            assertEquals(0, count("SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM " + parquetGlob("logs")
+                    + ") WHERE column_name = 'claims'"));
+            assertEquals(1, count("SELECT COUNT(*) FROM " + parquetGlob("logs")));
+        }
+    }
+}

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorCustomQueueTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelCollectorCustomQueueTest.java
@@ -107,15 +107,21 @@ public class OtelCollectorCustomQueueTest {
 
     /** Generates a signed JWT embedding the given queue ID as a claim. */
     static String tokenWithQueueClaim(String queueId) {
+        return tokenWithQueueClaim(queueId, java.util.Map.of());
+    }
+
+    /** Generates a signed JWT with the queue claim plus the given extra claims. */
+    static String tokenWithQueueClaim(String queueId, java.util.Map<String, String> extraClaims) {
         SecretKey key = Validator.fromBase64String(SECRET_KEY_BASE64);
         Calendar exp = Calendar.getInstance();
         exp.add(Calendar.HOUR, 1);
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .subject("admin")
                 .claim(Headers.CLAIM_INGESTION_QUEUE, queueId)
                 .expiration(exp.getTime())
-                .signWith(key)
-                .compact();
+                .signWith(key);
+        extraClaims.forEach(builder::claim);
+        return builder.compact();
     }
 
     static Metadata bearerMetadata(String token) {
@@ -125,6 +131,11 @@ public class OtelCollectorCustomQueueTest {
     }
 
     static io.dazzleduck.sql.commons.ingestion.IngestionHandler noopHandler(String outputPath, String... knownQueues) {
+        return noopHandler(id -> outputPath, false, knownQueues);
+    }
+
+    static io.dazzleduck.sql.commons.ingestion.IngestionHandler noopHandler(
+            java.util.function.Function<String, String> pathFor, boolean extractClaims, String... knownQueues) {
         java.util.Set<String> known = new java.util.LinkedHashSet<>(java.util.List.of(knownQueues));
         return new io.dazzleduck.sql.commons.ingestion.IngestionHandler() {
             @Override public io.dazzleduck.sql.commons.ingestion.PostIngestionTask
@@ -133,8 +144,9 @@ public class OtelCollectorCustomQueueTest {
             }
             @Override public java.util.Set<String> getKnownQueues() { return known; }
             // Mirror real handlers: a target path exists only for a known queue (null ⇒ unknown).
-            @Override public String getTargetPath(String id) { return known.contains(id) ? outputPath : null; }
+            @Override public String getTargetPath(String id) { return known.contains(id) ? pathFor.apply(id) : null; }
             @Override public String[] getPartitionBy(String id) { return new String[0]; }
+            @Override public boolean extractClaims(String id) { return extractClaims; }
         };
     }
 

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/auth/JwtClaimsFilterTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/auth/JwtClaimsFilterTest.java
@@ -1,0 +1,64 @@
+package io.dazzleduck.sql.otel.collector.auth;
+
+import io.dazzleduck.sql.common.Headers;
+import io.dazzleduck.sql.commons.auth.Validator;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.SecretKey;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JwtClaimsFilterTest {
+
+    private static final SecretKey KEY = newKey();
+
+    private static SecretKey newKey() {
+        try {
+            return Validator.generateRandoSecretKey();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Claims parse(String token) {
+        return Jwts.parser().verifyWith(KEY).build().parseSignedClaims(token).getPayload();
+    }
+
+    @Test
+    void filterClaims_dropsRegisteredClaims_keepsAndStringifiesTheRest() {
+        String token = Jwts.builder()
+                .subject("admin")
+                .issuer("test-issuer")
+                .id("token-1")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 60_000))
+                .claim(Headers.CLAIM_INGESTION_QUEUE, "logs")
+                .claim("org_id", "acme")
+                .claim("retries", 3)
+                .signWith(KEY)
+                .compact();
+
+        assertEquals(Map.of(
+                        Claims.SUBJECT, "admin",
+                        Headers.CLAIM_INGESTION_QUEUE, "logs",
+                        "org_id", "acme",
+                        "retries", "3"),
+                JwtServerInterceptor.filterClaims(parse(token)));
+    }
+
+    @Test
+    void filterClaims_onlyRegisteredClaims_yieldsEmptyMap() {
+        String token = Jwts.builder()
+                .expiration(new Date(System.currentTimeMillis() + 60_000))
+                .signWith(KEY)
+                .compact();
+
+        assertTrue(JwtServerInterceptor.filterClaims(parse(token)).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **claims column** to the OTel collector: a queue mapping can set `extract_claims = true`, and every row ingested into that queue then carries a `claims MAP(VARCHAR, VARCHAR)` column — alongside `attributes` and `resource_attributes` — populated from the caller's **verified** JWT.

- Registered token claims (`exp`, `iat`, `nbf`, `iss`, `aud`, `jti`) are excluded; `sub` and all custom claims are kept, values stringified.
- The map is stamped **per request at batch-write time** (in the signal services, from claims the auth interceptor already parsed), so it stays correct even when the ingestion queue combines batches from different tokens into one Parquet write — the reason this cannot be done with a per-queue `transformation`, which runs once per bucket.
- Default **off**; zero behavior or schema change for queues that don't opt in.

**Why:** it makes authenticated per-request data available to transformations and partitioning. One shared view can derive a first-class column from any claim:

```sql
CREATE VIEW my_catalog.main.logs_transform AS
SELECT *, claims['org_id'] AS org_id FROM my_catalog.main.raw_logs;

ALTER TABLE my_catalog.main.logs SET PARTITIONED BY (org_id);
```

## Changes

**commons**
- `extract_claims` key on `ingestion_queue_table_mapping` entries; `QueueIdToTableMapping` gains the component plus a `withExtractClaims` wither (existing constructors unchanged, default `false`)
- `IngestionHandler.extractClaims(queueId)` default method and the `CLAIMS_COLUMN` constant; `DuckLakeIngestionHandler` lookup (with a new `mappingFor` helper deduplicating the exact-then-suffix idiom at three pre-existing sites)
- On queue-state build, a **warning when the DuckLake target table lacks the `claims` column** (via `DuckLakeTableManager.currentColumnNames`) — registration tolerates extra file columns, so the data would otherwise be dropped silently; the warning names the exact `ALTER TABLE` to run

**otel-collector**
- `JwtServerInterceptor` publishes the filtered claims in a gRPC context key next to the existing queue-claim key
- The claims schema variant is derived and memoized from each base signal schema, with the column **appended last** so the per-signal batch writers are untouched; `OtelServiceBase` picks the variant per request
- `ClaimsColumnWriter` pre-encodes the constant map to Arrow `Text` once (not once per row) and fills the column after the batch writer runs; a shared `writeEntry` helper now owns the map-writer cast idiom at all five sites in the module
- `reference.conf` + README document the flag, the privacy caveat (enabling it persists token claims into the data), the DDL, and the restart rule

**Limitations (documented):** flag changes require a restart (a bucket must not mix batches with and without the column); the dynamic SQLite registry does not carry the flag — same limitation watermarks have.

## Test plan

- `ExtractClaimsMappingTest` (commons): record defaults, provider config parsing, handler lookup against a real DuckLake catalog (also runs the missing-column warning path)
- `JwtClaimsFilterTest`: registered claims dropped, custom claims kept, non-string values stringified
- `OtelCollectorClaimsColumnTest`: end-to-end over real gRPC for all three signals — Parquet contents queried back via SQL asserting the claim values are present and `exp` is absent; plus the flag-off case asserting the written schema has **no** `claims` column
- Verified locally on JDK 21: all new tests pass; module suites green except the pre-existing Windows-only `OtelCollectorConfigDuckLakeTest` failure (raw Windows temp path in HOCON), which exists on `main` and is unrelated

Independent of #394 (the cluster-scoping PR): this branch is based directly on `main`, deliberately avoids the `x-dd-*` claim namespace in examples/tests, and the two merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
