### PR TITLE
feat(ingestion): optional watermark_snapshot_id_column

### DIFF
--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
@@ -21,6 +21,13 @@ import java.util.Map;
  * registration and watermark commit or roll back together. This task never re-reads the written
  * files.
  *
+ * <p>When the spec also configures {@code watermark_snapshot_id_column}, a second statement runs
+ * on the SAME connection once that transaction has committed, recording the snapshot the batch
+ * committed at. It cannot be part of the transaction: a transaction cannot learn the snapshot it
+ * is about to create. See {@link WatermarkSpec} for the mechanism and its two consequences — one
+ * extra snapshot per batch, and a NULL that the next batch sweeps up if the process dies between
+ * the two commits.
+ *
  * <p>Limitation: queues registered through the dynamic SQLite registry
  * ({@link DynamicQueueRepository}) do not carry {@code additional_parameters}, so watermarks are
  * only available for statically configured queue mappings.
@@ -81,8 +88,14 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
         if (watermarkSpec != null && watermarkRows != null && !watermarkRows.isEmpty()) {
             queries.add(watermarkSpec.insertSql(catalogName, schemaName, watermarkRows));
         }
+        String stampSql = watermarkSpec == null ? null : watermarkSpec.snapshotStampSql(catalogName, schemaName);
         try (Connection conn = ConnectionPool.getConnection()) {
             ConnectionPool.executeBatchInTxn(conn, queries.toArray(String[]::new));
+            if (stampSql != null) {
+                // Same connection, after the commit: ducklake_last_committed_snapshot() is
+                // per-connection and now names the transaction above.
+                ConnectionPool.execute(conn, stampSql);
+            }
         }
     }
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
@@ -27,7 +27,30 @@ import java.util.stream.Collectors;
  *       column the MAX lands in.</li>
  *   <li>{@code watermark_row_count_column} — required when the table is set; receives
  *       {@code COUNT(*)} for the group.</li>
+ *   <li>{@code watermark_snapshot_id_column} — OPTIONAL; receives the DuckLake snapshot the batch
+ *       committed at. Absent means the column is not written at all, which is the behaviour
+ *       every existing configuration keeps.</li>
  * </ul>
+
+ * <p><b>The snapshot id is stamped after the batch commits, not inside it.</b> A transaction
+ * cannot learn the snapshot it is about to create: {@code ducklake_current_snapshot()} returns the
+ * snapshot being READ, and the new id only exists once the commit completes. So when
+ * {@code watermark_snapshot_id_column} is configured, {@link DuckLakePostIngestionTask} follows the
+ * ingest transaction with a second statement on the SAME connection:
+ *
+ * <pre>{@code UPDATE <watermark table>
+ *      SET <snapshot column> = (SELECT * FROM ducklake_last_committed_snapshot('<catalog>'))
+ *    WHERE <snapshot column> IS NULL}</pre>
+ *
+ * {@code ducklake_last_committed_snapshot} is per-connection and the subquery is evaluated before
+ * the UPDATE's own commit, so the value recorded is the ingest batch's snapshot — the one that made
+ * both the data files and the watermark row visible — and never another writer's.
+ *
+ * <p>Two consequences worth knowing. The stamp is its own transaction, so it creates one extra
+ * snapshot per batch. And a crash between the two commits leaves the row with a NULL snapshot id;
+ * the {@code IS NULL} predicate makes the next batch sweep it up, and readers must tolerate NULL
+ * in the meantime. The predicate assumes a single writer per watermark table, which is the model
+ * already: one queue, one watermark table.
  *
  * <p>A group whose timestamps are all NULL still produces a row: NULL min and max, with the real
  * row count. Only a genuinely empty batch is skipped.
@@ -46,7 +69,14 @@ import java.util.stream.Collectors;
  * unknown {@code watermark_}-prefixed keys are rejected to surface typos.
  */
 public record WatermarkSpec(String table, String timestampColumn, List<String> groupColumns,
-                            String minTimestampColumn, String maxTimestampColumn, String rowCountColumn) {
+                            String minTimestampColumn, String maxTimestampColumn, String rowCountColumn,
+                            String snapshotIdColumn) {
+
+    /** Without a snapshot-id column — the shape every configuration had before that key existed. */
+    public WatermarkSpec(String table, String timestampColumn, List<String> groupColumns,
+                         String minTimestampColumn, String maxTimestampColumn, String rowCountColumn) {
+        this(table, timestampColumn, groupColumns, minTimestampColumn, maxTimestampColumn, rowCountColumn, null);
+    }
 
     public static final String TABLE_KEY = "watermark_table";
     public static final String TIMESTAMP_COLUMN_KEY = "watermark_timestamp_column";
@@ -54,9 +84,10 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
     public static final String MIN_TIMESTAMP_COLUMN_KEY = "watermark_min_timestamp_column";
     public static final String MAX_TIMESTAMP_COLUMN_KEY = "watermark_max_timestamp_column";
     public static final String ROW_COUNT_COLUMN_KEY = "watermark_row_count_column";
+    public static final String SNAPSHOT_ID_COLUMN_KEY = "watermark_snapshot_id_column";
 
     private static final List<String> KNOWN_KEYS = List.of(TABLE_KEY, TIMESTAMP_COLUMN_KEY, GROUP_COLUMNS_KEY,
-            MIN_TIMESTAMP_COLUMN_KEY, MAX_TIMESTAMP_COLUMN_KEY, ROW_COUNT_COLUMN_KEY);
+            MIN_TIMESTAMP_COLUMN_KEY, MAX_TIMESTAMP_COLUMN_KEY, ROW_COUNT_COLUMN_KEY, SNAPSHOT_ID_COLUMN_KEY);
 
     public WatermarkSpec {
         requireNonBlank(table, TABLE_KEY);
@@ -66,6 +97,10 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
         requireNonBlank(minTimestampColumn, MIN_TIMESTAMP_COLUMN_KEY);
         requireNonBlank(maxTimestampColumn, MAX_TIMESTAMP_COLUMN_KEY);
         requireNonBlank(rowCountColumn, ROW_COUNT_COLUMN_KEY);
+        // Optional: null means "do not record it". Present-but-blank is a typo, not a choice.
+        if (snapshotIdColumn != null) {
+            requireNonBlank(snapshotIdColumn, SNAPSHOT_ID_COLUMN_KEY);
+        }
     }
 
     /**
@@ -90,6 +125,7 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
         String minTimestampColumn = parameters.get(MIN_TIMESTAMP_COLUMN_KEY);
         String maxTimestampColumn = parameters.get(MAX_TIMESTAMP_COLUMN_KEY);
         String rowCountColumn = parameters.get(ROW_COUNT_COLUMN_KEY);
+        String snapshotIdColumn = parameters.get(SNAPSHOT_ID_COLUMN_KEY);
         if (isBlank(table) || isBlank(timestampColumn) || isBlank(minTimestampColumn)
                 || isBlank(maxTimestampColumn) || isBlank(rowCountColumn)) {
             throw new IllegalArgumentException(
@@ -100,7 +136,9 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
         try {
             return new WatermarkSpec(table.trim(), timestampColumn.trim(),
                     parseGroupColumns(parameters.get(GROUP_COLUMNS_KEY)),
-                    minTimestampColumn.trim(), maxTimestampColumn.trim(), rowCountColumn.trim());
+                    minTimestampColumn.trim(), maxTimestampColumn.trim(), rowCountColumn.trim(),
+                    // Only absence means "unconfigured"; a blank value is rejected by the constructor.
+                    snapshotIdColumn == null ? null : snapshotIdColumn.trim());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Queue '%s': %s".formatted(queueName, e.getMessage()), e);
         }
@@ -190,6 +228,24 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
         return "INSERT INTO %s.%s.%s (%s) VALUES %s".formatted(
                 HeaderUtils.quoteIdentifier(catalog), HeaderUtils.quoteIdentifier(schema),
                 HeaderUtils.quoteIdentifier(table), columnList, values);
+    }
+
+    /**
+     * The statement that records the snapshot the batch committed at, or {@code null} when
+     * {@code watermark_snapshot_id_column} is unconfigured.
+     *
+     * <p>Runs AFTER the ingest transaction, on the same connection — see this class's header for
+     * why the id cannot be known inside it. {@code IS NULL} both scopes the update to rows this
+     * connection has just written and sweeps up any row a previous crash left unstamped.
+     */
+    public String snapshotStampSql(String catalog, String schema) {
+        if (snapshotIdColumn == null) {
+            return null;
+        }
+        String column = HeaderUtils.quoteIdentifier(snapshotIdColumn);
+        return "UPDATE %s.%s.%s SET %s = (SELECT * FROM ducklake_last_committed_snapshot('%s')) WHERE %s IS NULL"
+                .formatted(HeaderUtils.quoteIdentifier(catalog), HeaderUtils.quoteIdentifier(schema),
+                        HeaderUtils.quoteIdentifier(table), column, catalog.replace("'", "''"), column);
     }
 
     /** Group columns plus the three aggregates: MIN timestamp, MAX timestamp, row count. */

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -177,5 +178,69 @@ class DuckLakeWatermarkPostIngestionTest {
         List<String> rows = new ArrayList<>();
         ConnectionPool.collectAll(conn, sql, rs -> rs.getString("r")).forEach(rows::add);
         return rows;
+    }
+
+    /**
+     * With {@code watermark_snapshot_id_column} configured, the row records the snapshot the batch
+     * committed at — the same one that made the data files visible. The value cannot come from
+     * inside the ingest transaction (a transaction cannot learn the snapshot it is creating), so
+     * the task stamps it immediately afterwards on the same connection.
+     */
+    @Test
+    void recordsTheSnapshotTheBatchCommittedAt() throws Exception {
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn, "ALTER TABLE %s.main.ingest_watermark ADD COLUMN snapshot_id BIGINT".formatted(CATALOG));
+        }
+        List<String> files = writeBatchFiles();
+
+        Map<String, String> params = new java.util.HashMap<>(watermarkParams("ingest_watermark"));
+        params.put(WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "snapshot_id");
+        new DuckLakePostIngestionTask(result(files, computeRows(files)), CATALOG, "facts", "main", params).execute();
+
+        try (Connection conn = ConnectionPool.getConnection();
+             var st = conn.createStatement()) {
+            // Every watermark row carries an id, and they all carry the SAME one: a batch is one
+            // transaction, so one snapshot.
+            try (var rs = st.executeQuery(
+                    "SELECT count(*), count(snapshot_id), count(DISTINCT snapshot_id) FROM %s.main.ingest_watermark".formatted(CATALOG))) {
+                assertTrue(rs.next());
+                assertEquals(3, rs.getInt(1), "three groups in the batch");
+                assertEquals(3, rs.getInt(2), "none left NULL");
+                assertEquals(1, rs.getInt(3), "one batch, one snapshot");
+            }
+            // And it is the snapshot the DATA landed in, not a later one: reading the facts table
+            // at that version must already show the batch's rows. AT (VERSION => ...) takes no
+            // subquery, so the id is read out first.
+            long stamped;
+            try (var rs = st.executeQuery("SELECT max(snapshot_id) FROM %s.main.ingest_watermark".formatted(CATALOG))) {
+                assertTrue(rs.next());
+                stamped = rs.getLong(1);
+            }
+            try (var rs = st.executeQuery(
+                    "SELECT count(*) FROM %s.main.facts AT (VERSION => %d)".formatted(CATALOG, stamped))) {
+                assertTrue(rs.next());
+                assertEquals(4, rs.getInt(1), "the stamped snapshot already contains the batch's rows");
+            }
+        }
+    }
+
+    /** Without the key, the column is never touched — the shape every existing queue keeps. */
+    @Test
+    void leavesTheSnapshotColumnAloneWhenUnconfigured() throws Exception {
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn, "ALTER TABLE %s.main.ingest_watermark ADD COLUMN snapshot_id BIGINT".formatted(CATALOG));
+        }
+        List<String> files = writeBatchFiles();
+
+        new DuckLakePostIngestionTask(result(files, computeRows(files)), CATALOG, "facts", "main",
+                watermarkParams("ingest_watermark")).execute();
+
+        try (Connection conn = ConnectionPool.getConnection();
+             var st = conn.createStatement();
+             var rs = st.executeQuery("SELECT count(*), count(snapshot_id) FROM %s.main.ingest_watermark".formatted(CATALOG))) {
+            assertTrue(rs.next());
+            assertEquals(3, rs.getInt(1));
+            assertEquals(0, rs.getInt(2), "unconfigured: the column stays NULL");
+        }
     }
 }

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpecTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpecTest.java
@@ -183,4 +183,68 @@ class WatermarkSpecTest {
                 "watermark_timestamp_column", "ts",
                 "watermark_max_timestamp_column", "max_ts")));
     }
+
+    @Test
+    void parsesTheOptionalSnapshotIdColumn() {
+        Map<String, String> params = new java.util.HashMap<>(Map.of(
+                WatermarkSpec.TABLE_KEY, "wm",
+                WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts",
+                WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
+                WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
+                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count"));
+        params.put(WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, " snapshot_id ");
+
+        assertEquals("snapshot_id", WatermarkSpec.fromParameters("q", params).snapshotIdColumn());
+    }
+
+    @Test
+    void snapshotIdColumnIsOptional() {
+        Map<String, String> params = Map.of(
+                WatermarkSpec.TABLE_KEY, "wm",
+                WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts",
+                WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
+                WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
+                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count");
+
+        WatermarkSpec spec = WatermarkSpec.fromParameters("q", params);
+
+        // Absent means the column is never written: every pre-existing configuration is unchanged.
+        assertNull(spec.snapshotIdColumn());
+        assertNull(spec.snapshotStampSql("cat", "main"));
+    }
+
+    @Test
+    void blankSnapshotIdColumnIsRejected() {
+        Map<String, String> params = new java.util.HashMap<>(Map.of(
+                WatermarkSpec.TABLE_KEY, "wm",
+                WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts",
+                WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
+                WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
+                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count"));
+        params.put(WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "  ");
+
+        // Present-but-blank is a typo, not a way to disable it.
+        assertThrows(IllegalArgumentException.class, () -> WatermarkSpec.fromParameters("q", params));
+    }
+
+    @Test
+    void rendersTheSnapshotStamp() {
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", "row_count", "snapshot_id");
+
+        // IS NULL scopes it to rows not yet stamped, which also sweeps up anything a crash between
+        // the two commits left behind. The catalog is a literal inside the function call.
+        assertEquals("UPDATE \"cat\".\"main\".\"wm\" SET \"snapshot_id\" = "
+                        + "(SELECT * FROM ducklake_last_committed_snapshot('cat')) WHERE \"snapshot_id\" IS NULL",
+                spec.snapshotStampSql("cat", "main"));
+    }
+
+    @Test
+    void snapshotIdColumnIsNotWrittenByTheInsert() {
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", "row_count", "snapshot_id");
+
+        // The INSERT shape is unchanged: the id does not exist yet when this statement is built.
+        String sql = spec.insertSql("cat", "main", List.of(List.of("2026-08-01 00:00:00", "2026-08-01 00:05:00", "3")));
+
+        assertFalse(sql.contains("snapshot_id"), sql);
+    }
 }


### PR DESCRIPTION
Records the DuckLake snapshot a batch committed at, on that batch's own watermark row.

Opt-in and additive — without the key nothing changes, and every existing queue configuration keeps its current behaviour. `insertSql` is untouched.

## Why it can't be part of the INSERT

A transaction cannot learn the snapshot it is about to create. Measured on DuckDB 1.5.2 + ducklake:

```
                          ducklake_current_snapshot   ducklake_last_committed_snapshot
before write                        3                            NULL
inside txn, after write             3                            NULL      <- pending id (4) invisible
after commit                        4                            4
```

`current_snapshot()` reports the snapshot being **read**, so inside the ingest transaction it still names the previous one. The new id exists only once the commit completes.

## What this does instead

`DuckLakePostIngestionTask` follows the ingest transaction with one statement, on the **same connection**:

```sql
UPDATE <watermark table>
   SET <snapshot column> = (SELECT * FROM ducklake_last_committed_snapshot('<catalog>'))
 WHERE <snapshot column> IS NULL
```

`ducklake_last_committed_snapshot` is per-connection, and the subquery is evaluated before the `UPDATE`'s own commit — so the value recorded is the **ingest batch's** snapshot, the one that made both the data files and the watermark row visible, and never another writer's. The end-to-end test asserts exactly that: reading the fact table `AT (VERSION => <stamped id>)` already shows the batch's rows.

## Two consequences, documented at both sites

- The stamp is its own transaction, so a queue that configures the key creates **one extra snapshot per batch**.
- A crash between the two commits leaves the row with a NULL id. The `IS NULL` predicate makes the next batch sweep it up, and readers must tolerate NULL in the meantime. That predicate assumes a **single writer per watermark table** — the existing model, one queue to one watermark table.

## Shape of the key

Optional, unlike the other five: absent means the column is never written. Present-but-blank is rejected, since that's a typo rather than a way to disable it. A 6-argument `WatermarkSpec` constructor keeps existing call sites compiling.

## Tests

`WatermarkSpecTest` — parsing (present / absent / blank), the rendered statement, and that `insertSql` still doesn't mention the column.

`DuckLakeWatermarkPostIngestionTest` — two end-to-end cases through `DuckLakePostIngestionTask`: every row carries the same id and it is the snapshot the data landed in; and with the key unconfigured the column stays NULL.

```
WatermarkSpecTest                  17 tests
DuckLakeWatermarkPostIngestionTest  7 tests
                                   24 passed
```

`DuckLakePostIngestionTaskTest.shouldAddFilesToDuckLakeTableTest` fails on my machine with an Arrow/netty `ExceptionInInitializerError` — it fails identically on a clean checkout of `main`, so it's a local JDK/native-access issue, not this change.

## One open question for maintainers

`doc/INGESTION_ARCHITECTURE.md` references a `PRODUCER_WATERMARK_SPEC.md` ("proposed durable producer watermarks") that isn't in the tree. If that design names this key differently, this should conform to it — renaming later is a breaking config change, since an unknown `watermark_`-prefixed key fails startup.

## Motivation

A downstream consumer resumes incremental aggregation from a DuckLake snapshot cursor. When its checkpoint's snapshot expires it needs a second, non-expiring way to bracket unconsumed batches. Today it derives one from the watermark row's `rowid`, which works but can't be compared against a stored snapshot id; with this key the watermark row carries the id directly and the derivation goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
