### PR TITLE
release: set version 0.2.17-SNAPSHOT → 0.2.17

### DIFF
--- a/dazzleduck-sql-client-grpc/pom.xml
+++ b/dazzleduck-sql-client-grpc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
 
     <artifactId>dazzleduck-sql-client-grpc</artifactId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-client/pom.xml
+++ b/dazzleduck-sql-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
 
     <artifactId>dazzleduck-sql-client</artifactId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-common/pom.xml
+++ b/dazzleduck-sql-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
     <artifactId>dazzleduck-sql-common</artifactId>
     <name>DazzleDuck Project Common</name>

--- a/dazzleduck-sql-commons/pom.xml
+++ b/dazzleduck-sql-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
     <artifactId>dazzleduck-sql-commons</artifactId>
     <name>DazzleDuck Project Commons</name>
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <!-- Test only: ResultStreamsTest exercises ZSTD Arrow round-trip via CommonsCompressionFactory
              (brings zstd-jni transitively). commons main code stays compression-impl-free. -->

--- a/dazzleduck-sql-ducklake-compactor/pom.xml
+++ b/dazzleduck-sql-ducklake-compactor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
 
     <artifactId>dazzleduck-sql-ducklake-compactor</artifactId>

--- a/dazzleduck-sql-examples/pom.xml
+++ b/dazzleduck-sql-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
 
     <artifactId>dazzleduck-sql-examples</artifactId>

--- a/dazzleduck-sql-flight/pom.xml
+++ b/dazzleduck-sql-flight/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
 
     <artifactId>dazzleduck-sql-flight</artifactId>
@@ -44,19 +44,19 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId> <!-- ✅ fixed -->
             <artifactId>dazzleduck-sql-login</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>

--- a/dazzleduck-sql-http/pom.xml
+++ b/dazzleduck-sql-http/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
     <artifactId>dazzleduck-sql-http</artifactId>
     <name>DazzleDuck Project Http Sql</name>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-login</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-flight</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/dazzleduck-sql-logback/pom.xml
+++ b/dazzleduck-sql-logback/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
     <artifactId>dazzleduck-sql-logback</artifactId>
     <name>DazzleDuck Project Logback</name>

--- a/dazzleduck-sql-login/pom.xml
+++ b/dazzleduck-sql-login/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
     <artifactId>dazzleduck-sql-login</artifactId>
     <name>DazzleDuck Project Login</name>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/dazzleduck-sql-micrometer/pom.xml
+++ b/dazzleduck-sql-micrometer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
 
     <artifactId>dazzleduck-sql-micrometer</artifactId>
@@ -63,18 +63,18 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-runtime</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/dazzleduck-sql-otel-collector/pom.xml
+++ b/dazzleduck-sql-otel-collector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
 
     <artifactId>dazzleduck-sql-otel-collector</artifactId>
@@ -87,12 +87,12 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-common</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
 
         <!-- Logging -->

--- a/dazzleduck-sql-runtime/pom.xml
+++ b/dazzleduck-sql-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
     <name>DazzleDuck Project Runtime</name>
     <description>Server runtime that starts the DazzleDuck Arrow Flight SQL and HTTP endpoints.</description>

--- a/dazzleduck-sql-scrapper/pom.xml
+++ b/dazzleduck-sql-scrapper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
 
     <artifactId>dazzleduck-sql-scrapper</artifactId>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-client</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
     </dependencies>
 

--- a/dazzleduck-sql-search/pom.xml
+++ b/dazzleduck-sql-search/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dazzleduck.sql</groupId>
         <artifactId>dazzleduck-parent</artifactId>
-        <version>0.2.17-SNAPSHOT</version>
+        <version>0.2.17</version>
     </parent>
     <name>DazzleDuck Project Search</name>
     <description>Full-text search indexing for DazzleDuck SQL.</description>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.dazzleduck.sql</groupId>
             <artifactId>dazzleduck-sql-commons</artifactId>
-            <version>0.2.17-SNAPSHOT</version>
+            <version>0.2.17</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.dazzleduck.sql</groupId>
     <artifactId>dazzleduck-parent</artifactId>
-    <version>0.2.17-SNAPSHOT</version>
+    <version>0.2.17</version>
     <packaging>pom</packaging>
     <name>DazzleDuck Project Parent POM</name>
     <url>https://github.com/dazzleduck-web/dazzleduck-sql-server</url>


### PR DESCRIPTION
> **Merge after #399, not before.** This only sets the version; whatever is on `main` at merge time is what 0.2.17 contains. Merged first, it would cut a release without `watermark_snapshot_id_column` and burn the version number that consumer already pins.

Mechanical version bump, mirroring #396 (`0.2.16-SNAPSHOT → 0.2.16`): 16 pom files, 37 occurrences, parent references included. No other changes.

Offered because a downstream consumer is waiting on a published `dazzleduck/dazzleduck-otel-collector:0.2.17` image to pick up #399 — happy to close this if you'd rather cut the release yourselves or bundle it differently. The tag and publish are yours either way; this only saves the `mvn versions:set`.

Suggested order:

1. merge #399
2. merge this
3. tag `v0.2.17` on the resulting commit → `release.yml` builds and publishes
4. the usual follow-up: `Prepare next development version 0.2.18-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
