### PR TITLE
fix(commons)!: treat the row cap as a ceiling, not an assignment

### DIFF
--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ExpressionConstants.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ExpressionConstants.java
@@ -20,11 +20,13 @@ public class ExpressionConstants {
     public static final String CASE_TYPE_EXPR = "CASE_EXPR";
     public static final String CAST_CLASS = "CAST";
     public static final String CAST_TYPE_OPERATOR = "OPERATOR_CAST";
+    public static final String COALESCE_TYPE_OPERATOR = "OPERATOR_COALESCE";
     public static final String CONJUNCTION_CLASS = "CONJUNCTION";
     public static final String CONJUNCTION_TYPE_AND = "CONJUNCTION_AND";
     public static final String CONJUNCTION_TYPE_OR = "CONJUNCTION_OR";
     public static final String SELECT_NODE_TYPE = "SELECT_NODE";
     public static final String LIMIT_MODIFIER_TYPE = "LIMIT_MODIFIER";
+    public static final String LIMIT_PERCENT_MODIFIER_TYPE = "LIMIT_PERCENT_MODIFIER";
     public static final String FUNCTION_CLASS = "FUNCTION";
     public static final String FUNCTION_TYPE = "FUNCTION";
 

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ExpressionFactory.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/ExpressionFactory.java
@@ -241,6 +241,7 @@ public class ExpressionFactory {
      * @param offset the number of rows to skip (can be negative to disable)
      * @return JsonNode representing the LIMIT clause
      */
+    @Deprecated(since = "0.2.18", forRemoval = true)
     public static JsonNode limitModifier(long limit, long offset) {
         ObjectNode result = JsonNodeFactory.instance.objectNode();
         result.put(FIELD_TYPE, LIMIT_MODIFIER_TYPE);

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -1959,15 +1959,19 @@ public class Transformations {
      *
      * <p>A negative {@code offset} means "no offset" and leaves the query untouched.
      *
-     * @throws IllegalArgumentException if the offset lands at or past the query's own literal
-     *         LIMIT - that page is empty, and serving it silently would let a paginating client
-     *         mistake "past the end" for "no more data" (the same reasoning as {@code
-     *         resolveLimit} rejecting rather than clamping), or if the query's LIMIT is not an
-     *         integer literal - see {@link #rejectNonLiteralLimit}.
+     * <p>A zero or negative {@code offset} means "no offset" and leaves the query untouched -
+     * including its modifiers and any construct {@link #rejectNonLiteralLimit} would refuse, since
+     * nothing is being bounded.
+     *
+     * @throws IllegalArgumentException if the offset lands strictly <i>past</i> the query's own
+     *         literal LIMIT. An offset exactly <i>at</i> that LIMIT is allowed and yields an empty
+     *         page, so the usual "request pages until a short page" loop still terminates; going
+     *         beyond it can only be a client error. Also thrown if the query's LIMIT is not a
+     *         non-negative integer literal - see {@link #rejectNonLiteralLimit}.
      */
     public static JsonNode applyOffset(JsonNode query, long offset) {
-        if (offset < 0) {
-            return query;
+        if (offset <= 0) {
+            return query;   // skipping zero rows changes nothing - do not touch the AST
         }
         ObjectNode modifier = limitModifierOf(query);
         JsonNode ownLimit = modifier.get(FIELD_LIMIT);
@@ -2052,11 +2056,18 @@ public class Transformations {
         if (ownLimit == null || ownLimit.isNull() || isNullConstant(ownLimit)) {
             return;
         }
-        if (literalIntOf(ownLimit) == null) {
+        Long literal = literalIntOf(ownLimit);
+        if (literal == null) {
             throw new IllegalArgumentException(
                     "the query's LIMIT must be an integer literal when a row cap or offset "
-                    + "applies; an expression, scalar subquery or bind parameter cannot be "
-                    + "bounded reliably. Use a literal LIMIT instead.");
+                    + "applies; an expression, scalar subquery, bind parameter or non-integer "
+                    + "literal cannot be bounded reliably. Use a literal integer LIMIT instead.");
+        }
+        if (literal < 0) {
+            // DuckDB folds "LIMIT -1" into a constant, so it reaches here and would otherwise be
+            // reported as an offset problem by rejectOffsetPastOwnLimit.
+            throw new IllegalArgumentException(
+                    "the query's LIMIT must not be negative, got " + literal + ".");
         }
     }
 
@@ -2069,10 +2080,10 @@ public class Transformations {
             return;
         }
         Long literal = literalIntOf(ownLimit);
-        if (literal != null && offset >= literal) {
+        if (literal != null && offset > literal) {
             throw new IllegalArgumentException(
-                    "'offset' " + offset + " is at or past the query's own LIMIT " + literal
-                    + ", so that page is empty. Lower the offset or raise the query's LIMIT.");
+                    "'offset' " + offset + " is past the query's own LIMIT " + literal
+                    + ". Lower the offset or raise the query's LIMIT.");
         }
     }
 
@@ -2161,9 +2172,20 @@ public class Transformations {
     }
 
     /**
+     * DuckDB {@code type.id} values whose serialized constant is a plain integer. Anything else -
+     * DECIMAL, DOUBLE, FLOAT - is <b>not</b> read as a literal, because DuckDB serializes a
+     * DECIMAL as its <i>unscaled</i> integer plus a scale in {@code type_info}: {@code LIMIT 10.9}
+     * arrives as {@code 109}, and reading that as 10.9 rows would widen the query's own bound by
+     * 10^scale - the very bug this class now guards against.
+     */
+    private static final Set<String> INTEGER_CONSTANT_TYPE_IDS = Set.of(
+            "TINYINT", "SMALLINT", "INTEGER", "BIGINT", "HUGEINT",
+            "UTINYINT", "USMALLINT", "UINTEGER", "UBIGINT", "UHUGEINT");
+
+    /**
      * The value of a LIMIT/OFFSET expression when it is an integer literal, else {@code null} (an
-     * expression, bind parameter, or NULL) - i.e. when it cannot be folded in Java and must be
-     * combined with {@code least} / {@code add} instead.
+     * expression, bind parameter, NULL, or a non-integer numeric type) - i.e. when it cannot be
+     * folded in Java, and so is rejected or composed at execution time instead.
      */
     private static Long literalIntOf(JsonNode node) {
         if (node == null || node.isNull()
@@ -2172,6 +2194,9 @@ public class Transformations {
         }
         JsonNode value = node.get(FIELD_VALUE);
         if (value == null || value.path(FIELD_IS_NULL).asBoolean(false)) {
+            return null;
+        }
+        if (!INTEGER_CONSTANT_TYPE_IDS.contains(value.path(FIELD_TYPE).path(FIELD_ID).asText())) {
             return null;
         }
         JsonNode inner = value.get(FIELD_VALUE);

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/Transformations.java
@@ -1900,32 +1900,282 @@ public class Transformations {
         }
     }
     /**
-     * Applies LIMIT (and optionally OFFSET) to the outermost SELECT node.
+     * Applies a row cap and a request offset to the outermost SELECT node - a thin delegate over
+     * {@link #applyOffset} then {@link #capLimit}, kept for callers compiled against it.
      *
-     * <p>Works for all FROM clause types: BASE_TABLE, TABLE_FUNCTION, SUBQUERY,
-     * SET_OPERATION_NODE. Previously only BASE_TABLE and simple SUBQUERY were
-     * handled; TABLE_FUNCTION queries (e.g. generate_series) were silently skipped.
+     * <p>The order matters: applying an offset reduces how many of the query's own rows remain,
+     * and the cap is then a ceiling on whatever is left.
+     *
+     * @param limit  row cap, or negative for "no cap"
+     * @param offset request offset, or negative for "no offset"
+     * @deprecated the name says "add" but this caps, and it bundles two unrelated concerns - the
+     *             row cap is a security bound, the offset is request pagination - which is how
+     *             several offset bugs stayed hidden. Call {@link #applyOffset(JsonNode, long)}
+     *             then {@link #capLimit(JsonNode, long)} instead, in that order:
+     *             <pre>{@code capLimit(applyOffset(query, offset), cap)}</pre>
      */
+    @Deprecated(since = "0.2.18", forRemoval = true)
     public static JsonNode addLimit(JsonNode query, long limit, long offset) {
-        if (limit < 0 && offset < 0) {
+        return capLimit(applyOffset(query, offset), limit);
+    }
+
+    /**
+     * Bounds the outermost SELECT's LIMIT by {@code cap} - a <b>ceiling, not an assignment</b>.
+     * When the query already carries a LIMIT, the smaller of the two wins; a cap must never widen
+     * a query's own {@code LIMIT 10} to the cap, which is what made a named-query template with
+     * {@code LIMIT 10} render all 16 rows.
+     *
+     * <p>The query's LIMIT must be an integer literal, or unlimited (absent, or {@code LIMIT
+     * NULL} - which SQL reads as every row). The min folds in Java, so the emitted SQL stays a
+     * plain {@code LIMIT n}.
+     *
+     * <p>A negative {@code cap} means "no cap" and leaves the query untouched.
+     *
+     * <p>Both {@code LIMIT n%} and a non-literal LIMIT (expression, scalar subquery, bind
+     * parameter) are <b>rejected</b> with an {@link IllegalArgumentException}, which both
+     * transports map to 400 / INVALID_ARGUMENT - see {@link #rejectPercentLimit} and
+     * {@link #rejectNonLiteralLimit}. A negative cap still leaves such a query untouched.
+     */
+    public static JsonNode capLimit(JsonNode query, long cap) {
+        if (cap < 0) {
             return query;
         }
-        var select = (ObjectNode) getFirstStatementNode(query);
+        ObjectNode modifier = limitModifierOf(query);
+        modifier.set(FIELD_LIMIT, cappedLimit(modifier.get(FIELD_LIMIT), cap));
+        return query;
+    }
 
+    /**
+     * Applies a request offset to the outermost SELECT node, <b>composing</b> with the query's own
+     * OFFSET rather than replacing it: a request offset paginates within the query's result, which
+     * already begins after the query's own OFFSET, so the two add ({@code OFFSET 5} + request 10 =
+     * {@code OFFSET 15}). Replacing it silently discarded a template's {@code OFFSET 5} on every
+     * non-paginated read, since the cap path passes {@code offset = 0}.
+     *
+     * <p>It also <b>reduces the query's own LIMIT</b> by the offset. That LIMIT bounds the query's
+     * <i>result</i>, so skipping {@code offset} rows of it leaves only {@code own - offset} rows
+     * for this page; without that, {@code LIMIT 10} with a request offset of 9 returned 10 rows
+     * instead of the single row that remains.
+     *
+     * <p>A negative {@code offset} means "no offset" and leaves the query untouched.
+     *
+     * @throws IllegalArgumentException if the offset lands at or past the query's own literal
+     *         LIMIT - that page is empty, and serving it silently would let a paginating client
+     *         mistake "past the end" for "no more data" (the same reasoning as {@code
+     *         resolveLimit} rejecting rather than clamping), or if the query's LIMIT is not an
+     *         integer literal - see {@link #rejectNonLiteralLimit}.
+     */
+    public static JsonNode applyOffset(JsonNode query, long offset) {
+        if (offset < 0) {
+            return query;
+        }
+        ObjectNode modifier = limitModifierOf(query);
+        JsonNode ownLimit = modifier.get(FIELD_LIMIT);
+        rejectOffsetPastOwnLimit(ownLimit, offset);
+        modifier.set(FIELD_LIMIT, remainingAfterOffset(ownLimit, offset));
+        modifier.set(FIELD_OFFSET, composedOffset(modifier.get(FIELD_OFFSET), offset));
+        return query;
+    }
+
+    /**
+     * The outermost SELECT's LIMIT_MODIFIER, creating an empty one (limit = JSON null, DuckDB's
+     * own shape for an OFFSET-only modifier) when absent. Mutated in place, so LIMIT and OFFSET
+     * can be set independently without either clobbering the other - they share one AST node,
+     * which is why a rewrite of one used to destroy the other.
+     */
+    private static ObjectNode limitModifierOf(JsonNode query) {
+        var select = (ObjectNode) getFirstStatementNode(query);
         ArrayNode modifiers = (ArrayNode) select.get(FIELD_MODIFIERS);
         if (modifiers == null) {
             modifiers = select.putArray(FIELD_MODIFIERS);
-        } else {
-            for (int i = 0; i < modifiers.size(); i++) {
-                if (modifiers.get(i).get(FIELD_TYPE).asText().equals(LIMIT_MODIFIER_TYPE)) {
-                    modifiers.remove(i);
-                    break;
-                }
+        }
+        rejectPercentLimit(modifiers);
+        for (JsonNode modifier : modifiers) {
+            if (LIMIT_MODIFIER_TYPE.equals(modifier.path(FIELD_TYPE).asText())) {
+                rejectNonLiteralLimit(modifier.get(FIELD_LIMIT));
+                return (ObjectNode) modifier;
             }
         }
+        ObjectNode created = modifiers.addObject();
+        created.put(FIELD_TYPE, LIMIT_MODIFIER_TYPE);
+        created.set(FIELD_LIMIT, NullNode.getInstance());
+        return created;
+    }
 
-        modifiers.add(ExpressionFactory.limitModifier(limit, offset));
-        return query;
+    /**
+     * Rejects {@code LIMIT n%}, which no row cap can meaningfully bound.
+     *
+     * <p>A percent limit is a fraction of the query's <i>result cardinality</i>, so the engine
+     * must materialize the whole result before it can take the percentage. A row cap therefore
+     * cannot bound the work: {@code SELECT * FROM huge LIMIT 1%} still builds the entire result
+     * and discards 99% of it, making the cap cosmetic in exactly the modes that rely on it.
+     *
+     * <p>It is also not expressible by merging: {@code %} is a syntactic form, not a scalar, so
+     * there is no {@code least(cap, 3%)} to emit ({@code Parser Error}), and a percent limit is a
+     * separate LIMIT_PERCENT_MODIFIER node - appending a row LIMIT beside it produced
+     * {@code LIMIT (3) % LIMIT 5}, which does not parse.
+     *
+     * <p>Only reached when a cap or an offset is actually being applied, so a query with
+     * {@code LIMIT n%} and no cap is left alone.
+     */
+    private static void rejectPercentLimit(ArrayNode modifiers) {
+        for (JsonNode modifier : modifiers) {
+            if (LIMIT_PERCENT_MODIFIER_TYPE.equals(modifier.path(FIELD_TYPE).asText())) {
+                throw new IllegalArgumentException(
+                        "'LIMIT n%' is not supported when a row cap or offset applies: a percent "
+                        + "limit is a fraction of the result, so the whole result must be built "
+                        + "before it can be taken and the cap cannot bound the work. "
+                        + "Use an absolute LIMIT instead.");
+            }
+        }
+    }
+
+    /**
+     * Rejects a LIMIT that is not an integer literal, when a cap or offset is being applied.
+     *
+     * <p>Bounding a non-literal limit means reproducing SQL's own semantics in AST arithmetic -
+     * {@code least} skips NULLs but {@code subtract} propagates them, {@code greatest} clamps only
+     * after {@code subtract} has already poisoned the value, and {@code LIMIT NULL} is
+     * <i>unlimited</i> in SQL but NULL in arithmetic. Each limit form was a separate special case,
+     * and each one passed its tests before the next was found. Rejecting is the honest bound: the
+     * caller learns the query cannot be paginated instead of receiving a plausible wrong page.
+     *
+     * <p>It also closes an inconsistency: {@link #rejectOffsetPastOwnLimit} can only compare a
+     * literal, so {@code LIMIT 5+5 OFFSET 20} previously returned a silent empty page where
+     * {@code LIMIT 10 OFFSET 20} raised. With non-literals rejected, that guard always applies.
+     *
+     * <p>An <i>unlimited</i> limit is allowed: an absent LIMIT and an explicit {@code LIMIT NULL}
+     * both mean "every row", which is exactly the case the cap handles, so there is no arithmetic
+     * to get wrong.
+     */
+    private static void rejectNonLiteralLimit(JsonNode ownLimit) {
+        if (ownLimit == null || ownLimit.isNull() || isNullConstant(ownLimit)) {
+            return;
+        }
+        if (literalIntOf(ownLimit) == null) {
+            throw new IllegalArgumentException(
+                    "the query's LIMIT must be an integer literal when a row cap or offset "
+                    + "applies; an expression, scalar subquery or bind parameter cannot be "
+                    + "bounded reliably. Use a literal LIMIT instead.");
+        }
+    }
+
+    /**
+     * Rejects a request offset that lands at or past the query's own LIMIT - that page is empty,
+     * and merging modifiers would instead hand back rows the query's own bound excluded.
+     */
+    private static void rejectOffsetPastOwnLimit(JsonNode ownLimit, long offset) {
+        if (offset <= 0) {
+            return;
+        }
+        Long literal = literalIntOf(ownLimit);
+        if (literal != null && offset >= literal) {
+            throw new IllegalArgumentException(
+                    "'offset' " + offset + " is at or past the query's own LIMIT " + literal
+                    + ", so that page is empty. Lower the offset or raise the query's LIMIT.");
+        }
+    }
+
+    /**
+     * The query's own LIMIT less {@code offset} rows already skipped, clamped at 0.
+     *
+     * <p>An unlimited query stays unlimited: there is nothing to subtract from. That covers an
+     * absent LIMIT and an explicit {@code LIMIT NULL}, which SQL reads as <i>unlimited</i> - it
+     * parses as a CONSTANT whose value is NULL, not as JSON null, so without the
+     * {@link #isNullConstant} check it took the arithmetic path and
+     * {@code greatest(subtract(NULL, 5), 0)} collapsed to {@code LIMIT 0}, i.e. an empty page for
+     * a query that asked for every row.
+     */
+    private static JsonNode remainingAfterOffset(JsonNode ownLimit, long offset) {
+        if (ownLimit == null || ownLimit.isNull() || isNullConstant(ownLimit)) {
+            return NullNode.getInstance();
+        }
+        if (offset == 0) {
+            return ownLimit;
+        }
+        // Guaranteed a literal by rejectNonLiteralLimit, and > offset by rejectOffsetPastOwnLimit.
+        return ExpressionFactory.constant(literalIntOf(ownLimit) - offset);
+    }
+
+    /**
+     * The limit bounded by {@code cap}. A pure ceiling - no offset arithmetic. An unlimited query
+     * (absent LIMIT, or {@code LIMIT NULL}) is bounded by the cap itself; otherwise the limit is
+     * an integer literal, guaranteed by {@link #rejectNonLiteralLimit}, so the min folds in Java
+     * and the emitted SQL stays a plain {@code LIMIT n}.
+     */
+    private static JsonNode cappedLimit(JsonNode existing, long cap) {
+        if (existing == null || existing.isNull() || isNullConstant(existing)) {
+            return ExpressionFactory.constant(cap);
+        }
+        return ExpressionFactory.constant(Math.min(literalIntOf(existing), cap));
+    }
+
+    /**
+     * The query's own OFFSET composed additively with the caller's. A non-literal offset is
+     * wrapped in {@code coalesce(..., 0)} so a NULL offset contributes 0 instead of poisoning the
+     * sum - the {@code add} counterpart to {@code least}'s NULL-skipping in {@link #cappedLimit}.
+     */
+    private static JsonNode composedOffset(JsonNode existing, long offset) {
+        if (existing == null || existing.isNull()) {
+            return ExpressionFactory.constant(offset);
+        }
+        if (offset == 0) {
+            return existing;
+        }
+        Long literal = literalIntOf(existing);
+        if (literal != null) {
+            long sum = literal + offset;
+            return ExpressionFactory.constant(sum < 0 ? Long.MAX_VALUE : sum); // saturate
+        }
+        return call("add", coalesceWithZero(existing), ExpressionFactory.constant(offset));
+    }
+
+    /**
+     * {@code coalesce(expr, 0)}. COALESCE is not a FUNCTION node in DuckDB's AST - it serializes
+     * as an OPERATOR of type OPERATOR_COALESCE (so does {@code ifnull}), and a FUNCTION node
+     * named "coalesce" fails to bind.
+     */
+    private static JsonNode coalesceWithZero(JsonNode expression) {
+        ObjectNode coalesce = JsonNodeFactory.instance.objectNode();
+        coalesce.put(FIELD_CLASS, OPERATOR_CLASS);
+        coalesce.put(FIELD_TYPE, COALESCE_TYPE_OPERATOR);
+        ArrayNode children = coalesce.putArray(FIELD_CHILDREN);
+        children.add(expression);
+        children.add(ExpressionFactory.constant(0L));
+        return coalesce;
+    }
+
+    /** A two-argument function call in the default catalog/schema. */
+    private static JsonNode call(String name, JsonNode left, JsonNode right) {
+        ArrayNode args = JsonNodeFactory.instance.arrayNode();
+        args.add(left);
+        args.add(right);
+        return ExpressionFactory.createFunction(name, "", "", args);
+    }
+
+    /** True for a CONSTANT node whose value is NULL - i.e. an explicit {@code LIMIT/OFFSET NULL}. */
+    private static boolean isNullConstant(JsonNode node) {
+        return node != null
+                && CONSTANT_CLASS.equals(node.path(FIELD_CLASS).asText())
+                && node.path(FIELD_VALUE).path(FIELD_IS_NULL).asBoolean(false);
+    }
+
+    /**
+     * The value of a LIMIT/OFFSET expression when it is an integer literal, else {@code null} (an
+     * expression, bind parameter, or NULL) - i.e. when it cannot be folded in Java and must be
+     * combined with {@code least} / {@code add} instead.
+     */
+    private static Long literalIntOf(JsonNode node) {
+        if (node == null || node.isNull()
+                || !CONSTANT_CLASS.equals(node.path(FIELD_CLASS).asText())) {
+            return null;
+        }
+        JsonNode value = node.get(FIELD_VALUE);
+        if (value == null || value.path(FIELD_IS_NULL).asBoolean(false)) {
+            return null;
+        }
+        JsonNode inner = value.get(FIELD_VALUE);
+        return inner != null && inner.isIntegralNumber() ? inner.asLong() : null;
     }
 
     private static String escapeSpecialChar(String sql) {

--- a/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/authorization/SqlAuthorizer.java
+++ b/dazzleduck-sql-commons/src/main/java/io/dazzleduck/sql/commons/authorization/SqlAuthorizer.java
@@ -143,7 +143,9 @@ public interface SqlAuthorizer {
     default JsonNode authorize(String user, String database, String schema, JsonNode query,
                        Map<String, String> verifiedClaims, long limit, long offset) throws UnauthorizedException {
         var authorized = authorize(user, database, schema, query, verifiedClaims);
-        return Transformations.addLimit(authorized, limit, offset);
+        // Offset first: skipping rows of the query's own bounded result reduces what remains,
+        // and the cap is then a ceiling on whatever is left.
+        return Transformations.capLimit(Transformations.applyOffset(authorized, offset), limit);
     }
 
     boolean hasWriteAccess(String user, String ingestionQueue, Map<String, String> verifiedClaims);

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/authorization/SqlAuthorizerLimitTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/authorization/SqlAuthorizerLimitTest.java
@@ -2,6 +2,7 @@ package io.dazzleduck.sql.commons.authorization;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.dazzleduck.sql.commons.ConnectionPool;
 import io.dazzleduck.sql.commons.ExpressionConstants;
 import io.dazzleduck.sql.commons.Transformations;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class SqlAuthorizerLimitTest {
 
@@ -72,5 +75,442 @@ public class SqlAuthorizerLimitTest {
         ArrayNode modifiers = (ArrayNode) statement.get(ExpressionConstants.FIELD_MODIFIERS);
         boolean hasLimit = modifiers != null && modifiers.size() > 0;
         assertEquals(false, hasLimit, "Expected no LIMIT modifier when limit=-1 and offset=-1");
+    }
+
+    // ── limit-as-ceiling regression tests ────────────────────────────────────────────────────
+    // Guard for the "top users showed 16 rows under LIMIT 10" bug: the RESTRICT_READ_ONLY
+    // authorizer applied the engine page cap (duckdb.max-rows) as an assignment, discarding a
+    // named-query template's own LIMIT N so every user rendered.
+
+    private static java.util.List<String> modifierTypes(JsonNode authorized) {
+        JsonNode statement = authorized.get(ExpressionConstants.FIELD_STATEMENTS)
+                .get(0).get(ExpressionConstants.FIELD_NODE);
+        ArrayNode modifiers = (ArrayNode) statement.get(ExpressionConstants.FIELD_MODIFIERS);
+        var out = new java.util.ArrayList<String>();
+        if (modifiers != null) {
+            for (JsonNode m : modifiers) {
+                out.add(m.get(ExpressionConstants.FIELD_TYPE).asText());
+            }
+        }
+        return out;
+    }
+
+    @Test
+    public void testCap_preservesTighterTemplateLimit() throws Exception {
+        // The template asks for 10; the engine cap is 1000. The template must win.
+        JsonNode query = Transformations.parseToTree(
+                "SELECT user_id, count(*) AS n FROM ai_txn GROUP BY user_id ORDER BY n DESC LIMIT 10");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 0L);
+        assertEquals(10L, extractLimit(authorized),
+                "an engine page cap must not widen the query's own LIMIT 10");
+        assertEquals(true, modifierTypes(authorized).contains("ORDER_MODIFIER"),
+                "ORDER BY must survive limit capping - otherwise 'top N' loses its ordering");
+    }
+
+    @Test
+    public void testCap_appliedWhenQueryLimitExceedsCap() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM t LIMIT 5000");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 0L);
+        assertEquals(1000L, extractLimit(authorized), "the cap must still bound a larger LIMIT");
+    }
+
+    @Test
+    public void testCap_equalToQueryLimit() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM t LIMIT 1000");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 0L);
+        assertEquals(1000L, extractLimit(authorized));
+    }
+
+    /** The first row of the round-tripped query - over range(100) this is the effective OFFSET. */
+    private static long firstValueOf(JsonNode authorized) throws Exception {
+        String sql = Transformations.parseToSql(authorized);
+        return ConnectionPool.collectFirst(
+                "SELECT coalesce(min(range), -1) FROM (" + sql + ")", Long.class);
+    }
+
+    /** Round-trips the authorized AST back to SQL and returns the rows it actually produces. */
+    private static long rowsOf(JsonNode authorized) throws Exception {
+        String sql = Transformations.parseToSql(authorized);
+        return ConnectionPool.collectFirst("SELECT count(*) FROM (" + sql + ")", Long.class);
+    }
+
+
+
+    @Test
+    public void testCap_limitNullIsBounded() throws Exception {
+        // Bare LIMIT NULL reads as *unlimited* in SQL. least() skips NULLs, so least(7, NULL) is 7
+        // and the cap now binds where it previously could not.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT NULL");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 7L, 0L);
+        assertEquals(7L, rowsOf(authorized), "LIMIT NULL must be bounded by the cap");
+    }
+
+
+    @Test
+    public void testCap_literalPathStaysFolded() throws Exception {
+        // Both sides literal - folded in Java so the emitted SQL stays a plain LIMIT 10.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 0L);
+        String sql = Transformations.parseToSql(authorized);
+        assertEquals(false, sql.toLowerCase().contains("least"),
+                "a literal LIMIT must not be wrapped in least(): " + sql);
+        assertEquals(10L, rowsOf(authorized));
+    }
+
+    @Test
+    public void testNoCap_preservesExistingLimit() throws Exception {
+        // limit < 0 means "no cap"; an OFFSET-only rewrite must not clobber the query's LIMIT.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM t LIMIT 10");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), -1L, 0L);
+        assertEquals(10L, extractLimit(authorized));
+    }
+
+    @Test
+    public void testCap_singleLimitModifierAfterCapping() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM t LIMIT 10");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 0L);
+        long limitModifiers = modifierTypes(authorized).stream()
+                .filter(t -> t.equals(ExpressionConstants.LIMIT_MODIFIER_TYPE)).count();
+        assertEquals(1L, limitModifiers, "capping must not leave a duplicate LIMIT modifier");
+    }
+
+    // ── offset composition ───────────────────────────────────────────────────────────────────
+    // The cap path passes offset=0, which previously *replaced* a template's own OFFSET.
+
+    @Test
+    public void testOffset_templateOffsetSurvivesTheCapPath() throws Exception {
+        // range(100) OFFSET 5 LIMIT 10 -> rows 6..15. The cap must not reset the offset to 0.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10 OFFSET 5");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 0L);
+        assertEquals(10L, rowsOf(authorized));
+        assertEquals(5L, firstValueOf(authorized), "the template's OFFSET 5 must survive");
+    }
+
+    @Test
+    public void testOffset_requestOffsetAddsToTemplateOffset() throws Exception {
+        // A request offset paginates within the query's result, which already starts after 5.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) OFFSET 5");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 10L);
+        assertEquals(15L, firstValueOf(authorized), "OFFSET 5 + request 10 must compose to 15");
+    }
+
+    @Test
+    public void testOffset_nonLiteralOffsetComposesViaAdd() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) OFFSET 2+3");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 10L);
+        assertEquals(15L, firstValueOf(authorized), "add(2+3, 10) must compose to 15");
+    }
+
+    @Test
+    public void testOffset_onlyOffsetRequestedIsNotLimitMinusOne() throws Exception {
+        // limit=-1 with offset>=0 used to emit "LIMIT -1", a DuckDB binder error
+        // ("LIMIT/OFFSET cannot be negative"). It must serialize as an OFFSET-only modifier.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100)");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), -1L, 5L);
+        String sql = Transformations.parseToSql(authorized);
+        assertEquals(false, sql.contains("-1"), "must not emit LIMIT -1: " + sql);
+        assertEquals(95L, rowsOf(authorized), "OFFSET 5 over range(100) leaves 95 rows");
+    }
+
+    @Test
+    public void testOffset_absentOffsetStillOmitted() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100)");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 10L, -1L);
+        assertEquals(10L, rowsOf(authorized));
+        assertEquals(0L, firstValueOf(authorized), "no offset requested and none in the query");
+    }
+
+    @Test
+    public void testOffset_nullOffsetDoesNotSwallowTheRequestOffset() throws Exception {
+        // OFFSET NULL is not a literal, so it took the add() path: add(NULL, 5) is NULL, which
+        // DuckDB reads as OFFSET 0 - a paginating client got page 1 back for every page.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) OFFSET NULL");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 3L, 5L);
+        assertEquals(5L, firstValueOf(authorized),
+                "coalesce(NULL, 0) + 5 must honour the requested offset");
+        assertEquals(3L, rowsOf(authorized), "the cap must still apply");
+    }
+
+    @Test
+    public void testOffset_emptySubqueryOffsetDoesNotSwallowTheRequestOffset() throws Exception {
+        // Same shape via a scalar subquery that evaluates to NULL.
+        JsonNode query = Transformations.parseToTree(
+                "SELECT * FROM range(100) OFFSET (SELECT max(x) FROM (SELECT 1 AS x) WHERE false)");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 3L, 5L);
+        assertEquals(5L, firstValueOf(authorized));
+    }
+
+    // ── offset past the query's own LIMIT is rejected, not served as an empty page ────────────
+
+    @Test
+    public void testOffset_atTemplateLimitIsRejected() throws Exception {
+        // LIMIT 10 with a request offset of 10: that page is empty. Merging modifiers would hand
+        // back rows 11-20 - rows the template's own LIMIT excluded.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 10L));
+        assertEquals(true, e.getMessage().contains("at or past the query's own LIMIT 10"),
+                "message must name the offending bound: " + e.getMessage());
+    }
+
+    @Test
+    public void testOffset_pastTemplateLimitIsRejected() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10");
+        assertThrows(IllegalArgumentException.class, () ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 25L));
+    }
+
+    @Test
+    public void testOffset_lastRowWithinTemplateLimitIsAllowed() throws Exception {
+        // offset 9 against LIMIT 10 is the final row - valid, must not be rejected.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 9L);
+        assertEquals(1L, rowsOf(authorized), "offset 9 of LIMIT 10 must return the last row");
+        assertEquals(9L, firstValueOf(authorized));
+    }
+
+    @Test
+    public void testOffset_paginatingWithinALargerTemplateLimitIsAllowed() throws Exception {
+        // The cap is a page size, not the result size: paging inside the query's own 100-row
+        // bound with a 10-row cap is legitimate and must not be rejected.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(1000) LIMIT 100");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 10L, 10L);
+        assertEquals(10L, rowsOf(authorized));
+        assertEquals(10L, firstValueOf(authorized));
+    }
+
+    @Test
+    public void testOffset_noTemplateLimitIsNeverRejected() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100)");
+        assertDoesNotThrow(() ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 50L));
+    }
+
+
+
+
+    @Test
+    public void testOffset_templateOffsetAndRequestOffsetWithOwnLimit() throws Exception {
+        // LIMIT 10 OFFSET 5 -> rows 5..14. Request offset 3 -> rows 8..14, i.e. 7 rows.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10 OFFSET 5");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 3L);
+        assertEquals(7L, rowsOf(authorized), "10 own rows minus 3 skipped leaves 7");
+        assertEquals(8L, firstValueOf(authorized), "own OFFSET 5 + request 3");
+    }
+
+    // ── the split: each method touches only its own field of the shared LIMIT_MODIFIER ───────
+
+    private static JsonNode limitModifier(JsonNode tree) {
+        JsonNode statement = tree.get(ExpressionConstants.FIELD_STATEMENTS)
+                .get(0).get(ExpressionConstants.FIELD_NODE);
+        ArrayNode modifiers = (ArrayNode) statement.get(ExpressionConstants.FIELD_MODIFIERS);
+        for (JsonNode m : modifiers) {
+            if (m.get(ExpressionConstants.FIELD_TYPE).asText()
+                    .equals(ExpressionConstants.LIMIT_MODIFIER_TYPE)) {
+                return m;
+            }
+        }
+        throw new AssertionError("no LIMIT_MODIFIER in " + tree);
+    }
+
+    @Test
+    public void testCapLimit_doesNotTouchTheOffset() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 50 OFFSET 5");
+        JsonNode out = Transformations.capLimit(query, 10L);
+        assertEquals(10L, extractLimit(out), "cap must bound the limit");
+        assertEquals(5L, limitModifier(out).get(ExpressionConstants.FIELD_OFFSET)
+                .get(ExpressionConstants.FIELD_VALUE)
+                .get(ExpressionConstants.FIELD_VALUE).asLong(),
+                "capLimit must leave OFFSET 5 untouched");
+    }
+
+    @Test
+    public void testApplyOffset_doesNotInventACap() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100)");
+        JsonNode out = Transformations.applyOffset(query, 5L);
+        assertEquals(true, limitModifier(out).get(ExpressionConstants.FIELD_LIMIT).isNull(),
+                "applyOffset must leave the limit as JSON null, not fabricate one");
+        assertEquals(95L, rowsOf(out), "OFFSET 5 over range(100) leaves 95 rows, uncapped");
+    }
+
+    @Test
+    public void testCapLimit_negativeCapIsANoOp() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 7");
+        JsonNode out = Transformations.capLimit(query, -1L);
+        assertEquals(7L, extractLimit(out));
+        assertEquals(7L, rowsOf(out));
+    }
+
+    @Test
+    public void testApplyOffset_negativeOffsetIsANoOp() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 7");
+        JsonNode out = Transformations.applyOffset(query, -1L);
+        assertEquals(7L, rowsOf(out));
+        assertEquals(0L, firstValueOf(out), "no offset must be applied");
+    }
+
+    @Test
+    public void testAddLimit_matchesApplyOffsetThenCapLimit() throws Exception {
+        // The delegate must equal the hand-composed pair, in that order.
+        String sql = "SELECT * FROM range(100) LIMIT 20 OFFSET 4";
+        JsonNode viaDelegate = Transformations.addLimit(Transformations.parseToTree(sql), 5L, 3L);
+        JsonNode viaSplit = Transformations.capLimit(
+                Transformations.applyOffset(Transformations.parseToTree(sql), 3L), 5L);
+        assertEquals(Transformations.parseToSql(viaSplit), Transformations.parseToSql(viaDelegate));
+        assertEquals(5L, rowsOf(viaDelegate), "min(cap 5, 20 own - 3 skipped)");
+        assertEquals(7L, firstValueOf(viaDelegate), "own OFFSET 4 + request 3");
+    }
+
+    @Test
+    public void testApplyOffset_rejectionIsRaisedByTheOffsetMethod() throws Exception {
+        // The guard belongs to offset semantics, so applyOffset alone must raise it.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10");
+        assertThrows(IllegalArgumentException.class, () -> Transformations.applyOffset(query, 10L));
+    }
+
+    // ── LIMIT n% is rejected when a cap or offset applies ────────────────────────────────────
+
+    @Test
+    public void testPercentLimit_isRejectedUnderACap() throws Exception {
+        // Previously produced LIMIT (3) % LIMIT 5 -> Parser Error. Now a clear 400.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 3%");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 5L, 0L));
+        assertEquals(true, e.getMessage().contains("'LIMIT n%' is not supported"),
+                "message must name the unsupported construct: " + e.getMessage());
+    }
+
+    @Test
+    public void testPercentLimit_isRejectedByCapLimitDirectly() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 3%");
+        assertThrows(IllegalArgumentException.class, () -> Transformations.capLimit(query, 5L));
+    }
+
+    @Test
+    public void testPercentLimit_isRejectedByApplyOffsetDirectly() throws Exception {
+        // An offset alone would also append a second LIMIT modifier and corrupt the SQL.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 3%");
+        assertThrows(IllegalArgumentException.class, () -> Transformations.applyOffset(query, 5L));
+    }
+
+    @Test
+    public void testPercentLimit_isLeftAloneWhenNoCapApplies() throws Exception {
+        // No cap, no offset -> nothing is being applied, so the query must pass through and run.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 3%");
+        JsonNode out = assertDoesNotThrow(() -> Transformations.capLimit(query, -1L));
+        assertEquals(3L, rowsOf(out), "3% of 100 rows must still work uncapped");
+    }
+
+    @Test
+    public void testPercentLimit_neverEmitsUnparseableSql() throws Exception {
+        // Guard the specific corruption: two LIMIT modifiers on one SELECT.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 3%");
+        try {
+            PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 5L, 0L);
+        } catch (IllegalArgumentException expected) {
+            return; // rejected before any SQL could be produced
+        }
+        throw new AssertionError("a percent limit under a cap must be rejected, not serialized");
+    }
+
+    @Test
+    public void testCap_limitNullWithAnOffsetStaysUnlimited() throws Exception {
+        // LIMIT NULL means *unlimited*, so there is nothing for the offset to subtract from.
+        // It parses as a CONSTANT whose value is NULL (not JSON null), so it previously took the
+        // arithmetic path: greatest(subtract(NULL, 5), 0) collapsed to LIMIT 0 - an empty page
+        // for a query that asked for every row.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT NULL");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 3L, 5L);
+        assertEquals(3L, rowsOf(authorized), "cap 3 over an unlimited query must yield 3 rows");
+        assertEquals(5L, firstValueOf(authorized), "the request offset must still apply");
+    }
+
+    @Test
+    public void testCap_limitNullWithOffsetAndNoCap() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT NULL");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), -1L, 5L);
+        assertEquals(95L, rowsOf(authorized), "unlimited minus 5 skipped rows leaves 95");
+    }
+
+    // ── a non-literal LIMIT is rejected when a cap or offset applies ─────────────────────────
+    // Bounding one meant reproducing SQL's NULL / unlimited semantics in AST arithmetic, which
+    // produced a new edge case per limit form. Rejecting tells the caller the query cannot be
+    // paginated instead of handing back a plausible wrong page.
+
+    @Test
+    public void testNonLiteralLimit_expressionIsRejectedUnderACap() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 1+1");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 0L));
+        assertEquals(true, e.getMessage().contains("must be an integer literal"),
+                "message must say what is required: " + e.getMessage());
+    }
+
+    @Test
+    public void testNonLiteralLimit_scalarSubqueryIsRejected() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT (SELECT 3)");
+        assertThrows(IllegalArgumentException.class, () ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 0L));
+    }
+
+    @Test
+    public void testNonLiteralLimit_rejectedByCapLimitAndApplyOffsetAlike() throws Exception {
+        JsonNode q1 = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 5+5");
+        assertThrows(IllegalArgumentException.class, () -> Transformations.capLimit(q1, 1000L));
+        JsonNode q2 = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 5+5");
+        assertThrows(IllegalArgumentException.class, () -> Transformations.applyOffset(q2, 7L));
+    }
+
+    @Test
+    public void testNonLiteralLimit_overrunNoLongerSilentlyEmpty() throws Exception {
+        // Closes the inconsistency: LIMIT 5+5 OFFSET 20 used to return a silent empty page while
+        // LIMIT 10 OFFSET 20 raised. Both now raise.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 5+5");
+        assertThrows(IllegalArgumentException.class, () ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 20L));
+    }
+
+    @Test
+    public void testNonLiteralLimit_isLeftAloneWhenNothingApplies() throws Exception {
+        // No cap, no offset -> nothing is being bounded, so the query must pass through and run.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 5+5");
+        JsonNode out = assertDoesNotThrow(() -> Transformations.capLimit(query, -1L));
+        assertEquals(10L, rowsOf(out), "LIMIT 5+5 must still work when uncapped");
+    }
+
+    @Test
+    public void testNonLiteralLimit_unlimitedFormsRemainAllowed() throws Exception {
+        // An absent LIMIT and an explicit LIMIT NULL both mean "every row" - exactly the case the
+        // cap handles, so there is no arithmetic to get wrong and no reason to reject.
+        JsonNode absent = Transformations.parseToTree("SELECT * FROM range(100)");
+        assertEquals(3L, rowsOf(PASSTHROUGH.authorize(
+                "user", "db", "schema", absent, Map.of(), 3L, 5L)));
+        JsonNode explicitNull = Transformations.parseToTree("SELECT * FROM range(100) LIMIT NULL");
+        assertEquals(3L, rowsOf(PASSTHROUGH.authorize(
+                "user", "db", "schema", explicitNull, Map.of(), 3L, 5L)));
+    }
+
+    @Test
+    public void testNonLiteralLimit_emittedSqlIsAlwaysAPlainLimit() throws Exception {
+        // With non-literals rejected, no least/greatest/subtract can reach the SQL.
+        for (String sql : new String[]{
+                "SELECT * FROM range(100) LIMIT 50 OFFSET 5",
+                "SELECT * FROM range(100) LIMIT NULL",
+                "SELECT * FROM range(100)"}) {
+            String out = Transformations.parseToSql(PASSTHROUGH.authorize(
+                    "user", "db", "schema", Transformations.parseToTree(sql), Map.of(), 10L, 2L));
+            String lower = out.toLowerCase();
+            assertEquals(false,
+                    lower.contains("least") || lower.contains("greatest") || lower.contains("subtract"),
+                    "no limit arithmetic must survive: " + out);
+        }
+    }
+
+    /** Non-literal OFFSET composition is retained - adding offsets has no unlimited semantics. */
+    @Test
+    public void testNonLiteralOffset_stillComposes() throws Exception {
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) OFFSET 2+3");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 10L);
+        assertEquals(15L, firstValueOf(authorized), "add(coalesce(2+3,0), 10) must be 15");
     }
 }

--- a/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/authorization/SqlAuthorizerLimitTest.java
+++ b/dazzleduck-sql-commons/src/test/java/io/dazzleduck/sql/commons/authorization/SqlAuthorizerLimitTest.java
@@ -243,14 +243,29 @@ public class SqlAuthorizerLimitTest {
     // ── offset past the query's own LIMIT is rejected, not served as an empty page ────────────
 
     @Test
-    public void testOffset_atTemplateLimitIsRejected() throws Exception {
-        // LIMIT 10 with a request offset of 10: that page is empty. Merging modifiers would hand
-        // back rows 11-20 - rows the template's own LIMIT excluded.
+    public void testOffset_exactlyAtTemplateLimitIsAnEmptyPage() throws Exception {
+        // offset == own LIMIT is the end of the result, not an error: a client paging until it
+        // sees a short page must be able to request that page and get zero rows back. Rejecting
+        // it ended every such scan in a server error.
         JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10");
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
-                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 10L));
-        assertEquals(true, e.getMessage().contains("at or past the query's own LIMIT 10"),
-                "message must name the offending bound: " + e.getMessage());
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 10L);
+        assertEquals(0L, rowsOf(authorized), "the page at the end of the result must be empty");
+    }
+
+    @Test
+    public void testOffset_pageUntilShortPageTerminates() throws Exception {
+        // The loop the previous contract broke: cap 10 over a template LIMIT 100 yields ten full
+        // pages, then an empty one. No page may raise.
+        long total = 0;
+        for (int offset = 0; offset <= 100; offset += 10) {
+            JsonNode q = Transformations.parseToTree("SELECT * FROM range(1000) LIMIT 100");
+            final int off = offset;
+            JsonNode authorized = assertDoesNotThrow(() -> PASSTHROUGH.authorize(
+                    "user", "db", "schema", q, Map.of(), 10L, (long) off),
+                    "offset " + offset + " must not raise");
+            total += rowsOf(authorized);
+        }
+        assertEquals(100L, total, "ten pages of 10 then an empty page");
     }
 
     @Test
@@ -363,9 +378,10 @@ public class SqlAuthorizerLimitTest {
 
     @Test
     public void testApplyOffset_rejectionIsRaisedByTheOffsetMethod() throws Exception {
-        // The guard belongs to offset semantics, so applyOffset alone must raise it.
+        // The guard belongs to offset semantics, so applyOffset alone must raise it. 11 is
+        // strictly past the query's own LIMIT 10; 10 itself is the allowed empty page.
         JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 10");
-        assertThrows(IllegalArgumentException.class, () -> Transformations.applyOffset(query, 10L));
+        assertThrows(IllegalArgumentException.class, () -> Transformations.applyOffset(query, 11L));
     }
 
     // ── LIMIT n% is rejected when a cap or offset applies ────────────────────────────────────
@@ -512,5 +528,75 @@ public class SqlAuthorizerLimitTest {
         JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) OFFSET 2+3");
         JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 10L);
         assertEquals(15L, firstValueOf(authorized), "add(coalesce(2+3,0), 10) must be 15");
+    }
+
+    // ── code-review findings on PR #409 ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDecimalLimit_isNotReadAsItsUnscaledValue() throws Exception {
+        // DuckDB serializes DECIMAL as an unscaled integer plus a scale, so LIMIT 10.9 arrives as
+        // 109. Reading that as a literal emitted LIMIT 109 - widening the query's own bound by
+        // 10^scale, the exact bug this class exists to prevent. It must be rejected instead.
+        for (String limit : new String[]{"10.9", "10.0", "0.5"}) {
+            JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT " + limit);
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+                    PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, -1L),
+                    "LIMIT " + limit + " must not be treated as an integer literal");
+            assertEquals(true, e.getMessage().contains("integer literal"), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDecimalOffset_isNotReadAsItsUnscaledValue() throws Exception {
+        // Same trap on the offset side: OFFSET 5.0 arrives as 50, so composing gave OFFSET 60
+        // instead of 15. Non-literal offsets compose at execution time, so the result is correct
+        // rather than rejected.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) OFFSET 5.0");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 1000L, 10L);
+        assertEquals(15L, firstValueOf(authorized), "5.0 + 10 must be 15, not 60");
+    }
+
+    @Test
+    public void testDoubleLimit_isRejected() throws Exception {
+        // LIMIT 1e2 serializes as a DOUBLE whose value is 100.0.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 1e2");
+        assertThrows(IllegalArgumentException.class, () ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 10L, -1L));
+    }
+
+    @Test
+    public void testLargeIntegerLimit_isStillAccepted() throws Exception {
+        // BIGINT-typed literals must keep working - the type check must not be over-tight.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT 3000000000");
+        JsonNode authorized = PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 7L, -1L);
+        assertEquals(7L, rowsOf(authorized), "a BIGINT literal must be capped, not rejected");
+    }
+
+    @Test
+    public void testZeroOffset_isATrueNoOp() throws Exception {
+        // The cap path passes offset = 0. That must not fabricate an OFFSET 0, and must not make
+        // applyOffset reject constructs an uncapped read is documented to leave alone.
+        JsonNode plain = Transformations.parseToTree("SELECT * FROM range(100)");
+        assertEquals("SELECT * FROM \"range\"(100)",
+                Transformations.parseToSql(Transformations.applyOffset(plain, 0L)),
+                "offset 0 must not add an OFFSET clause");
+
+        for (String sql : new String[]{"SELECT * FROM range(100) LIMIT 3%",
+                                       "SELECT * FROM range(100) LIMIT 5+5"}) {
+            JsonNode q = Transformations.parseToTree(sql);
+            assertDoesNotThrow(() -> Transformations.applyOffset(q, 0L),
+                    "offset 0 bounds nothing, so it must not reject: " + sql);
+        }
+    }
+
+    @Test
+    public void testNegativeLimit_reportsTheLimitNotTheOffset() throws Exception {
+        // DuckDB folds LIMIT -1 into a constant, so it used to be reported as
+        // "'offset' 3 is at or past the query's own LIMIT -1" - misdirecting to the offset.
+        JsonNode query = Transformations.parseToTree("SELECT * FROM range(100) LIMIT -1");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+                PASSTHROUGH.authorize("user", "db", "schema", query, Map.of(), 10L, 3L));
+        assertEquals(true, e.getMessage().contains("must not be negative"),
+                "message must point at the LIMIT: " + e.getMessage());
     }
 }

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/DuckDBFlightSqlProducer.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/DuckDBFlightSqlProducer.java
@@ -1447,6 +1447,11 @@ public class DuckDBFlightSqlProducer implements FlightSqlHttpProducer, SqlProduc
             query = transformQuery(context, connection, query);
         } catch (UnauthorizedException e) {
             throw CallStatus.UNAUTHORIZED.withCause(e).withDescription(e.getMessage()).toRuntimeException();
+        } catch (IllegalArgumentException e) {
+            // A rejected request (unsupported LIMIT form, offset past the query's own bound) is a
+            // client error. getStreamStatement already maps it via ErrorHandling; without this
+            // branch the getFlightInfo half of the same call returned INTERNAL / HTTP 500.
+            throw CallStatus.INVALID_ARGUMENT.withCause(e).withDescription(e.getMessage()).toRuntimeException();
         } catch (Exception e){
             throw CallStatus.INTERNAL.withCause(e).withDescription("Failed to transform query: " + e.getMessage()).toRuntimeException();
         }

--- a/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/ErrorHandling.java
+++ b/dazzleduck-sql-flight/src/main/java/io/dazzleduck/sql/flight/server/ErrorHandling.java
@@ -62,6 +62,14 @@ public class ErrorHandling {
             handleSqlException(s);
         } else if (t instanceof IOException io) {
             handleIOException(io);
+        } else if (t instanceof IllegalArgumentException e) {
+            // Mirrors the ServerStreamListener overload: a rejected request (an unsupported
+            // LIMIT form, an offset past the query's own bound) is the caller's mistake, so it
+            // must not surface as INTERNAL - which gRPC clients retry and which pages ops.
+            throw CallStatus.INVALID_ARGUMENT
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .toRuntimeException();
         } else if (t instanceof Exception e) {
             var exception = CallStatus.INTERNAL
                     .withDescription(e.getMessage())


### PR DESCRIPTION
## The bug

`Transformations.addLimit` removed a query's own top-level `LIMIT` and replaced it with the caller's value. The search engines pass the configured page cap (`duckdb.max-rows`) whenever a request carries no explicit limit, so a named-query template's `LIMIT 10` was discarded in favour of the 1000-row cap and every row rendered — the *"top users showed 16 rows under `LIMIT 10`"* bug.

The cap is now a **ceiling**: the smaller of the cap and the query's own `LIMIT` wins.

## Seven more defects on the same path

Fixing that surfaced further bugs on the same code path, each verified by **executing** the round-tripped SQL rather than inspecting the AST:

| Defect | Symptom |
|---|---|
| Caller's `OFFSET` replaced the query's own | The cap path passes `offset = 0`, so a template's `OFFSET 5` was silently reset on every non-paginated read |
| `limit < 0` with `offset >= 0` emitted `LIMIT -1` | `Binder Error: LIMIT/OFFSET cannot be negative` — every offset-without-cap request failed outright |
| Request offset did not reduce the query's own `LIMIT` | `LIMIT 10` with offset 9 returned **10 rows instead of 1** |
| `LIMIT NULL` collapsed to `LIMIT 0` | Means *unlimited*, but parses as a CONSTANT whose value is NULL, so it took the arithmetic path — an empty page for a query asking for every row |
| `add(NULL, 5)` is `NULL`, read as offset 0 | A paginating client received **page 1 for every page** |
| A DECIMAL limit was read as its **unscaled** value | DuckDB serializes `DECIMAL` as unscaled-integer + scale, so `LIMIT 10.9` arrived as `109` and was emitted as `LIMIT 109` — **the cap widening the query's own bound, the very bug this PR fixes.** A named query rendering `LIMIT {{ n }}` from a JSON float hits it; `OFFSET 5.0` composed to `OFFSET 60` instead of 15 |
| `applyOffset(query, 0)` was not a no-op | Offset 0 — what the cap path passes — fabricated `OFFSET 0` and rejected constructs an uncapped read is documented to leave untouched |

## Three constructs rejected

With `IllegalArgumentException`, mapped to 400 / `INVALID_ARGUMENT`:

- **An offset strictly past the query's own `LIMIT`.** An offset *at* the limit is allowed and yields an empty page, so the standard "request pages until a short page" loop still terminates — with a page cap of 10 over a template `LIMIT 100`, every page returns exactly 10 rows and the client's only termination signal is the empty page at offset 100. Going beyond that can only be a client error.
- **`LIMIT n%`** — a fraction of the *result cardinality*, so the engine must materialise the whole result before taking it; no row cap can bound the work, making the cap cosmetic in exactly the modes that rely on it. It is also not expressible by merging: `%` is syntax, not a scalar (`least(cap, 3%)` is a parser error), and appending a row `LIMIT` beside the percent modifier produced the unparseable `LIMIT (3) % LIMIT 5`.
- **A non-literal `LIMIT`** (expression, scalar subquery, bind parameter, or non-integer literal) — bounding one meant reproducing SQL's NULL and unlimited semantics in AST arithmetic, which yielded a fresh edge case per limit form. This also removes an inconsistency: `LIMIT 5+5 OFFSET 20` returned a silent empty page where `LIMIT 10 OFFSET 20` raised.

All three are rejected **only when a cap or a non-zero offset is actually applied**, so such queries still run untouched on an uncapped read. Unlimited forms (absent `LIMIT`, `LIMIT NULL`) stay allowed — that is precisely the case the cap handles, with no arithmetic to get wrong.

## Error mapping (`dazzleduck-sql-flight`)

`getStreamStatement` already mapped `IllegalArgumentException` to `INVALID_ARGUMENT`, but two paths did not, so a rejected request returned gRPC `INTERNAL` / HTTP 500 — an error class gRPC clients retry and that pages ops:

- `DuckDBFlightSqlProducer.getFlightInfoStatement` — the `getFlightInfo` half of the same call Flight SQL / JDBC clients make
- `ErrorHandling.handleThrowable(Throwable)` — used by the restricted producer's getFlightInfo path

Both now map to `INVALID_ARGUMENT`, matching the streaming overload.

## API change

`addLimit` bundled a security bound (the row cap) with request pagination, which is how several of these defects stayed hidden. It is split into:

- `capLimit(query, cap)` — touches only the `limit` field
- `applyOffset(query, offset)` — touches only `offset`, plus the remainder on `limit`

Both mutate the shared `LIMIT_MODIFIER` **in place** via one helper, instead of the old remove-and-re-append — that rebuild is exactly what destroyed the other field. Order matters (`capLimit(applyOffset(q, offset), cap)`): applying an offset reduces how many of the query's own rows remain, and the cap is then a ceiling on what is left.

`addLimit` is retained as a `@Deprecated(forRemoval = true)` thin delegate, so callers compiled against it keep working; `SqlAuthorizer` now calls the pair directly. `ExpressionFactory.limitModifier` lost its last caller in the split and is likewise deprecated. Marked `!` as the emitted SQL and the rejection behaviour change for restricted modes.

## Testing

52 tests in `SqlAuthorizerLimitTest`. The behavioural ones round-trip the authorized AST back to SQL and **execute it against `range(100)`**, asserting real row counts and effective offsets — not tree shapes.

Verified non-vacuous at each stage by stashing only the production change: 9 tests fail against the original `addLimit`, and 6 against the first commit — each naming the actual defect (e.g. `expected: <10> but was: <1000>`, `5.0 + 10 must be 15, not 60`, `offset 100 must not raise`).

```
dazzleduck-sql-commons  485 tests  ✅
dazzleduck-sql-flight   148 tests  ✅
dazzleduck-sql-http     106 tests  ✅
```

Branched off `main` at `4b48e9f9`; none of the touched files is modified by intervening commits.

## Commits

1. `d1545c6b` — the cap-as-ceiling fix and the five defects it surfaced, plus the `capLimit`/`applyOffset` split
2. `e200c54f` — five code-review findings: the DECIMAL unscaled-value bug, the INTERNAL/500 mapping, the `offset == 0` no-op, the pagination boundary, and a misdirecting message for a negative `LIMIT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)