### PR TITLE
test(ingestion): cover the snapshot-id repair path

### DIFF
--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/ingestion/DuckLakeWatermarkPostIngestionTest.java
@@ -313,6 +313,74 @@ class DuckLakeWatermarkPostIngestionTest {
                 "the error should name the missing key, got: " + e.getMessage());
     }
 
+    /**
+     * The repair path, which only runs when a concurrent writer takes the predicted id. Every other
+     * test here commits unopposed, so the prediction is exact, {@code verifySnapshotId} returns
+     * early and {@link WatermarkSpec#updateSnapshotIdSql} never executes — leaving the subtlest
+     * query in the feature unexercised, and silently so, since the verify step logs its failures
+     * rather than throwing.
+     *
+     * <p>The lost race is reproduced by inserting a batch with a deliberately stale predicted id
+     * (the value an earlier batch legitimately holds) and then running the repair, which is the
+     * state a losing transaction actually commits in. The three rows discriminate between the
+     * rowid scoping and both simpler predicates that look adequate:
+     * <ul>
+     *   <li>{@code WHERE min_commit_snapshot_id IS NULL} would sweep up the stray row belonging to
+     *       a concurrent queue's in-flight batch on the same table.</li>
+     *   <li>{@code WHERE min_commit_snapshot_id = predicted} would clobber the earlier batch's
+     *       rows, which correctly hold exactly that id.</li>
+     * </ul>
+     */
+    @Test
+    void repairStampsOnlyTheRowsOfTheBatchThatLostTheRace() throws Exception {
+        // An earlier batch commits unopposed: its rows hold the exact snapshot it committed as.
+        List<String> first = writeSingleFile("r1.parquet", "king");
+        new DuckLakePostIngestionTask(result(first, computeRowsFor(first)), CATALOG, "facts", "main",
+                watermarkParams("ingest_watermark")).execute();
+        long firstSnapshot = maxSnapshot();
+
+        // A concurrent queue's in-flight batch on the shared watermark table: inserted, unstamped.
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn, ("INSERT INTO %s.main.ingest_watermark "
+                    + "(county, state, min_ts, max_ts, row_count, min_commit_snapshot_id) VALUES "
+                    + "('stray', 'zz', TIMESTAMP '2026-01-01 00:00', TIMESTAMP '2026-01-01 00:00', 7, NULL)")
+                    .formatted(CATALOG));
+        }
+
+        // The losing batch: it predicted firstSnapshot, which was already taken by the time it
+        // committed, so its rows land carrying an id that belongs to someone else.
+        List<String> second = writeSingleFile("r2.parquet", "pierce");
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.executeBatchInTxn(conn, new String[]{
+                    SPEC.insertSql(CATALOG, "main", computeRowsFor(second), firstSnapshot)});
+        }
+        long secondSnapshot = maxSnapshot();
+        assertTrue(secondSnapshot > firstSnapshot,
+                "the losing batch must commit after the id it predicted, got " + secondSnapshot + " <= " + firstSnapshot);
+
+        // The repair, as DuckLakePostIngestionTask's verify step issues it.
+        try (Connection conn = ConnectionPool.getConnection()) {
+            ConnectionPool.execute(conn, SPEC.updateSnapshotIdSql(CATALOG, "main", secondSnapshot));
+        }
+
+        try (Connection conn = ConnectionPool.getConnection()) {
+            assertEquals(
+                    List.of("king=" + firstSnapshot, "pierce=" + secondSnapshot, "stray=null"),
+                    collect(conn, ("""
+                            SELECT county || '=' || coalesce(min_commit_snapshot_id::VARCHAR, 'null') AS r
+                            FROM %s.main.ingest_watermark ORDER BY county""").formatted(CATALOG)),
+                    "the repair must tighten only the losing batch's rows");
+        }
+    }
+
+    private long maxSnapshot() throws Exception {
+        try (Connection conn = ConnectionPool.getConnection()) {
+            return Long.parseLong(collect(conn,
+                    "SELECT max(snapshot_id)::VARCHAR AS r FROM __ducklake_metadata_%s.ducklake_snapshot"
+                            .formatted(CATALOG)).get(0));
+        }
+    }
+
     private static List<String> collect(Connection conn, String sql) throws Exception {
         List<String> rows = new ArrayList<>();
         ConnectionPool.collectAll(conn, sql, rs -> rs.getString("r")).forEach(rows::add);


### PR DESCRIPTION
Follow-up to #401. The repair path it added — `WatermarkSpec.updateSnapshotIdSql`, the query that tightens the recorded lower bound after a lost race — was not executed by any test.

Every watermark test commits unopposed, so the prediction is exact, `verifySnapshotId` returns early and `updateSnapshotIdSql` never runs. That left the one query with non-obvious scoping unexercised, and silently so: the verify step logs its failures rather than throwing, so a broken repair would produce a permanently loose lower bound with a green suite and no error at runtime. A future DuckLake change to `ducklake_table_insertions`' signature, or to whether it exposes `rowid`, would land exactly there.

## The test

`repairStampsOnlyTheRowsOfTheBatchThatLostTheRace` reproduces a lost race by inserting a batch that carries a stale predicted id — the value an earlier batch legitimately holds — and then running the repair, which is the state a losing transaction actually commits in. Three rows make it discriminating:

| Row | Role |
|---|---|
| `king` | an earlier batch that committed unopposed and holds the exact id |
| `pierce` | the losing batch, carrying the stale id |
| `stray` | a concurrent queue's in-flight batch on the shared watermark table, unstamped |

## Verified by mutation

Both simpler predicates that `updateSnapshotIdSql`'s javadoc says are wrong now actually fail a test:

| Predicate | Outcome |
|---|---|
| `WHERE rowid IN (SELECT rowid FROM ducklake_table_insertions(...))` (current) | passes — `[king=2, pierce=4, stray=null]` |
| `WHERE min_commit_snapshot_id IS NULL` | fails — `[king=2, pierce=2, stray=4]`: the stray row is swept up, the losing batch stays stale |
| `WHERE min_commit_snapshot_id < committed` | fails — `[king=4, pierce=4, stray=null]`: the earlier batch is clobbered |

This also closes a gap in `aStrayUnstampedRowIsNotClaimedByThisBatch`, whose comment claims to demonstrate what rowid scoping buys over a blanket `IS NULL` — but since no `UPDATE` runs in that test, it would pass under either predicate.

## Testing

Test-only change; no production code touched. 437 commons tests pass on JDK 21 (436 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)