### PR TITLE
fix(otel-collector): return UNAVAILABLE, not INTERNAL, for a failed write

### DIFF
--- a/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelServiceBase.java
+++ b/dazzleduck-sql-otel-collector/src/main/java/io/dazzleduck/sql/otel/collector/OtelServiceBase.java
@@ -213,12 +213,29 @@ class OtelServiceBase implements Closeable {
     /**
      * Maps an ingestion failure to a meaningful gRPC status. Forwarding the raw exception would
      * make gRPC surface it as {@code UNKNOWN} with an empty message, so clients could not tell
-     * overload from a server bug. Backpressure ({@link PendingWriteExceededException} anywhere in
-     * the cause chain — it arrives wrapped in {@code CompletionException}) becomes
-     * {@code RESOURCE_EXHAUSTED} with {@code RetryInfo} carrying the queue's suggested retry
-     * delay, which OTLP exporters honor for throttling; an already-built {@code
-     * StatusRuntimeException} passes through; anything else becomes {@code INTERNAL} with the
-     * root cause's message.
+     * overload from a server bug.
+     *
+     * <p>Backpressure ({@link PendingWriteExceededException} anywhere in the cause chain — it
+     * arrives wrapped in {@code CompletionException}) becomes {@code RESOURCE_EXHAUSTED} with
+     * {@code RetryInfo} carrying the queue's suggested retry delay. Deliberately NOT a
+     * gRPC-retryable code: the Go and Java OTLP exporters honor the delay and back off, and
+     * turning overload into a retryable status would have every client re-send immediately and
+     * amplify the overload we are signalling. (The C++ exporter honors neither — see below — so a
+     * C++ producer drops the batch on backpressure until it grows its own retry layer.)
+     *
+     * <p>An already-built {@code StatusRuntimeException} passes through, which is how the
+     * permanent, caller-fault conditions keep their codes: {@code INVALID_ARGUMENT} for an
+     * unknown/absent queue claim, {@code FAILED_PRECONDITION} for a queue that is not ready.
+     *
+     * <p>Anything else is a write that failed after the batch was accepted — the bucket is dropped
+     * ({@code BulkIngestQueue}'s write loop) and the data is gone unless the producer sends it
+     * again. It becomes {@code UNAVAILABLE}, not {@code INTERNAL}, because the OTel C++ exporter's
+     * retryable set is fixed by the SDK at {@code CANCELLED, DEADLINE_EXCEEDED, ABORTED,
+     * OUT_OF_RANGE, DATA_LOSS, UNAVAILABLE} and is not configurable — {@code INTERNAL} means the
+     * producer discards the batch without a single retry. The trade-off is that a genuinely
+     * permanent failure (a malformed batch, a server bug) is now retried up to the client's
+     * attempt limit before being lost anyway; the collector's own {@code log.error} in
+     * {@link #batchCompleteHandler} remains the accurate diagnosis either way.
      */
     static StatusRuntimeException toStatusError(Throwable t) {
         Throwable root = t;
@@ -241,7 +258,7 @@ class OtelServiceBase implements Closeable {
             }
             root = current;
         }
-        return Status.INTERNAL
+        return Status.UNAVAILABLE
                 .withDescription(root.getMessage() != null ? root.getMessage() : root.getClass().getName())
                 .withCause(root)
                 .asRuntimeException();

--- a/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelServiceBaseTest.java
+++ b/dazzleduck-sql-otel-collector/src/test/java/io/dazzleduck/sql/otel/collector/OtelServiceBaseTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -150,12 +151,26 @@ class OtelServiceBaseTest {
     }
 
     @Test
-    void genericFailure_mapsToInternalWithMessage() {
+    void writeFailure_mapsToUnavailableWithMessage() {
         var ex = new java.util.concurrent.CompletionException(
                 new java.io.IOException("disk full"));
         var sre = OtelServiceBase.toStatusError(ex);
-        assertEquals(Status.Code.INTERNAL, sre.getStatus().getCode());
+        // UNAVAILABLE, not INTERNAL: a batch that failed after being accepted is dropped by the
+        // write loop, and the OTel C++ exporter only retries the SDK's fixed status set — INTERNAL
+        // would have the producer discard the batch without retrying once.
+        assertEquals(Status.Code.UNAVAILABLE, sre.getStatus().getCode());
         assertEquals("disk full", sre.getStatus().getDescription());
+    }
+
+    @Test
+    void backpressure_isNotMappedToARetryableCode() {
+        var ex = new java.util.concurrent.CompletionException(
+                new PendingWriteExceededException(100, 50, 7));
+        var code = OtelServiceBase.toStatusError(ex).getStatus().getCode();
+        // Overload must not come back as a code gRPC retries on: clients would re-send at once and
+        // amplify the overload. RetryInfo (asserted above) is the throttling signal instead.
+        assertNotEquals(Status.Code.UNAVAILABLE, code);
+        assertEquals(Status.Code.RESOURCE_EXHAUSTED, code);
     }
 
     @Test


### PR DESCRIPTION
## The bug

A batch that fails **after being accepted** is dropped by `BulkIngestQueue`'s write loop, and the data is gone unless the producer sends it again. `toStatusError()` mapped that to `INTERNAL`.

`INTERNAL` is not in the OTel **C++** exporter's retryable set. That set is fixed by the SDK at `CANCELLED, DEADLINE_EXCEEDED, ABORTED, OUT_OF_RANGE, DATA_LOSS, UNAVAILABLE` (`otlp_grpc_client.cc`, inside the retry service-config block) and is **not configurable**. So the producer discarded the batch without a single retry attempt — guaranteed loss on every transient write failure, dropped on both sides at once.

## The fix

The fallback becomes `UNAVAILABLE`, which is retryable, so the producer's in-call retry fires.

Trade-off, stated plainly: a genuinely permanent failure (malformed batch, server bug) is now retried up to the client's attempt limit before being lost anyway. The collector's own `log.error` in `batchCompleteHandler` remains the accurate diagnosis either way, so nothing is lost diagnostically.

## What deliberately did *not* change

Backpressure stays `RESOURCE_EXHAUSTED` + `RetryInfo` and is **not** made retryable. Turning overload into a retryable status would have every client re-send immediately and amplify the exact condition being signalled; `RetryInfo` is the correct throttle signal for the Go and Java exporters, which honor it.

Worth recording, because the previous javadoc claimed otherwise: **the C++ exporter honors neither.** `RESOURCE_EXHAUSTED` appears only in a status-code-to-string helper (`otlp_grpc_utils.cc:37-38`) and `RetryInfo` appears nowhere in the tree, at 1.24.0 or 1.28.0. So a C++ producer still drops on backpressure until it grows its own retry layer. A new test pins this choice so it is not "fixed" later by accident.

## Tests

`Tests run: 57, Failures: 0, Errors: 0` in `dazzleduck-sql-otel-collector`.

- `writeFailure_mapsToUnavailableWithMessage` (was `genericFailure_mapsToInternalWithMessage`)
- `backpressure_isNotMappedToARetryableCode` — new

Note: **JDK 21 is required.** On JDK 25 every test in this class errors in `setUp` with a Netty/Arrow `UnsupportedOperationException` (`EmptyByteBuf.memoryAddress`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)