### PR TITLE
feat(ingestion)!: record the DuckLake commit snapshot on watermark rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ row count. Configure under `additional_parameters`:
 | `watermark_max_timestamp_column` | Yes | Destination column for the MAX timestamp |
 | `watermark_row_count_column` | Yes | Destination column for the batch row count |
 | `watermark_group_columns` | No | Comma-separated grouping columns; empty = one global row per batch |
-| `watermark_snapshot_id_column` | Yes | Destination column for the DuckLake snapshot id the batch commits as |
+| `watermark_snapshot_id_column` | Yes | Destination column for a lower bound on the DuckLake snapshot the batch committed in |
 
 A malformed spec (partial keys, blanks, typos in `watermark_*` keys) fails at startup rather
 than per batch. Watermarks are not available for queues registered via the dynamic SQLite
@@ -569,7 +569,7 @@ provider, whose registry does not store `additional_parameters`.
 
 ### The snapshot id column
 
-Every watermark row records the DuckLake snapshot its batch committed as, so the watermark table
+Every watermark row records the DuckLake snapshot its batch committed in, so the watermark table
 must carry the column named by `watermark_snapshot_id_column`:
 
 ```sql
@@ -580,23 +580,29 @@ The key is **required** whenever a watermark is configured; a spec without it fa
 The column must be `BIGINT` and nullable — it is written on every insert, but leaving it nullable
 lets an existing table be migrated without a rewrite.
 
-The id is written by the same INSERT as the rest of the row, so a batch remains **one transaction
-and one snapshot**. DuckLake does not expose the pending snapshot id — it is assigned at COMMIT —
-but it derives the id as `max(snapshot_id) + 1` and enforces it with a primary key, so the value is
-computed just before the transaction opens and verified immediately afterwards.
+**The value is a lower bound, not an exact id.** The true snapshot is the recorded value or
+higher, never lower. Join with `>=`, not `=`:
 
-What to expect from the recorded value:
+```sql
+-- batches whose data is visible as of snapshot N
+SELECT * FROM ingest_watermark WHERE commit_snapshot_id <= N;
+```
 
-- Normally it is exactly the snapshot the batch's data files landed in, and matches
-  `begin_snapshot` in `ducklake_data_file` for those files.
-- If a concurrent writer takes that id first, DuckLake retries the commit one higher **without
-  error**. The committed id is therefore always **greater than or equal to** the predicted one —
-  the value can only ever be under-reported, never ahead. The verification step detects this and
-  repairs the rows.
-- If the process dies between the commit and the verification, the row keeps the under-reported
-  id. That id names a real snapshot belonging to a different writer, so it joins cleanly to the
-  wrong batch rather than failing loudly. Treat the column as authoritative only while ingestion
-  is running normally; to audit it, compare against `begin_snapshot` of the batch's files.
+The bound holds unconditionally. DuckLake assigns the snapshot id at COMMIT and does not expose
+the pending one, so what gets written is `max(snapshot_id) + 1` — the same formula DuckLake uses,
+read just before the transaction opens. The committed id can only be that or higher, because
+`max(snapshot_id)` never decreases (even aggressive `ducklake_expire_snapshots` retains the newest
+snapshot, and ids are never reused) and a concurrent writer taking the id first merely pushes the
+commit higher.
+
+In practice the bound is tight: immediately after committing, the id is verified against
+`begin_snapshot` of the batch's files and corrected if a concurrent writer won the race, so the
+recorded value is normally the exact snapshot. That step improves accuracy rather than
+correctness — if it is skipped, or the process dies before it runs, the column still satisfies its
+contract and no reader is misled.
+
+To recover the exact snapshot for a batch at any time, read `begin_snapshot` from
+`ducklake_data_file` for that batch's files.
 
 Never predict this id yourself without the verification step: a lost race commits silently, with
 no error.

--- a/README.md
+++ b/README.md
@@ -561,10 +561,19 @@ row count. Configure under `additional_parameters`:
 | `watermark_max_timestamp_column` | Yes | Destination column for the MAX timestamp |
 | `watermark_row_count_column` | Yes | Destination column for the batch row count |
 | `watermark_group_columns` | No | Comma-separated grouping columns; empty = one global row per batch |
+| `watermark_snapshot_id_column` | No | Destination column for the DuckLake snapshot id the batch committed as |
 
 A malformed spec (partial keys, blanks, typos in `watermark_*` keys) fails at startup rather
 than per batch. Watermarks are not available for queues registered via the dynamic SQLite
 provider, whose registry does not store `additional_parameters`.
+
+`watermark_snapshot_id_column` is written by the same INSERT as the rest of the row, so the
+batch stays a single transaction and a single snapshot. DuckLake does not expose the pending
+snapshot id, but it derives it as `max(snapshot_id) + 1` and enforces it with a primary key, so
+the value is computed up front and is correct unless a concurrent writer takes that id first —
+DuckLake then retries the commit one higher and the rows are repaired after the fact. Never
+predict this id yourself without that verification step: a lost race commits silently, with no
+error.
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -573,19 +573,20 @@ Every watermark row records the DuckLake snapshot its batch committed in, so the
 must carry the column named by `watermark_snapshot_id_column`:
 
 ```sql
-ALTER TABLE my_catalog.main.ingest_watermark ADD COLUMN commit_snapshot_id BIGINT;
+ALTER TABLE my_catalog.main.ingest_watermark ADD COLUMN min_commit_snapshot_id BIGINT;
 ```
 
 The key is **required** whenever a watermark is configured; a spec without it fails at startup.
 The column must be `BIGINT` and nullable — it is written on every insert, but leaving it nullable
 lets an existing table be migrated without a rewrite.
 
-**The value is a lower bound, not an exact id.** The true snapshot is the recorded value or
-higher, never lower. Join with `>=`, not `=`:
+**The value is a lower bound, not an exact id** — hence the `min_` prefix in the suggested column
+name. The true snapshot is the recorded value or higher, never lower, so compare with `>=` / `<=`
+rather than `=`:
 
 ```sql
 -- batches whose data is visible as of snapshot N
-SELECT * FROM ingest_watermark WHERE commit_snapshot_id <= N;
+SELECT * FROM ingest_watermark WHERE min_commit_snapshot_id <= N;
 ```
 
 The bound holds unconditionally. DuckLake assigns the snapshot id at COMMIT and does not expose

--- a/README.md
+++ b/README.md
@@ -561,19 +561,45 @@ row count. Configure under `additional_parameters`:
 | `watermark_max_timestamp_column` | Yes | Destination column for the MAX timestamp |
 | `watermark_row_count_column` | Yes | Destination column for the batch row count |
 | `watermark_group_columns` | No | Comma-separated grouping columns; empty = one global row per batch |
-| `watermark_snapshot_id_column` | No | Destination column for the DuckLake snapshot id the batch committed as |
+| `watermark_snapshot_id_column` | Yes | Destination column for the DuckLake snapshot id the batch commits as |
 
 A malformed spec (partial keys, blanks, typos in `watermark_*` keys) fails at startup rather
 than per batch. Watermarks are not available for queues registered via the dynamic SQLite
 provider, whose registry does not store `additional_parameters`.
 
-`watermark_snapshot_id_column` is written by the same INSERT as the rest of the row, so the
-batch stays a single transaction and a single snapshot. DuckLake does not expose the pending
-snapshot id, but it derives it as `max(snapshot_id) + 1` and enforces it with a primary key, so
-the value is computed up front and is correct unless a concurrent writer takes that id first —
-DuckLake then retries the commit one higher and the rows are repaired after the fact. Never
-predict this id yourself without that verification step: a lost race commits silently, with no
-error.
+### The snapshot id column
+
+Every watermark row records the DuckLake snapshot its batch committed as, so the watermark table
+must carry the column named by `watermark_snapshot_id_column`:
+
+```sql
+ALTER TABLE my_catalog.main.ingest_watermark ADD COLUMN commit_snapshot_id BIGINT;
+```
+
+The key is **required** whenever a watermark is configured; a spec without it fails at startup.
+The column must be `BIGINT` and nullable — it is written on every insert, but leaving it nullable
+lets an existing table be migrated without a rewrite.
+
+The id is written by the same INSERT as the rest of the row, so a batch remains **one transaction
+and one snapshot**. DuckLake does not expose the pending snapshot id — it is assigned at COMMIT —
+but it derives the id as `max(snapshot_id) + 1` and enforces it with a primary key, so the value is
+computed just before the transaction opens and verified immediately afterwards.
+
+What to expect from the recorded value:
+
+- Normally it is exactly the snapshot the batch's data files landed in, and matches
+  `begin_snapshot` in `ducklake_data_file` for those files.
+- If a concurrent writer takes that id first, DuckLake retries the commit one higher **without
+  error**. The committed id is therefore always **greater than or equal to** the predicted one —
+  the value can only ever be under-reported, never ahead. The verification step detects this and
+  repairs the rows.
+- If the process dies between the commit and the verification, the row keeps the under-reported
+  id. That id names a real snapshot belonging to a different writer, so it joins cleanly to the
+  wrong batch rather than failing loudly. Treat the column as authoritative only while ingestion
+  is running normally; to audit it, compare against `begin_snapshot` of the batch's files.
+
+Never predict this id yourself without the verification step: a lost race commits silently, with
+no error.
 
 ## Publishing
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
@@ -11,7 +11,6 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Post-ingestion task that adds newly ingested files to a DuckLake table.
@@ -24,9 +23,9 @@ import java.util.stream.Collectors;
  * registration and watermark commit or roll back together. This task never re-reads the written
  * files.
  *
- * <p>When the spec also sets {@code watermark_snapshot_id_column}, the snapshot id is written by
- * that same INSERT, so it commits with the rows rather than being patched in afterwards. DuckLake
- * does not expose the pending snapshot id, but it derives it as {@code max(snapshot_id) + 1} and
+ * <p>The snapshot id ({@code watermark_snapshot_id_column}) is written by that same INSERT, so it
+ * commits with the rows rather than being patched in afterwards. DuckLake does not expose the
+ * pending snapshot id, but it derives it as {@code max(snapshot_id) + 1} and
  * enforces it with a primary key, so the value can be computed up front (see
  * {@link #predictNextSnapshotId}) and is guaranteed correct unless a competing writer takes the id
  * first — in which case DuckLake retries our commit one higher, and
@@ -91,16 +90,14 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
         List<List<String>> watermarkRows = ingestionResult.watermarkRows();
         boolean hasWatermark = watermarkSpec != null && watermarkRows != null && !watermarkRows.isEmpty();
         try (Connection conn = ConnectionPool.getConnection()) {
-            Long predictedSnapshotId = hasWatermark && watermarkSpec.snapshotIdColumn() != null
-                    ? predictNextSnapshotId(conn)
-                    : null;
-            if (hasWatermark) {
-                queries.add(watermarkSpec.insertSql(catalogName, schemaName, watermarkRows, predictedSnapshotId));
+            if (!hasWatermark) {
+                ConnectionPool.executeBatchInTxn(conn, queries.toArray(String[]::new));
+                return;
             }
+            long predictedSnapshotId = predictNextSnapshotId(conn);
+            queries.add(watermarkSpec.insertSql(catalogName, schemaName, watermarkRows, predictedSnapshotId));
             ConnectionPool.executeBatchInTxn(conn, queries.toArray(String[]::new));
-            if (predictedSnapshotId != null) {
-                verifySnapshotId(conn, files, predictedSnapshotId);
-            }
+            verifySnapshotId(conn, files, predictedSnapshotId);
         }
     }
 
@@ -123,16 +120,23 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
      * if not.
      *
      * <p>The prediction only loses when a competing writer takes the id first: DuckLake then
-     * retries our commit internally at a higher id, transparently and without error. That is rare,
-     * so the common path is a single transaction carrying the correct id; this is the safety net
-     * that keeps a lost race from silently persisting a wrong one.
+     * retries our commit internally at a higher id, transparently and without error.
+     *
+     * <p>The common case is settled without touching {@code ducklake_data_file} at all. The
+     * committed id is always {@code >=} the predicted one, and {@code current_snapshot()} is the
+     * newest id in the catalog, so {@code current == predicted} can only mean our commit took
+     * exactly the predicted id. Only when the catalog has moved further does the file lookup run —
+     * which is also the only case where a repair could be needed.
      *
      * <p>Failures here are logged rather than thrown — the batch is already durable, and failing an
      * ingest that succeeded would be worse than a stale id.
      */
     private void verifySnapshotId(Connection conn, List<String> files, long predicted) {
         try {
-            Long actual = resolveCommittedSnapshotId(conn, files, predicted);
+            if (currentSnapshotId(conn) == predicted) {
+                return;
+            }
+            Long actual = resolveCommittedSnapshotId(conn, files.get(0), predicted);
             if (actual == null || actual == predicted) {
                 return;
             }
@@ -145,28 +149,37 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
         }
     }
 
+    /** Newest snapshot in the catalog, i.e. an upper bound on the id this batch committed as. */
+    private long currentSnapshotId(Connection conn) throws SQLException {
+        try (Statement statement = conn.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                     "SELECT id FROM ducklake_current_snapshot('%s')".formatted(escapeLiteral(catalogName)))) {
+            resultSet.next();
+            return resultSet.getLong("id");
+        }
+    }
+
     /**
-     * The snapshot the just-registered files became visible in. All files of one batch are
-     * registered by a single transaction, so exactly one distinct {@code begin_snapshot} is
-     * expected; anything else means the batch did not commit as one unit and is not stamped.
+     * The snapshot a registered file became visible in. One file is enough: the whole batch is
+     * registered by a single transaction, so every file of it carries the same
+     * {@code begin_snapshot}.
+     *
+     * <p>{@code begin_snapshot >= lowerBound} is free pruning rather than a filter on correctness —
+     * the committed id is always {@code >=} the predicted one, and {@code begin_snapshot} rises with
+     * time, so zone maps skip almost the whole table instead of scanning every path in the catalog.
      */
-    private Long resolveCommittedSnapshotId(Connection conn, List<String> files, long lowerBound) throws SQLException {
-        String paths = files.stream().map(f -> "'" + escapeLiteral(f) + "'").collect(Collectors.joining(", "));
-        // begin_snapshot >= lowerBound is free pruning, not a filter on correctness: the committed id
-        // is always >= the predicted one (DuckLake takes max+1 at commit, and max only grows), and
-        // begin_snapshot rises with time, so this lets zone maps skip nearly the whole table. Without
-        // it this is an unindexed scan of every path in the catalog — 3.4ms vs 0.3ms at 1M files.
-        String query = ("SELECT count(DISTINCT begin_snapshot) AS distinct_snapshots, max(begin_snapshot) AS snapshot_id "
-                + "FROM __ducklake_metadata_%s.ducklake_data_file WHERE begin_snapshot >= %d AND path IN (%s)")
-                .formatted(escapeLiteral(catalogName), lowerBound, paths);
+    private Long resolveCommittedSnapshotId(Connection conn, String file, long lowerBound) throws SQLException {
+        String query = ("SELECT begin_snapshot FROM __ducklake_metadata_%s.ducklake_data_file "
+                + "WHERE begin_snapshot >= %d AND path = '%s'")
+                .formatted(escapeLiteral(catalogName), lowerBound, escapeLiteral(file));
         try (Statement statement = conn.createStatement();
              ResultSet resultSet = statement.executeQuery(query)) {
-            if (!resultSet.next() || resultSet.getLong("distinct_snapshots") != 1) {
-                logger.warn("Expected exactly one snapshot for the {} files registered for queue '{}'; "
-                        + "leaving '{}' NULL", files.size(), ingestionResult.queueName(), watermarkSpec.snapshotIdColumn());
+            if (!resultSet.next()) {
+                logger.warn("Could not locate registered file {} for queue '{}'; leaving '{}' as written",
+                        file, ingestionResult.queueName(), watermarkSpec.snapshotIdColumn());
                 return null;
             }
-            return resultSet.getLong("snapshot_id");
+            return resultSet.getLong("begin_snapshot");
         }
     }
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
@@ -24,12 +24,21 @@ import java.util.Map;
  * files.
  *
  * <p>The snapshot id ({@code watermark_snapshot_id_column}) is written by that same INSERT, so it
- * commits with the rows rather than being patched in afterwards. DuckLake does not expose the
- * pending snapshot id, but it derives it as {@code max(snapshot_id) + 1} and
- * enforces it with a primary key, so the value can be computed up front (see
- * {@link #predictNextSnapshotId}) and is guaranteed correct unless a competing writer takes the id
- * first — in which case DuckLake retries our commit one higher, and
- * {@link #verifySnapshotId} repairs the rows.
+ * commits with the rows rather than being patched in afterwards. DuckLake assigns a snapshot id at
+ * COMMIT and does not expose the pending one, so what is written is
+ * {@code max(snapshot_id) + 1} — the same formula DuckLake uses, read just before the transaction
+ * opens.
+ *
+ * <p><strong>The column is therefore a lower bound, and is specified as one.</strong> The committed
+ * id is always {@code >=} what was written: DuckLake takes {@code max + 1} at commit, {@code max}
+ * only ever grows (even aggressive snapshot expiry retains the newest snapshot and ids are never
+ * reused), and a competing writer that takes the id first only pushes our commit higher. So the
+ * recorded value can be stale but never ahead of the truth, whatever happens — including a crash
+ * between the commit and the verification below.
+ *
+ * <p>{@link #verifySnapshotId} then tightens the bound to the exact snapshot, which is the normal
+ * outcome. That step is an accuracy improvement, not a correctness requirement: if it is skipped or
+ * fails, the column still satisfies its contract.
  *
  * <p>Limitation: queues registered through the dynamic SQLite registry
  * ({@link DynamicQueueRepository}) do not carry {@code additional_parameters}, so watermarks are

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
@@ -125,46 +125,30 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
     }
 
     /**
-     * Confirms the transaction actually committed as the predicted snapshot, and repairs the rows
-     * if not.
+     * Tightens the recorded lower bound to the exact snapshot the batch committed in.
      *
-     * <p>The prediction only loses when a competing writer takes the id first: DuckLake then
-     * retries our commit internally at a higher id, transparently and without error.
+     * <p>One query settles it: the file we just registered carries the committed id in its
+     * {@code begin_snapshot}. A cheaper pre-check was tried and removed — both a global
+     * {@code current_snapshot()} and a per-table high-water mark cost about as much as this lookup
+     * (0.15-0.21ms vs 0.16ms at 1M files), and when either says "something moved" this query still
+     * has to run. One unconditional exact lookup is simpler and no slower.
      *
-     * <p>The common case is settled without touching {@code ducklake_data_file} at all. The
-     * committed id is always {@code >=} the predicted one, and {@code current_snapshot()} is the
-     * newest id in the catalog, so {@code current == predicted} can only mean our commit took
-     * exactly the predicted id. Only when the catalog has moved further does the file lookup run —
-     * which is also the only case where a repair could be needed.
-     *
-     * <p>Failures here are logged rather than thrown — the batch is already durable, and failing an
-     * ingest that succeeded would be worse than a stale id.
+     * <p>Failures here are logged rather than thrown. The batch is already durable, and the column
+     * is specified as a lower bound, so a skipped repair leaves a value that is merely loose rather
+     * than wrong — whereas failing an ingest that succeeded would be a real loss.
      */
     private void verifySnapshotId(Connection conn, List<String> files, long predicted) {
         try {
-            if (currentSnapshotId(conn) == predicted) {
-                return;
-            }
             Long actual = resolveCommittedSnapshotId(conn, files.get(0), predicted);
             if (actual == null || actual == predicted) {
                 return;
             }
             logger.info("Queue '{}' committed as snapshot {} rather than the predicted {} (a concurrent "
-                    + "writer took the id); correcting the watermark rows", ingestionResult.queueName(), actual, predicted);
+                    + "writer took the id); tightening the watermark rows", ingestionResult.queueName(), actual, predicted);
             ConnectionPool.execute(conn, watermarkSpec.updateSnapshotIdSql(catalogName, schemaName, actual));
         } catch (Exception e) {
-            logger.warn("Could not verify the snapshot id written to {}.{}.{}; rows may carry the predicted {} "
-                    + "instead of the committed id", catalogName, schemaName, watermarkSpec.table(), predicted, e);
-        }
-    }
-
-    /** Newest snapshot in the catalog, i.e. an upper bound on the id this batch committed as. */
-    private long currentSnapshotId(Connection conn) throws SQLException {
-        try (Statement statement = conn.createStatement();
-             ResultSet resultSet = statement.executeQuery(
-                     "SELECT id FROM ducklake_current_snapshot('%s')".formatted(escapeLiteral(catalogName)))) {
-            resultSet.next();
-            return resultSet.getLong("id");
+            logger.warn("Could not tighten the snapshot id written to {}.{}.{}; rows keep the lower bound {}",
+                    catalogName, schemaName, watermarkSpec.table(), predicted, e);
         }
     }
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/DuckLakePostIngestionTask.java
@@ -5,10 +5,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Post-ingestion task that adds newly ingested files to a DuckLake table.
@@ -20,6 +23,14 @@ import java.util.Map;
  * to the watermark table via a plain {@code INSERT ... VALUES} in the SAME transaction, so file
  * registration and watermark commit or roll back together. This task never re-reads the written
  * files.
+ *
+ * <p>When the spec also sets {@code watermark_snapshot_id_column}, the snapshot id is written by
+ * that same INSERT, so it commits with the rows rather than being patched in afterwards. DuckLake
+ * does not expose the pending snapshot id, but it derives it as {@code max(snapshot_id) + 1} and
+ * enforces it with a primary key, so the value can be computed up front (see
+ * {@link #predictNextSnapshotId}) and is guaranteed correct unless a competing writer takes the id
+ * first — in which case DuckLake retries our commit one higher, and
+ * {@link #verifySnapshotId} repairs the rows.
  *
  * <p>Limitation: queues registered through the dynamic SQLite registry
  * ({@link DynamicQueueRepository}) do not carry {@code additional_parameters}, so watermarks are
@@ -78,11 +89,84 @@ public class DuckLakePostIngestionTask implements PostIngestionTask {
                         escapeLiteral(catalogName), escapeLiteral(tableName), escapeLiteral(file), escapeLiteral(schemaName)))
                 .toList());
         List<List<String>> watermarkRows = ingestionResult.watermarkRows();
-        if (watermarkSpec != null && watermarkRows != null && !watermarkRows.isEmpty()) {
-            queries.add(watermarkSpec.insertSql(catalogName, schemaName, watermarkRows));
-        }
+        boolean hasWatermark = watermarkSpec != null && watermarkRows != null && !watermarkRows.isEmpty();
         try (Connection conn = ConnectionPool.getConnection()) {
+            Long predictedSnapshotId = hasWatermark && watermarkSpec.snapshotIdColumn() != null
+                    ? predictNextSnapshotId(conn)
+                    : null;
+            if (hasWatermark) {
+                queries.add(watermarkSpec.insertSql(catalogName, schemaName, watermarkRows, predictedSnapshotId));
+            }
             ConnectionPool.executeBatchInTxn(conn, queries.toArray(String[]::new));
+            if (predictedSnapshotId != null) {
+                verifySnapshotId(conn, files, predictedSnapshotId);
+            }
+        }
+    }
+
+    /**
+     * The id this transaction will commit as, barring a competing writer: DuckLake derives the next
+     * snapshot id the same way and enforces it with a primary key on {@code ducklake_snapshot}.
+     */
+    private long predictNextSnapshotId(Connection conn) throws SQLException {
+        String query = "SELECT coalesce(max(snapshot_id), -1) + 1 AS next_id FROM __ducklake_metadata_%s.ducklake_snapshot"
+                .formatted(escapeLiteral(catalogName));
+        try (Statement statement = conn.createStatement();
+             ResultSet resultSet = statement.executeQuery(query)) {
+            resultSet.next();
+            return resultSet.getLong("next_id");
+        }
+    }
+
+    /**
+     * Confirms the transaction actually committed as the predicted snapshot, and repairs the rows
+     * if not.
+     *
+     * <p>The prediction only loses when a competing writer takes the id first: DuckLake then
+     * retries our commit internally at a higher id, transparently and without error. That is rare,
+     * so the common path is a single transaction carrying the correct id; this is the safety net
+     * that keeps a lost race from silently persisting a wrong one.
+     *
+     * <p>Failures here are logged rather than thrown — the batch is already durable, and failing an
+     * ingest that succeeded would be worse than a stale id.
+     */
+    private void verifySnapshotId(Connection conn, List<String> files, long predicted) {
+        try {
+            Long actual = resolveCommittedSnapshotId(conn, files, predicted);
+            if (actual == null || actual == predicted) {
+                return;
+            }
+            logger.info("Queue '{}' committed as snapshot {} rather than the predicted {} (a concurrent "
+                    + "writer took the id); correcting the watermark rows", ingestionResult.queueName(), actual, predicted);
+            ConnectionPool.execute(conn, watermarkSpec.updateSnapshotIdSql(catalogName, schemaName, actual));
+        } catch (Exception e) {
+            logger.warn("Could not verify the snapshot id written to {}.{}.{}; rows may carry the predicted {} "
+                    + "instead of the committed id", catalogName, schemaName, watermarkSpec.table(), predicted, e);
+        }
+    }
+
+    /**
+     * The snapshot the just-registered files became visible in. All files of one batch are
+     * registered by a single transaction, so exactly one distinct {@code begin_snapshot} is
+     * expected; anything else means the batch did not commit as one unit and is not stamped.
+     */
+    private Long resolveCommittedSnapshotId(Connection conn, List<String> files, long lowerBound) throws SQLException {
+        String paths = files.stream().map(f -> "'" + escapeLiteral(f) + "'").collect(Collectors.joining(", "));
+        // begin_snapshot >= lowerBound is free pruning, not a filter on correctness: the committed id
+        // is always >= the predicted one (DuckLake takes max+1 at commit, and max only grows), and
+        // begin_snapshot rises with time, so this lets zone maps skip nearly the whole table. Without
+        // it this is an unindexed scan of every path in the catalog — 3.4ms vs 0.3ms at 1M files.
+        String query = ("SELECT count(DISTINCT begin_snapshot) AS distinct_snapshots, max(begin_snapshot) AS snapshot_id "
+                + "FROM __ducklake_metadata_%s.ducklake_data_file WHERE begin_snapshot >= %d AND path IN (%s)")
+                .formatted(escapeLiteral(catalogName), lowerBound, paths);
+        try (Statement statement = conn.createStatement();
+             ResultSet resultSet = statement.executeQuery(query)) {
+            if (!resultSet.next() || resultSet.getLong("distinct_snapshots") != 1) {
+                logger.warn("Expected exactly one snapshot for the {} files registered for queue '{}'; "
+                        + "leaving '{}' NULL", files.size(), ingestionResult.queueName(), watermarkSpec.snapshotIdColumn());
+                return null;
+            }
+            return resultSet.getLong("snapshot_id");
         }
     }
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
@@ -27,8 +27,9 @@ import java.util.stream.Collectors;
  *       column the MAX lands in.</li>
  *   <li>{@code watermark_row_count_column} — required when the table is set; receives
  *       {@code COUNT(*)} for the group.</li>
- *   <li>{@code watermark_snapshot_id_column} — optional; receives the DuckLake snapshot id the
- *       batch commits as, written by the same INSERT as the rest of the row. Omit to skip it.</li>
+ *   <li>{@code watermark_snapshot_id_column} — required when the table is set; receives the
+ *       DuckLake snapshot id the batch commits as, written by the same INSERT as the rest of the
+ *       row.</li>
  * </ul>
  *
  * <p>A group whose timestamps are all NULL still produces a row: NULL min and max, with the real
@@ -70,16 +71,7 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
         requireNonBlank(minTimestampColumn, MIN_TIMESTAMP_COLUMN_KEY);
         requireNonBlank(maxTimestampColumn, MAX_TIMESTAMP_COLUMN_KEY);
         requireNonBlank(rowCountColumn, ROW_COUNT_COLUMN_KEY);
-        // Optional: absent means the snapshot id is simply not recorded.
-        if (snapshotIdColumn != null) {
-            requireNonBlank(snapshotIdColumn, SNAPSHOT_ID_COLUMN_KEY);
-        }
-    }
-
-    /** Spec without a snapshot-id column. */
-    public WatermarkSpec(String table, String timestampColumn, List<String> groupColumns,
-                         String minTimestampColumn, String maxTimestampColumn, String rowCountColumn) {
-        this(table, timestampColumn, groupColumns, minTimestampColumn, maxTimestampColumn, rowCountColumn, null);
+        requireNonBlank(snapshotIdColumn, SNAPSHOT_ID_COLUMN_KEY);
     }
 
     /**
@@ -104,19 +96,19 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
         String minTimestampColumn = parameters.get(MIN_TIMESTAMP_COLUMN_KEY);
         String maxTimestampColumn = parameters.get(MAX_TIMESTAMP_COLUMN_KEY);
         String rowCountColumn = parameters.get(ROW_COUNT_COLUMN_KEY);
-        if (isBlank(table) || isBlank(timestampColumn) || isBlank(minTimestampColumn)
-                || isBlank(maxTimestampColumn) || isBlank(rowCountColumn)) {
-            throw new IllegalArgumentException(
-                    "Queue '%s': watermark configuration requires non-blank '%s', '%s', '%s', '%s' and '%s'"
-                            .formatted(queueName, TABLE_KEY, TIMESTAMP_COLUMN_KEY, MIN_TIMESTAMP_COLUMN_KEY,
-                                    MAX_TIMESTAMP_COLUMN_KEY, ROW_COUNT_COLUMN_KEY));
-        }
         String snapshotIdColumn = parameters.get(SNAPSHOT_ID_COLUMN_KEY);
+        if (isBlank(table) || isBlank(timestampColumn) || isBlank(minTimestampColumn)
+                || isBlank(maxTimestampColumn) || isBlank(rowCountColumn) || isBlank(snapshotIdColumn)) {
+            throw new IllegalArgumentException(
+                    "Queue '%s': watermark configuration requires non-blank '%s', '%s', '%s', '%s', '%s' and '%s'"
+                            .formatted(queueName, TABLE_KEY, TIMESTAMP_COLUMN_KEY, MIN_TIMESTAMP_COLUMN_KEY,
+                                    MAX_TIMESTAMP_COLUMN_KEY, ROW_COUNT_COLUMN_KEY, SNAPSHOT_ID_COLUMN_KEY));
+        }
         try {
             return new WatermarkSpec(table.trim(), timestampColumn.trim(),
                     parseGroupColumns(parameters.get(GROUP_COLUMNS_KEY)),
                     minTimestampColumn.trim(), maxTimestampColumn.trim(), rowCountColumn.trim(),
-                    snapshotIdColumn == null ? null : snapshotIdColumn.trim());
+                    snapshotIdColumn.trim());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Queue '%s': %s".formatted(queueName, e.getMessage()), e);
         }
@@ -192,16 +184,11 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
 
     /**
      * Renders the INSERT appending precomputed watermark rows — explicit quoted column list
-     * (group columns then timestamp column), values as escaped string literals relying on
-     * DuckDB's implicit cast to the table's column types.
-     */
-    public String insertSql(String catalog, String schema, List<List<String>> rows) {
-        return insertSql(catalog, schema, rows, null);
-    }
-
-    /**
-     * As {@link #insertSql(String, String, List)}, additionally writing {@code snapshotId} into
-     * {@link #snapshotIdColumn} so the snapshot lands in the SAME transaction as the rows.
+     * (group columns, the timestamp columns, the row count, then {@link #snapshotIdColumn}), values
+     * as escaped string literals relying on DuckDB's implicit cast to the table's column types.
+     *
+     * <p>The snapshot id is written here, in the SAME transaction as the rows, rather than patched
+     * in afterwards.
      *
      * <p>{@code snapshotId} is the id the transaction is predicted to commit as
      * ({@code max(snapshot_id) + 1}). DuckLake does not expose the pending id, but it derives the
@@ -211,16 +198,13 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
      * one higher; {@code DuckLakePostIngestionTask} verifies the committed id afterwards and
      * repairs the rows on the rare occasion they disagree.
      */
-    public String insertSql(String catalog, String schema, List<List<String>> rows, Long snapshotId) {
-        boolean withSnapshot = snapshotIdColumn != null && snapshotId != null;
+    public String insertSql(String catalog, String schema, List<List<String>> rows, long snapshotId) {
         String columnList = groupColumns.stream().map(HeaderUtils::quoteIdentifier).collect(Collectors.joining(", "));
         columnList = (columnList.isEmpty() ? "" : columnList + ", ") + HeaderUtils.quoteIdentifier(minTimestampColumn);
         columnList += ", " + HeaderUtils.quoteIdentifier(maxTimestampColumn)
                 + ", " + HeaderUtils.quoteIdentifier(rowCountColumn);
-        if (withSnapshot) {
-            columnList += ", " + HeaderUtils.quoteIdentifier(snapshotIdColumn);
-        }
-        String suffix = withSnapshot ? ", " + snapshotId : "";
+        columnList += ", " + HeaderUtils.quoteIdentifier(snapshotIdColumn);
+        String suffix = ", " + snapshotId;
         String values = rows.stream()
                 .map(row -> row.stream().map(WatermarkSpec::literal).collect(Collectors.joining(", ", "(", suffix + ")")))
                 .collect(Collectors.joining(", "));

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
  *       column the MAX lands in.</li>
  *   <li>{@code watermark_row_count_column} — required when the table is set; receives
  *       {@code COUNT(*)} for the group.</li>
+ *   <li>{@code watermark_snapshot_id_column} — optional; receives the DuckLake snapshot id the
+ *       batch commits as, written by the same INSERT as the rest of the row. Omit to skip it.</li>
  * </ul>
  *
  * <p>A group whose timestamps are all NULL still produces a row: NULL min and max, with the real
@@ -46,7 +48,8 @@ import java.util.stream.Collectors;
  * unknown {@code watermark_}-prefixed keys are rejected to surface typos.
  */
 public record WatermarkSpec(String table, String timestampColumn, List<String> groupColumns,
-                            String minTimestampColumn, String maxTimestampColumn, String rowCountColumn) {
+                            String minTimestampColumn, String maxTimestampColumn, String rowCountColumn,
+                            String snapshotIdColumn) {
 
     public static final String TABLE_KEY = "watermark_table";
     public static final String TIMESTAMP_COLUMN_KEY = "watermark_timestamp_column";
@@ -54,9 +57,10 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
     public static final String MIN_TIMESTAMP_COLUMN_KEY = "watermark_min_timestamp_column";
     public static final String MAX_TIMESTAMP_COLUMN_KEY = "watermark_max_timestamp_column";
     public static final String ROW_COUNT_COLUMN_KEY = "watermark_row_count_column";
+    public static final String SNAPSHOT_ID_COLUMN_KEY = "watermark_snapshot_id_column";
 
     private static final List<String> KNOWN_KEYS = List.of(TABLE_KEY, TIMESTAMP_COLUMN_KEY, GROUP_COLUMNS_KEY,
-            MIN_TIMESTAMP_COLUMN_KEY, MAX_TIMESTAMP_COLUMN_KEY, ROW_COUNT_COLUMN_KEY);
+            MIN_TIMESTAMP_COLUMN_KEY, MAX_TIMESTAMP_COLUMN_KEY, ROW_COUNT_COLUMN_KEY, SNAPSHOT_ID_COLUMN_KEY);
 
     public WatermarkSpec {
         requireNonBlank(table, TABLE_KEY);
@@ -66,6 +70,16 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
         requireNonBlank(minTimestampColumn, MIN_TIMESTAMP_COLUMN_KEY);
         requireNonBlank(maxTimestampColumn, MAX_TIMESTAMP_COLUMN_KEY);
         requireNonBlank(rowCountColumn, ROW_COUNT_COLUMN_KEY);
+        // Optional: absent means the snapshot id is simply not recorded.
+        if (snapshotIdColumn != null) {
+            requireNonBlank(snapshotIdColumn, SNAPSHOT_ID_COLUMN_KEY);
+        }
+    }
+
+    /** Spec without a snapshot-id column. */
+    public WatermarkSpec(String table, String timestampColumn, List<String> groupColumns,
+                         String minTimestampColumn, String maxTimestampColumn, String rowCountColumn) {
+        this(table, timestampColumn, groupColumns, minTimestampColumn, maxTimestampColumn, rowCountColumn, null);
     }
 
     /**
@@ -97,10 +111,12 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
                             .formatted(queueName, TABLE_KEY, TIMESTAMP_COLUMN_KEY, MIN_TIMESTAMP_COLUMN_KEY,
                                     MAX_TIMESTAMP_COLUMN_KEY, ROW_COUNT_COLUMN_KEY));
         }
+        String snapshotIdColumn = parameters.get(SNAPSHOT_ID_COLUMN_KEY);
         try {
             return new WatermarkSpec(table.trim(), timestampColumn.trim(),
                     parseGroupColumns(parameters.get(GROUP_COLUMNS_KEY)),
-                    minTimestampColumn.trim(), maxTimestampColumn.trim(), rowCountColumn.trim());
+                    minTimestampColumn.trim(), maxTimestampColumn.trim(), rowCountColumn.trim(),
+                    snapshotIdColumn == null ? null : snapshotIdColumn.trim());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Queue '%s': %s".formatted(queueName, e.getMessage()), e);
         }
@@ -180,16 +196,61 @@ public record WatermarkSpec(String table, String timestampColumn, List<String> g
      * DuckDB's implicit cast to the table's column types.
      */
     public String insertSql(String catalog, String schema, List<List<String>> rows) {
+        return insertSql(catalog, schema, rows, null);
+    }
+
+    /**
+     * As {@link #insertSql(String, String, List)}, additionally writing {@code snapshotId} into
+     * {@link #snapshotIdColumn} so the snapshot lands in the SAME transaction as the rows.
+     *
+     * <p>{@code snapshotId} is the id the transaction is predicted to commit as
+     * ({@code max(snapshot_id) + 1}). DuckLake does not expose the pending id, but it derives the
+     * same value and enforces it with a primary key on {@code ducklake_snapshot} — so a commit that
+     * succeeds unopposed carries exactly this id. It is a prediction only in the sense that a
+     * competing writer can take the id first, in which case DuckLake's internal retry commits us
+     * one higher; {@code DuckLakePostIngestionTask} verifies the committed id afterwards and
+     * repairs the rows on the rare occasion they disagree.
+     */
+    public String insertSql(String catalog, String schema, List<List<String>> rows, Long snapshotId) {
+        boolean withSnapshot = snapshotIdColumn != null && snapshotId != null;
         String columnList = groupColumns.stream().map(HeaderUtils::quoteIdentifier).collect(Collectors.joining(", "));
         columnList = (columnList.isEmpty() ? "" : columnList + ", ") + HeaderUtils.quoteIdentifier(minTimestampColumn);
         columnList += ", " + HeaderUtils.quoteIdentifier(maxTimestampColumn)
                 + ", " + HeaderUtils.quoteIdentifier(rowCountColumn);
+        if (withSnapshot) {
+            columnList += ", " + HeaderUtils.quoteIdentifier(snapshotIdColumn);
+        }
+        String suffix = withSnapshot ? ", " + snapshotId : "";
         String values = rows.stream()
-                .map(row -> row.stream().map(WatermarkSpec::literal).collect(Collectors.joining(", ", "(", ")")))
+                .map(row -> row.stream().map(WatermarkSpec::literal).collect(Collectors.joining(", ", "(", suffix + ")")))
                 .collect(Collectors.joining(", "));
         return "INSERT INTO %s.%s.%s (%s) VALUES %s".formatted(
                 HeaderUtils.quoteIdentifier(catalog), HeaderUtils.quoteIdentifier(schema),
                 HeaderUtils.quoteIdentifier(table), columnList, values);
+    }
+
+    /**
+     * Renders the post-commit UPDATE stamping {@link #snapshotIdColumn} onto exactly the rows this
+     * batch inserted.
+     *
+     * <p>The rows are identified by DuckLake's stable {@code rowid}, read back from
+     * {@code ducklake_table_insertions} for the one snapshot the batch committed as. The two
+     * obvious alternatives are both wrong: watermark rows carry no key, so matching on values
+     * cannot distinguish two batches that aggregate identically, and {@code snapshot_id IS NULL}
+     * would stamp rows belonging to a concurrent queue's in-flight batch on the same table.
+     *
+     * <p>The id cannot be written by {@link #insertSql} instead: DuckLake only assigns a snapshot
+     * id at COMMIT, so inside the ingest transaction it does not yet exist.
+     */
+    public String updateSnapshotIdSql(String catalog, String schema, long snapshotId) {
+        return "UPDATE %s.%s.%s SET %s = %d WHERE rowid IN (SELECT rowid FROM ducklake_table_insertions('%s', '%s', '%s', %d, %d))"
+                .formatted(HeaderUtils.quoteIdentifier(catalog), HeaderUtils.quoteIdentifier(schema),
+                        HeaderUtils.quoteIdentifier(table), HeaderUtils.quoteIdentifier(snapshotIdColumn), snapshotId,
+                        escapeLiteral(catalog), escapeLiteral(schema), escapeLiteral(table), snapshotId, snapshotId);
+    }
+
+    private static String escapeLiteral(String value) {
+        return value.replace("'", "''");
     }
 
     /** Group columns plus the three aggregates: MIN timestamp, MAX timestamp, row count. */

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpec.java
@@ -27,9 +27,10 @@ import java.util.stream.Collectors;
  *       column the MAX lands in.</li>
  *   <li>{@code watermark_row_count_column} — required when the table is set; receives
  *       {@code COUNT(*)} for the group.</li>
- *   <li>{@code watermark_snapshot_id_column} — required when the table is set; receives the
- *       DuckLake snapshot id the batch commits as, written by the same INSERT as the rest of the
- *       row.</li>
+ *   <li>{@code watermark_snapshot_id_column} — required when the table is set; receives a LOWER
+ *       BOUND on the DuckLake snapshot the batch committed in, written by the same INSERT as the
+ *       rest of the row. The true snapshot is this value or higher, never lower — see
+ *       {@link DuckLakePostIngestionTask} for why. Consumers must join with {@code >=}.</li>
  * </ul>
  *
  * <p>A group whose timestamps are all NULL still produces a row: NULL min and max, with the real

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
@@ -35,7 +35,7 @@ class DuckLakeWatermarkPostIngestionTest {
                     "ATTACH 'ducklake:%s' AS %s (DATA_PATH '%s')".formatted(
                             tempDir.resolve("catalog"), CATALOG, tempDir.resolve("data")),
                     "CREATE TABLE %s.main.facts (county VARCHAR, state VARCHAR, ts TIMESTAMP, v DOUBLE)".formatted(CATALOG),
-                    "CREATE TABLE %s.main.ingest_watermark (county VARCHAR, state VARCHAR, min_ts TIMESTAMP, max_ts TIMESTAMP, row_count BIGINT, commit_snapshot_id BIGINT)".formatted(CATALOG)
+                    "CREATE TABLE %s.main.ingest_watermark (county VARCHAR, state VARCHAR, min_ts TIMESTAMP, max_ts TIMESTAMP, row_count BIGINT, min_commit_snapshot_id BIGINT)".formatted(CATALOG)
             });
         }
     }
@@ -64,7 +64,7 @@ class DuckLakeWatermarkPostIngestionTest {
         return List.of(f1, f2);
     }
 
-    private static final WatermarkSpec SPEC = new WatermarkSpec("ingest_watermark", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "commit_snapshot_id");
+    private static final WatermarkSpec SPEC = new WatermarkSpec("ingest_watermark", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "min_commit_snapshot_id");
 
     private static Map<String, String> watermarkParams(String table) {
         return Map.of(
@@ -74,7 +74,7 @@ class DuckLakeWatermarkPostIngestionTest {
                 WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
                 WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
                 WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count",
-                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "commit_snapshot_id");
+                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "min_commit_snapshot_id");
     }
 
     /** Computes the rows the way ParquetIngestionQueue does at write time: over the source relation. */
@@ -205,11 +205,11 @@ class DuckLakeWatermarkPostIngestionTest {
         try (Connection conn = ConnectionPool.getConnection()) {
             // every watermark row is stamped — no NULL left behind
             assertEquals(List.of("0"), collect(conn,
-                    "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NULL".formatted(CATALOG)));
+                    "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE min_commit_snapshot_id IS NULL".formatted(CATALOG)));
             // and the value is exactly the snapshot the data files became visible in
             assertEquals(List.of("1"), collect(conn, ("""
-                    SELECT count(DISTINCT commit_snapshot_id)::VARCHAR AS r FROM (
-                      SELECT commit_snapshot_id FROM %s.main.ingest_watermark
+                    SELECT count(DISTINCT min_commit_snapshot_id)::VARCHAR AS r FROM (
+                      SELECT min_commit_snapshot_id FROM %s.main.ingest_watermark
                       UNION
                       SELECT DISTINCT begin_snapshot FROM __ducklake_metadata_%s.ducklake_data_file
                       WHERE path IN ('%s', '%s'))""")
@@ -231,13 +231,13 @@ class DuckLakeWatermarkPostIngestionTest {
         try (Connection conn = ConnectionPool.getConnection()) {
             // two batches, two rows, two different snapshots — the first was not re-stamped
             assertEquals(List.of("2"), collect(conn,
-                    "SELECT count(DISTINCT commit_snapshot_id)::VARCHAR AS r FROM %s.main.ingest_watermark".formatted(CATALOG)));
+                    "SELECT count(DISTINCT min_commit_snapshot_id)::VARCHAR AS r FROM %s.main.ingest_watermark".formatted(CATALOG)));
             assertEquals(List.of("0"), collect(conn,
-                    "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NULL".formatted(CATALOG)));
+                    "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE min_commit_snapshot_id IS NULL".formatted(CATALOG)));
             // each row carries the snapshot of its own file
             assertEquals(List.of("king", "pierce"), collect(conn, ("""
                     SELECT w.county AS r FROM %s.main.ingest_watermark w
-                    JOIN __ducklake_metadata_%s.ducklake_data_file f ON f.begin_snapshot = w.commit_snapshot_id
+                    JOIN __ducklake_metadata_%s.ducklake_data_file f ON f.begin_snapshot = w.min_commit_snapshot_id
                     ORDER BY w.county""").formatted(CATALOG, CATALOG)));
         }
     }
@@ -246,13 +246,13 @@ class DuckLakeWatermarkPostIngestionTest {
      * The stamping must touch only the rows of its own batch. A pre-existing unstamped row — a
      * concurrent queue's in-flight batch on a shared watermark table, or a row from before the
      * column was added — must be left alone. This is precisely what rowid scoping buys over a
-     * blanket {@code WHERE commit_snapshot_id IS NULL}, which would sweep the stray row up too.
+     * blanket {@code WHERE min_commit_snapshot_id IS NULL}, which would sweep the stray row up too.
      */
     @Test
     void aStrayUnstampedRowIsNotClaimedByThisBatch() throws Exception {
         try (Connection conn = ConnectionPool.getConnection()) {
             ConnectionPool.execute(conn, ("INSERT INTO %s.main.ingest_watermark "
-                    + "(county, state, min_ts, max_ts, row_count, commit_snapshot_id) VALUES "
+                    + "(county, state, min_ts, max_ts, row_count, min_commit_snapshot_id) VALUES "
                     + "('stray', 'zz', TIMESTAMP '2026-01-01 00:00', TIMESTAMP '2026-01-01 00:00', 7, NULL)")
                     .formatted(CATALOG));
         }
@@ -264,10 +264,10 @@ class DuckLakeWatermarkPostIngestionTest {
         try (Connection conn = ConnectionPool.getConnection()) {
             // the stray row is still NULL; only this batch's 3 rows were stamped
             assertEquals(List.of("stray"), collect(conn,
-                    ("SELECT county AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NULL")
+                    ("SELECT county AS r FROM %s.main.ingest_watermark WHERE min_commit_snapshot_id IS NULL")
                             .formatted(CATALOG)));
             assertEquals(List.of("3"), collect(conn,
-                    ("SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NOT NULL")
+                    ("SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE min_commit_snapshot_id IS NOT NULL")
                             .formatted(CATALOG)));
         }
     }
@@ -294,7 +294,7 @@ class DuckLakeWatermarkPostIngestionTest {
             assertEquals(1, after - before, "ingest must advance the catalog by exactly one snapshot");
             // and that single snapshot is the one recorded on the rows
             assertEquals(List.of(String.valueOf(after)), collect(conn,
-                    "SELECT DISTINCT commit_snapshot_id::VARCHAR AS r FROM %s.main.ingest_watermark".formatted(CATALOG)));
+                    "SELECT DISTINCT min_commit_snapshot_id::VARCHAR AS r FROM %s.main.ingest_watermark".formatted(CATALOG)));
         }
     }
 

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * DuckLakePostIngestionTask's watermark append: watermark rows are precomputed at write time
@@ -34,7 +35,7 @@ class DuckLakeWatermarkPostIngestionTest {
                     "ATTACH 'ducklake:%s' AS %s (DATA_PATH '%s')".formatted(
                             tempDir.resolve("catalog"), CATALOG, tempDir.resolve("data")),
                     "CREATE TABLE %s.main.facts (county VARCHAR, state VARCHAR, ts TIMESTAMP, v DOUBLE)".formatted(CATALOG),
-                    "CREATE TABLE %s.main.ingest_watermark (county VARCHAR, state VARCHAR, min_ts TIMESTAMP, max_ts TIMESTAMP, row_count BIGINT)".formatted(CATALOG)
+                    "CREATE TABLE %s.main.ingest_watermark (county VARCHAR, state VARCHAR, min_ts TIMESTAMP, max_ts TIMESTAMP, row_count BIGINT, commit_snapshot_id BIGINT)".formatted(CATALOG)
             });
         }
     }
@@ -63,7 +64,7 @@ class DuckLakeWatermarkPostIngestionTest {
         return List.of(f1, f2);
     }
 
-    private static final WatermarkSpec SPEC = new WatermarkSpec("ingest_watermark", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count");
+    private static final WatermarkSpec SPEC = new WatermarkSpec("ingest_watermark", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "commit_snapshot_id");
 
     private static Map<String, String> watermarkParams(String table) {
         return Map.of(
@@ -72,7 +73,8 @@ class DuckLakeWatermarkPostIngestionTest {
                 WatermarkSpec.GROUP_COLUMNS_KEY, "county, state",
                 WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
                 WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
-                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count");
+                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count",
+                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "commit_snapshot_id");
     }
 
     /** Computes the rows the way ParquetIngestionQueue does at write time: over the source relation. */
@@ -175,19 +177,6 @@ class DuckLakeWatermarkPostIngestionTest {
 
     // ── watermark_snapshot_id_column ────────────────────────────────────────
 
-    private static Map<String, String> watermarkParamsWithSnapshot(String table) {
-        Map<String, String> params = new java.util.HashMap<>(watermarkParams(table));
-        params.put(WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "commit_snapshot_id");
-        return Map.copyOf(params);
-    }
-
-    private void addSnapshotIdColumn() throws Exception {
-        try (Connection conn = ConnectionPool.getConnection()) {
-            ConnectionPool.execute(conn,
-                    "ALTER TABLE %s.main.ingest_watermark ADD COLUMN commit_snapshot_id BIGINT".formatted(CATALOG));
-        }
-    }
-
     /** One file with a single row, so a batch can be run more than once with distinct files. */
     private List<String> writeSingleFile(String name, String county) throws Exception {
         String f = tempDir.resolve(name).toString();
@@ -208,11 +197,10 @@ class DuckLakeWatermarkPostIngestionTest {
 
     @Test
     void stampsTheSnapshotTheFilesWereRegisteredIn() throws Exception {
-        addSnapshotIdColumn();
         List<String> files = writeBatchFiles();
         List<List<String>> rows = computeRows(files);
         new DuckLakePostIngestionTask(result(files, rows), CATALOG, "facts", "main",
-                watermarkParamsWithSnapshot("ingest_watermark")).execute();
+                watermarkParams("ingest_watermark")).execute();
 
         try (Connection conn = ConnectionPool.getConnection()) {
             // every watermark row is stamped — no NULL left behind
@@ -232,8 +220,7 @@ class DuckLakeWatermarkPostIngestionTest {
     /** Consecutive batches each land on their own snapshot rather than sharing or overwriting one. */
     @Test
     void eachBatchIsStampedWithItsOwnSnapshot() throws Exception {
-        addSnapshotIdColumn();
-        Map<String, String> params = watermarkParamsWithSnapshot("ingest_watermark");
+        Map<String, String> params = watermarkParams("ingest_watermark");
 
         List<String> first = writeSingleFile("s1.parquet", "king");
         new DuckLakePostIngestionTask(result(first, computeRowsFor(first)), CATALOG, "facts", "main", params).execute();
@@ -263,7 +250,6 @@ class DuckLakeWatermarkPostIngestionTest {
      */
     @Test
     void aStrayUnstampedRowIsNotClaimedByThisBatch() throws Exception {
-        addSnapshotIdColumn();
         try (Connection conn = ConnectionPool.getConnection()) {
             ConnectionPool.execute(conn, ("INSERT INTO %s.main.ingest_watermark "
                     + "(county, state, min_ts, max_ts, row_count, commit_snapshot_id) VALUES "
@@ -273,7 +259,7 @@ class DuckLakeWatermarkPostIngestionTest {
 
         List<String> files = writeBatchFiles();
         new DuckLakePostIngestionTask(result(files, computeRows(files)), CATALOG, "facts", "main",
-                watermarkParamsWithSnapshot("ingest_watermark")).execute();
+                watermarkParams("ingest_watermark")).execute();
 
         try (Connection conn = ConnectionPool.getConnection()) {
             // the stray row is still NULL; only this batch's 3 rows were stamped
@@ -292,7 +278,6 @@ class DuckLakeWatermarkPostIngestionTest {
      */
     @Test
     void theWholeBatchIncludingTheSnapshotIdIsASingleSnapshot() throws Exception {
-        addSnapshotIdColumn();
         long before;
         try (Connection conn = ConnectionPool.getConnection()) {
             before = Long.parseLong(collect(conn,
@@ -301,7 +286,7 @@ class DuckLakeWatermarkPostIngestionTest {
 
         List<String> files = writeBatchFiles();
         new DuckLakePostIngestionTask(result(files, computeRows(files)), CATALOG, "facts", "main",
-                watermarkParamsWithSnapshot("ingest_watermark")).execute();
+                watermarkParams("ingest_watermark")).execute();
 
         try (Connection conn = ConnectionPool.getConnection()) {
             long after = Long.parseLong(collect(conn,
@@ -313,18 +298,19 @@ class DuckLakeWatermarkPostIngestionTest {
         }
     }
 
-    /** Without the key the column is left alone entirely — no second transaction, no stamping. */
+    /** The key is required whenever a watermark is configured — a spec without it fails to parse. */
     @Test
-    void withoutTheKeyTheSnapshotColumnStaysNull() throws Exception {
-        addSnapshotIdColumn();
-        List<String> files = writeBatchFiles();
-        new DuckLakePostIngestionTask(result(files, computeRows(files)), CATALOG, "facts", "main",
-                watermarkParams("ingest_watermark")).execute();
-
-        try (Connection conn = ConnectionPool.getConnection()) {
-            assertEquals(List.of("3"), collect(conn,
-                    "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NULL".formatted(CATALOG)));
-        }
+    void watermarkWithoutSnapshotColumnIsRejected() {
+        Map<String, String> withoutKey = Map.of(
+                WatermarkSpec.TABLE_KEY, "ingest_watermark",
+                WatermarkSpec.TIMESTAMP_COLUMN_KEY, "ts",
+                WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
+                WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
+                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count");
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> WatermarkSpec.fromParameters("q1", withoutKey));
+        assertTrue(e.getMessage().contains(WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY),
+                "the error should name the missing key, got: " + e.getMessage());
     }
 
     private static List<String> collect(Connection conn, String sql) throws Exception {

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
@@ -173,6 +173,160 @@ class DuckLakeWatermarkPostIngestionTest {
         }
     }
 
+    // ── watermark_snapshot_id_column ────────────────────────────────────────
+
+    private static Map<String, String> watermarkParamsWithSnapshot(String table) {
+        Map<String, String> params = new java.util.HashMap<>(watermarkParams(table));
+        params.put(WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "commit_snapshot_id");
+        return Map.copyOf(params);
+    }
+
+    private void addSnapshotIdColumn() throws Exception {
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn,
+                    "ALTER TABLE %s.main.ingest_watermark ADD COLUMN commit_snapshot_id BIGINT".formatted(CATALOG));
+        }
+    }
+
+    /** One file with a single row, so a batch can be run more than once with distinct files. */
+    private List<String> writeSingleFile(String name, String county) throws Exception {
+        String f = tempDir.resolve(name).toString();
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn, ("COPY (SELECT * FROM (VALUES "
+                    + "('%s', 'wa', TIMESTAMP '2026-08-01 03:00', 1.0::DOUBLE)"
+                    + ") AS t(county, state, ts, v)) TO '%s' (FORMAT parquet)").formatted(county, f));
+        }
+        return List.of(f);
+    }
+
+    private List<List<String>> computeRowsFor(List<String> files) throws Exception {
+        String relation = "SELECT * FROM read_parquet(['%s'])".formatted(String.join("', '", files));
+        try (Connection conn = ConnectionPool.getConnection()) {
+            return SPEC.computeRows(conn, relation);
+        }
+    }
+
+    @Test
+    void stampsTheSnapshotTheFilesWereRegisteredIn() throws Exception {
+        addSnapshotIdColumn();
+        List<String> files = writeBatchFiles();
+        List<List<String>> rows = computeRows(files);
+        new DuckLakePostIngestionTask(result(files, rows), CATALOG, "facts", "main",
+                watermarkParamsWithSnapshot("ingest_watermark")).execute();
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            // every watermark row is stamped — no NULL left behind
+            assertEquals(List.of("0"), collect(conn,
+                    "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NULL".formatted(CATALOG)));
+            // and the value is exactly the snapshot the data files became visible in
+            assertEquals(List.of("1"), collect(conn, ("""
+                    SELECT count(DISTINCT commit_snapshot_id)::VARCHAR AS r FROM (
+                      SELECT commit_snapshot_id FROM %s.main.ingest_watermark
+                      UNION
+                      SELECT DISTINCT begin_snapshot FROM __ducklake_metadata_%s.ducklake_data_file
+                      WHERE path IN ('%s', '%s'))""")
+                    .formatted(CATALOG, CATALOG, files.get(0), files.get(1))));
+        }
+    }
+
+    /** Consecutive batches each land on their own snapshot rather than sharing or overwriting one. */
+    @Test
+    void eachBatchIsStampedWithItsOwnSnapshot() throws Exception {
+        addSnapshotIdColumn();
+        Map<String, String> params = watermarkParamsWithSnapshot("ingest_watermark");
+
+        List<String> first = writeSingleFile("s1.parquet", "king");
+        new DuckLakePostIngestionTask(result(first, computeRowsFor(first)), CATALOG, "facts", "main", params).execute();
+
+        List<String> second = writeSingleFile("s2.parquet", "pierce");
+        new DuckLakePostIngestionTask(result(second, computeRowsFor(second)), CATALOG, "facts", "main", params).execute();
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            // two batches, two rows, two different snapshots — the first was not re-stamped
+            assertEquals(List.of("2"), collect(conn,
+                    "SELECT count(DISTINCT commit_snapshot_id)::VARCHAR AS r FROM %s.main.ingest_watermark".formatted(CATALOG)));
+            assertEquals(List.of("0"), collect(conn,
+                    "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NULL".formatted(CATALOG)));
+            // each row carries the snapshot of its own file
+            assertEquals(List.of("king", "pierce"), collect(conn, ("""
+                    SELECT w.county AS r FROM %s.main.ingest_watermark w
+                    JOIN __ducklake_metadata_%s.ducklake_data_file f ON f.begin_snapshot = w.commit_snapshot_id
+                    ORDER BY w.county""").formatted(CATALOG, CATALOG)));
+        }
+    }
+
+    /**
+     * The stamping must touch only the rows of its own batch. A pre-existing unstamped row — a
+     * concurrent queue's in-flight batch on a shared watermark table, or a row from before the
+     * column was added — must be left alone. This is precisely what rowid scoping buys over a
+     * blanket {@code WHERE commit_snapshot_id IS NULL}, which would sweep the stray row up too.
+     */
+    @Test
+    void aStrayUnstampedRowIsNotClaimedByThisBatch() throws Exception {
+        addSnapshotIdColumn();
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn, ("INSERT INTO %s.main.ingest_watermark "
+                    + "(county, state, min_ts, max_ts, row_count, commit_snapshot_id) VALUES "
+                    + "('stray', 'zz', TIMESTAMP '2026-01-01 00:00', TIMESTAMP '2026-01-01 00:00', 7, NULL)")
+                    .formatted(CATALOG));
+        }
+
+        List<String> files = writeBatchFiles();
+        new DuckLakePostIngestionTask(result(files, computeRows(files)), CATALOG, "facts", "main",
+                watermarkParamsWithSnapshot("ingest_watermark")).execute();
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            // the stray row is still NULL; only this batch's 3 rows were stamped
+            assertEquals(List.of("stray"), collect(conn,
+                    ("SELECT county AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NULL")
+                            .formatted(CATALOG)));
+            assertEquals(List.of("3"), collect(conn,
+                    ("SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NOT NULL")
+                            .formatted(CATALOG)));
+        }
+    }
+
+    /**
+     * The whole point of writing the id inline: the batch must still be ONE transaction, i.e. one
+     * snapshot. A patch-it-up-afterwards implementation commits twice and shows up here as two.
+     */
+    @Test
+    void theWholeBatchIncludingTheSnapshotIdIsASingleSnapshot() throws Exception {
+        addSnapshotIdColumn();
+        long before;
+        try (Connection conn = ConnectionPool.getConnection()) {
+            before = Long.parseLong(collect(conn,
+                    "SELECT max(snapshot_id)::VARCHAR AS r FROM __ducklake_metadata_%s.ducklake_snapshot".formatted(CATALOG)).get(0));
+        }
+
+        List<String> files = writeBatchFiles();
+        new DuckLakePostIngestionTask(result(files, computeRows(files)), CATALOG, "facts", "main",
+                watermarkParamsWithSnapshot("ingest_watermark")).execute();
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            long after = Long.parseLong(collect(conn,
+                    "SELECT max(snapshot_id)::VARCHAR AS r FROM __ducklake_metadata_%s.ducklake_snapshot".formatted(CATALOG)).get(0));
+            assertEquals(1, after - before, "ingest must advance the catalog by exactly one snapshot");
+            // and that single snapshot is the one recorded on the rows
+            assertEquals(List.of(String.valueOf(after)), collect(conn,
+                    "SELECT DISTINCT commit_snapshot_id::VARCHAR AS r FROM %s.main.ingest_watermark".formatted(CATALOG)));
+        }
+    }
+
+    /** Without the key the column is left alone entirely — no second transaction, no stamping. */
+    @Test
+    void withoutTheKeyTheSnapshotColumnStaysNull() throws Exception {
+        addSnapshotIdColumn();
+        List<String> files = writeBatchFiles();
+        new DuckLakePostIngestionTask(result(files, computeRows(files)), CATALOG, "facts", "main",
+                watermarkParams("ingest_watermark")).execute();
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            assertEquals(List.of("3"), collect(conn,
+                    "SELECT count(*)::VARCHAR AS r FROM %s.main.ingest_watermark WHERE commit_snapshot_id IS NULL".formatted(CATALOG)));
+        }
+    }
+
     private static List<String> collect(Connection conn, String sql) throws Exception {
         List<String> rows = new ArrayList<>();
         ConnectionPool.collectAll(conn, sql, rs -> rs.getString("r")).forEach(rows::add);

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpecTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpecTest.java
@@ -38,8 +38,8 @@ class WatermarkSpecTest {
                 WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
                 WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
                 WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count",
-                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "commit_snapshot_id"));
-        assertEquals(new WatermarkSpec("wm", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "commit_snapshot_id"), spec);
+                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "min_commit_snapshot_id"));
+        assertEquals(new WatermarkSpec("wm", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "min_commit_snapshot_id"), spec);
     }
 
     @Test
@@ -52,7 +52,7 @@ class WatermarkSpecTest {
                 WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
                 WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
                 WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count",
-                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "commit_snapshot_id"));
+                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "min_commit_snapshot_id"));
         assertEquals(List.of("county", "state"), spec.groupColumns());
     }
 
@@ -93,7 +93,7 @@ class WatermarkSpecTest {
 
     @Test
     void keepsAllNullTimestampGroupSoItsRowCountIsRecorded() throws Exception {
-        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "commit_snapshot_id");
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "min_commit_snapshot_id");
         try (Connection conn = ConnectionPool.getConnection()) {
             String relation = relationOver(conn,
                     "('king','wa',TIMESTAMP '2026-08-01 03:00'),"
@@ -116,7 +116,7 @@ class WatermarkSpecTest {
 
     @Test
     void globalModeSkipsOnlyGenuinelyEmptyInput() throws Exception {
-        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", "row_count", "commit_snapshot_id");
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", "row_count", "min_commit_snapshot_id");
         try (Connection conn = ConnectionPool.getConnection()) {
             // zero-row relation: a global MIN would be a single NULL row — must be suppressed
             String empty = relationOver(conn, "('x','y',TIMESTAMP '2026-01-01')",
@@ -139,11 +139,11 @@ class WatermarkSpecTest {
 
     @Test
     void insertSqlQuotesIdentifiersAndEscapesValues() {
-        WatermarkSpec spec = new WatermarkSpec("ingest-watermark", "timestamp", List.of("county"), "min_ts", "max_ts", "row_count", "commit_snapshot_id");
+        WatermarkSpec spec = new WatermarkSpec("ingest-watermark", "timestamp", List.of("county"), "min_ts", "max_ts", "row_count", "min_commit_snapshot_id");
         String sql = spec.insertSql("cat", "main",
                 List.of(List.of("o'brien", "2026-01-01 00:00:00", "2026-01-01 06:00:00", "3")), 7);
         assertEquals("INSERT INTO \"cat\".\"main\".\"ingest-watermark\""
-                + " (\"county\", \"min_ts\", \"max_ts\", \"row_count\", \"commit_snapshot_id\") "
+                + " (\"county\", \"min_ts\", \"max_ts\", \"row_count\", \"min_commit_snapshot_id\") "
                 + "VALUES ('o''brien', '2026-01-01 00:00:00', '2026-01-01 06:00:00', '3', 7)", sql);
     }
 
@@ -151,7 +151,7 @@ class WatermarkSpecTest {
 
     @Test
     void aggregationAlwaysIncludesMinMaxAndCount() {
-        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county"), "min_ts", "max_ts", "rows", "commit_snapshot_id");
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county"), "min_ts", "max_ts", "rows", "min_commit_snapshot_id");
         assertEquals("SELECT \"county\", MIN(\"ts\") AS \"min_ts\", MAX(\"ts\") AS \"max_ts\","
                 + " COUNT(*) AS \"rows\" FROM (SELECT 1) GROUP BY \"county\""
                 + " HAVING COUNT(*) > 0",
@@ -160,9 +160,9 @@ class WatermarkSpecTest {
 
     @Test
     void insertColumnOrderMatchesAggregateOrder() {
-        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county"), "min_ts", "max_ts", "rows", "commit_snapshot_id");
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county"), "min_ts", "max_ts", "rows", "min_commit_snapshot_id");
         assertEquals("INSERT INTO \"cat\".\"main\".\"wm\""
-                + " (\"county\", \"min_ts\", \"max_ts\", \"rows\", \"commit_snapshot_id\")"
+                + " (\"county\", \"min_ts\", \"max_ts\", \"rows\", \"min_commit_snapshot_id\")"
                 + " VALUES ('a', '1', '9', '42', 7)",
                 spec.insertSql("cat", "main", List.of(List.of("a", "1", "9", "42")), 7));
     }
@@ -170,9 +170,9 @@ class WatermarkSpecTest {
     @Test
     void blankMaxOrRowCountColumnIsRejected() {
         assertThrows(IllegalArgumentException.class,
-                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "  ", "rows", "commit_snapshot_id"));
+                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "  ", "rows", "min_commit_snapshot_id"));
         assertThrows(IllegalArgumentException.class,
-                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", null, "commit_snapshot_id"));
+                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", null, "min_commit_snapshot_id"));
         assertThrows(IllegalArgumentException.class,
                 () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", "rows", null));
     }

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpecTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/WatermarkSpecTest.java
@@ -37,8 +37,9 @@ class WatermarkSpecTest {
                 WatermarkSpec.GROUP_COLUMNS_KEY, " county , state ",
                 WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
                 WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
-                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count"));
-        assertEquals(new WatermarkSpec("wm", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count"), spec);
+                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count",
+                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "commit_snapshot_id"));
+        assertEquals(new WatermarkSpec("wm", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "commit_snapshot_id"), spec);
     }
 
     @Test
@@ -50,7 +51,8 @@ class WatermarkSpecTest {
                 WatermarkSpec.GROUP_COLUMNS_KEY, "[county, state]",
                 WatermarkSpec.MIN_TIMESTAMP_COLUMN_KEY, "min_ts",
                 WatermarkSpec.MAX_TIMESTAMP_COLUMN_KEY, "max_ts",
-                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count"));
+                WatermarkSpec.ROW_COUNT_COLUMN_KEY, "row_count",
+                WatermarkSpec.SNAPSHOT_ID_COLUMN_KEY, "commit_snapshot_id"));
         assertEquals(List.of("county", "state"), spec.groupColumns());
     }
 
@@ -91,7 +93,7 @@ class WatermarkSpecTest {
 
     @Test
     void keepsAllNullTimestampGroupSoItsRowCountIsRecorded() throws Exception {
-        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count");
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county", "state"), "min_ts", "max_ts", "row_count", "commit_snapshot_id");
         try (Connection conn = ConnectionPool.getConnection()) {
             String relation = relationOver(conn,
                     "('king','wa',TIMESTAMP '2026-08-01 03:00'),"
@@ -114,7 +116,7 @@ class WatermarkSpecTest {
 
     @Test
     void globalModeSkipsOnlyGenuinelyEmptyInput() throws Exception {
-        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", "row_count");
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", "row_count", "commit_snapshot_id");
         try (Connection conn = ConnectionPool.getConnection()) {
             // zero-row relation: a global MIN would be a single NULL row — must be suppressed
             String empty = relationOver(conn, "('x','y',TIMESTAMP '2026-01-01')",
@@ -137,19 +139,19 @@ class WatermarkSpecTest {
 
     @Test
     void insertSqlQuotesIdentifiersAndEscapesValues() {
-        WatermarkSpec spec = new WatermarkSpec("ingest-watermark", "timestamp", List.of("county"), "min_ts", "max_ts", "row_count");
+        WatermarkSpec spec = new WatermarkSpec("ingest-watermark", "timestamp", List.of("county"), "min_ts", "max_ts", "row_count", "commit_snapshot_id");
         String sql = spec.insertSql("cat", "main",
-                List.of(List.of("o'brien", "2026-01-01 00:00:00", "2026-01-01 06:00:00", "3")));
+                List.of(List.of("o'brien", "2026-01-01 00:00:00", "2026-01-01 06:00:00", "3")), 7);
         assertEquals("INSERT INTO \"cat\".\"main\".\"ingest-watermark\""
-                + " (\"county\", \"min_ts\", \"max_ts\", \"row_count\") "
-                + "VALUES ('o''brien', '2026-01-01 00:00:00', '2026-01-01 06:00:00', '3')", sql);
+                + " (\"county\", \"min_ts\", \"max_ts\", \"row_count\", \"commit_snapshot_id\") "
+                + "VALUES ('o''brien', '2026-01-01 00:00:00', '2026-01-01 06:00:00', '3', 7)", sql);
     }
 
     // ------------------------------------------------ MAX timestamp and row count
 
     @Test
     void aggregationAlwaysIncludesMinMaxAndCount() {
-        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county"), "min_ts", "max_ts", "rows");
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county"), "min_ts", "max_ts", "rows", "commit_snapshot_id");
         assertEquals("SELECT \"county\", MIN(\"ts\") AS \"min_ts\", MAX(\"ts\") AS \"max_ts\","
                 + " COUNT(*) AS \"rows\" FROM (SELECT 1) GROUP BY \"county\""
                 + " HAVING COUNT(*) > 0",
@@ -158,19 +160,21 @@ class WatermarkSpecTest {
 
     @Test
     void insertColumnOrderMatchesAggregateOrder() {
-        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county"), "min_ts", "max_ts", "rows");
+        WatermarkSpec spec = new WatermarkSpec("wm", "ts", List.of("county"), "min_ts", "max_ts", "rows", "commit_snapshot_id");
         assertEquals("INSERT INTO \"cat\".\"main\".\"wm\""
-                + " (\"county\", \"min_ts\", \"max_ts\", \"rows\")"
-                + " VALUES ('a', '1', '9', '42')",
-                spec.insertSql("cat", "main", List.of(List.of("a", "1", "9", "42"))));
+                + " (\"county\", \"min_ts\", \"max_ts\", \"rows\", \"commit_snapshot_id\")"
+                + " VALUES ('a', '1', '9', '42', 7)",
+                spec.insertSql("cat", "main", List.of(List.of("a", "1", "9", "42")), 7));
     }
 
     @Test
     void blankMaxOrRowCountColumnIsRejected() {
         assertThrows(IllegalArgumentException.class,
-                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "  ", "rows"));
+                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "  ", "rows", "commit_snapshot_id"));
         assertThrows(IllegalArgumentException.class,
-                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", null));
+                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", null, "commit_snapshot_id"));
+        assertThrows(IllegalArgumentException.class,
+                () -> new WatermarkSpec("wm", "ts", List.of(), "min_ts", "max_ts", "rows", null));
     }
 
     @Test

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -355,7 +355,7 @@ otel_collector {
                 #     watermark_min_timestamp_column = "min_timestamp"
                 #     watermark_max_timestamp_column = "max_timestamp"
                 #     watermark_row_count_column     = "row_count"
-                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # optional; snapshot the batch commits as
+                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # required; BIGINT column, snapshot the batch commits as
                 #     watermark_group_columns        = "county,state"      # optional
                 # }
             }

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -355,7 +355,7 @@ otel_collector {
                 #     watermark_min_timestamp_column = "min_timestamp"
                 #     watermark_max_timestamp_column = "max_timestamp"
                 #     watermark_row_count_column     = "row_count"
-                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # required; BIGINT, lower bound on the commit snapshot
+                #     watermark_snapshot_id_column   = "min_commit_snapshot_id"   # required; BIGINT, lower bound on the commit snapshot
                 #     watermark_group_columns        = "county,state"      # optional
                 # }
             }

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -355,7 +355,7 @@ otel_collector {
                 #     watermark_min_timestamp_column = "min_timestamp"
                 #     watermark_max_timestamp_column = "max_timestamp"
                 #     watermark_row_count_column     = "row_count"
-                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # required; BIGINT column, snapshot the batch commits as
+                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # required; BIGINT, lower bound on the commit snapshot
                 #     watermark_group_columns        = "county,state"      # optional
                 # }
             }

--- a/dazzleduck-sql-otel-collector/README.md
+++ b/dazzleduck-sql-otel-collector/README.md
@@ -355,6 +355,7 @@ otel_collector {
                 #     watermark_min_timestamp_column = "min_timestamp"
                 #     watermark_max_timestamp_column = "max_timestamp"
                 #     watermark_row_count_column     = "row_count"
+                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # optional; snapshot the batch commits as
                 #     watermark_group_columns        = "county,state"      # optional
                 # }
             }

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -92,7 +92,7 @@ otel_collector {
                 #     watermark_min_timestamp_column = "min_timestamp"
                 #     watermark_max_timestamp_column = "max_timestamp"
                 #     watermark_row_count_column     = "row_count"
-                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # required; BIGINT, lower bound on the commit snapshot
+                #     watermark_snapshot_id_column   = "min_commit_snapshot_id"   # required; BIGINT, lower bound on the commit snapshot
                 #     watermark_group_columns        = "county,state"   # optional; empty = one global row per batch
                 # }
             }

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -92,6 +92,7 @@ otel_collector {
                 #     watermark_min_timestamp_column = "min_timestamp"
                 #     watermark_max_timestamp_column = "max_timestamp"
                 #     watermark_row_count_column     = "row_count"
+                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # optional; snapshot the batch commits as
                 #     watermark_group_columns        = "county,state"   # optional; empty = one global row per batch
                 # }
             }

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -92,7 +92,7 @@ otel_collector {
                 #     watermark_min_timestamp_column = "min_timestamp"
                 #     watermark_max_timestamp_column = "max_timestamp"
                 #     watermark_row_count_column     = "row_count"
-                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # required; BIGINT column, snapshot the batch commits as
+                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # required; BIGINT, lower bound on the commit snapshot
                 #     watermark_group_columns        = "county,state"   # optional; empty = one global row per batch
                 # }
             }

--- a/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
+++ b/dazzleduck-sql-otel-collector/src/main/resources/reference.conf
@@ -92,7 +92,7 @@ otel_collector {
                 #     watermark_min_timestamp_column = "min_timestamp"
                 #     watermark_max_timestamp_column = "max_timestamp"
                 #     watermark_row_count_column     = "row_count"
-                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # optional; snapshot the batch commits as
+                #     watermark_snapshot_id_column   = "commit_snapshot_id"   # required; BIGINT column, snapshot the batch commits as
                 #     watermark_group_columns        = "county,state"   # optional; empty = one global row per batch
                 # }
             }


### PR DESCRIPTION
Every watermark row now records the DuckLake snapshot its batch committed as, written by the **same INSERT** as the rest of the row — file registration, watermark rows and the snapshot id stay one transaction and one snapshot.

## ⚠️ Breaking change

`watermark_snapshot_id_column` is **required** whenever a watermark is configured. A spec without it fails at startup, like the other watermark keys.

Existing watermark configs must add the key, and the watermark table must gain the column:

```sql
ALTER TABLE my_catalog.main.ingest_watermark ADD COLUMN min_commit_snapshot_id BIGINT;
```

```hocon
watermark_snapshot_id_column = "min_commit_snapshot_id"
```

The column must be `BIGINT` and nullable — it is written on every insert, but leaving it nullable lets an existing table be migrated without a rewrite.

## Why it isn't simply read inside the transaction

DuckLake assigns the snapshot id **at COMMIT**. Every in-transaction source was checked, and none work:

| Probe inside the txn | Result |
|---|---|
| `max(snapshot_id)` | previous snapshot, and frozen by snapshot isolation |
| `current_snapshot()` / `<cat>.current_snapshot()` | the **parent** snapshot, frozen for the txn's lifetime |
| `last_committed_snapshot()` | `NULL` |
| `ducklake_data_file.begin_snapshot` | 0 rows — registration is staged until commit |
| `ducklake_list_files` | 0 rows |

## What does work

DuckLake derives the id as `max(snapshot_id) + 1` and enforces it with a primary key on `ducklake_snapshot`. The value is computed **just before** the transaction opens (an unisolated read — reading it inside is stale) and verified immediately afterwards.

A competing writer can take the id first; DuckLake then retries the commit one higher **without error**. So the committed id is always `>=` the predicted one — the recorded value can only ever be *under*-reported, never ahead — and `verifySnapshotId` repairs it.

## Verification cost

One query. The file just registered carries the committed id in its `begin_snapshot`, and the lookup is bounded by `begin_snapshot >= predicted` — free given the monotonicity above, and it lets zone maps skip the table. Only one file is checked, not all: every file of a batch is registered by the same transaction, so they share `begin_snapshot`, and equality on one path beats an `IN` list.

Measured at 1M files on DuckDB **1.5.4.0** (the version this project ships):

| Verify query | Cost |
|---|---|
| unbounded `path IN (...)`, 8 files | 3.496 ms |
| bounded, 8 files | 0.417 ms |
| **bounded, one file** | **0.157 ms** |

A cheaper pre-check was tried and removed. Neither candidate earns its place ahead of a query that already returns the exact answer, since both cost about what they save and neither avoids the lookup when it reports movement:

| Pre-check | Cost |
|---|---|
| global `current_snapshot()` | ~0.15 ms |
| per-table `max(begin_snapshot)` | 0.11–0.21 ms |

(Of the two, per-table would be the better one — the global value is perturbed by every writer in the catalog, so it rarely matches on a busy server — but that only matters if a pre-check is worth having at all.)

### Why the unindexed `path =` is not a problem

`ducklake_data_file` has `data_file_id BIGINT PRIMARY KEY` and **no index on `path`**, so this is an unindexed string equality. Unbounded it costs what you would expect. The `begin_snapshot >= predicted` bound is what makes it cheap, and it does not depend on zone maps to do so — measured against a table with `begin_snapshot` deliberately shuffled against storage order, so nothing can be pruned:

| At 1M rows | monotonic (realistic) | shuffled (no pruning possible) |
|---|---|---|
| `path =` alone | 2.399 ms | 2.382 ms |
| `begin_snapshot >= N` + `path =` | **0.197 ms** | **0.283 ms** |

DuckDB applies the cheap integer predicate first, so the string comparison only runs on the rows that survive it — a million integer comparisons are vectorised and nearly free, a million string comparisons are not. Zone maps are an additional win when the layout cooperates, which it normally does since rows are appended in commit order.

The worst case therefore stays linear in the size of `ducklake_data_file`, roughly 0.28 ms per million rows. Snapshot expiry plus file cleanup keep that table bounded; if it ever grew far beyond that, adding `table_id` to the predicate would narrow it further, at the cost of a lookup that does not pay for itself at present sizes.

## What the recorded id guarantees

**It is a lower bound, not an exact id.** The true snapshot is the recorded value or higher, never lower — so consumers join with `>=`, not `=`.

The bound holds unconditionally:

- What gets written is `max(snapshot_id) + 1`, the same formula DuckLake uses.
- `max(snapshot_id)` never decreases — verified that expiring *every* snapshot still retains the newest one, and that ids are never reused.
- A concurrent writer taking the id first only pushes our commit higher.

In practice the bound is tight: the verification immediately after commit corrects it to the exact snapshot. That step is an **accuracy improvement, not a correctness requirement** — if it is skipped, or the process dies before it runs, the column still satisfies its contract and no reader is misled.

To recover the exact snapshot for a batch at any time, read `begin_snapshot` from `ducklake_data_file` for that batch's files.

## Testing

436 commons tests (up from 431) and 56 otel-collector tests pass on JDK 21. New coverage:

- the id recorded is the snapshot the files were registered in
- the whole batch, snapshot id included, is a **single** snapshot (fails at 2 for any patch-afterwards implementation)
- consecutive batches each get their own snapshot
- a pre-existing unstamped row is not claimed by a later batch
- a watermark spec without the key is rejected, and the error names the missing key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP4cdZfX2Yiy8kS76CS3eZ


